### PR TITLE
[71] Add commons-io library in syson-application-configuration

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,7 +8,10 @@
 
 === Dependency update
 
+- https://github.com/eclipse-syson/syson/issues/71[#71] [releng] Add `commons-io 2.11.0` dependency explicitly in `syson-application-configuration`.
+
 === Bug fixes
+
 
 === New features
 

--- a/backend/application/syson-application-configuration/pom.xml
+++ b/backend/application/syson-application-configuration/pom.xml
@@ -57,6 +57,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.11.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.sirius</groupId>
 			<artifactId>sirius-components-emf</artifactId>
 			<version>${sirius.web.version}</version>


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/71