### PR TITLE
[86] Improve Package headers' width and children layout

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,7 +35,7 @@ The partial edit allows to:
 Only provides candidates that will make sense.
 Also allow the creation of elements with their containing Membership in one click.
 - https://github.com/eclipse-syson/syson/issues/80[#80] [diagrams] Improves "Add existing elements" tool by making it recursive.
-
+- https://github.com/eclipse-syson/syson/issues/86[#86] [general-view] Improves Package headers' width to better handle longer labels and prevents Package children from overlapping the Package body's west border.
 
 === New features
 

--- a/frontend/syson-components/src/nodes/package/SysMLPackageNode.tsx
+++ b/frontend/syson-components/src/nodes/package/SysMLPackageNode.tsx
@@ -64,16 +64,15 @@ const packageHeaderStyle = (
   style: React.CSSProperties,
   selected: boolean,
   hovered: boolean,
-  faded: boolean,
-  labelWidth: number
+  faded: boolean
 ): React.CSSProperties => {
   const packageHeaderStyle: React.CSSProperties = {
     display: 'inline-flex',
     flexDirection: 'row',
     flexWrap: 'nowrap',
-    padding: '0px',
-    width: 'calc(' + labelWidth + 'ch + 56px)',
-    maxWidth: '45%',
+    padding: '0 16px 0 0',
+    width: 'fit-content',
+    maxWidth: '70%',
     opacity: faded ? '0.4' : '',
     ...style,
     backgroundColor: getCSSColor(String(style.backgroundColor), theme),
@@ -146,11 +145,9 @@ export const SysMLPackageNode = memo(({ data, id, selected }: NodeProps<SysMLPac
       ...data?.insideLabel?.style,
       whiteSpace: 'pre',
       overflow: 'hidden',
+      paddingRight: '0',
       justifyContent: 'flex-start',
       textAlign: 'left',
-      columnGap: '16px',
-      textOverflow: 'ellipsis',
-      '& div': {},
     },
   };
 
@@ -183,14 +180,7 @@ export const SysMLPackageNode = memo(({ data, id, selected }: NodeProps<SysMLPac
         <ConnectionHandles connectionHandles={data.connectionHandles} />
         <div
           style={{
-            ...packageHeaderStyle(
-              theme,
-              data.style,
-              selected,
-              hoveredNode?.id === id,
-              data.faded,
-              data.insideLabel ? data.insideLabel.text.length : 0
-            ),
+            ...packageHeaderStyle(theme, data.style, selected, hoveredNode?.id === id, data.faded),
             ...newConnectionStyleProvider.getNodeStyle(id, data.descriptionId),
             ...dropFeedbackStyle,
           }}>


### PR DESCRIPTION
This PR fixes the following issues:
- Increase the `maxWidth` of the Package headers to handle longer labels, especially when the Package has its default size
- Replaced the manual computation of the header width with `width: fit-content` (the previous version used `ch` to compute the width, which is not appropriate)
- Fix a layout issue for Package children that could overlap the Package's west border after a move

**Note**: this PR doesn't add ellipsis to Package labels that are too long for the Package header. This will be fixed in Sirius Web Label and can be reused for Package once it is available.