### PR TITLE
[88] Add spaces and remove "Usage" in node/edge creation tool names

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@ Also allow the creation of elements with their containing Membership in one clic
 - https://github.com/eclipse-syson/syson/issues/80[#80] [diagrams] Improves "Add existing elements" tool by making it recursive.
 - https://github.com/eclipse-syson/syson/issues/86[#86] [general-view] Improves Package headers' width to better handle longer labels and prevents Package children from overlapping the Package body's west border.
 - https://github.com/eclipse-syson/syson/issues/52[#52] [syson] Add all KerML and SysML standard libraries.
+- https://github.com/eclipse-syson/syson/issues/88[#88] [diagrams] Improves creation tool names by adding spaces between type words and removing "Usage" from tool names.
 
 === New features
 

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/util/DescriptionNameGenerator.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/util/DescriptionNameGenerator.java
@@ -12,12 +12,23 @@
  *******************************************************************************/
 package org.eclipse.syson.util;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.syson.sysml.SysmlPackage;
+
 /**
  * Name generator for all SysON description providers.
  * 
  * @author arichard
  */
 public class DescriptionNameGenerator {
+
+    private static final Pattern WORD_FINDER = Pattern.compile("(([A-Z]?[a-z]+)|([A-Z]))");
 
     protected static String getName(String prefix, String descType, String type) {
         StringBuilder name = new StringBuilder();
@@ -43,5 +54,30 @@ public class DescriptionNameGenerator {
 
     protected static String getEdgeName(String prefix, String type) {
         return getName(prefix, "Edge", type);
+    }
+
+    public static String getCreationToolName(EClassifier eClassifier) {
+        return getCreationToolName("New ", eClassifier);
+    }
+
+    public static String getCreationToolName(String prefix, EClassifier eClassifier) {
+        String nameToParse = eClassifier.getName();
+        if (eClassifier.getName().endsWith("Usage")) {
+            String baseClassifierName = eClassifier.getName().substring(0, eClassifier.getName().length() - 5);
+            EClassifier definitionEClassifier = SysmlPackage.eINSTANCE.getEClassifier(baseClassifierName + "Definition");
+            if (definitionEClassifier != null) {
+                nameToParse = baseClassifierName;
+            }
+        }
+        return prefix + findWordsInMixedCase(nameToParse).stream().collect(Collectors.joining(" "));
+    }
+
+    private static List<String> findWordsInMixedCase(String text) {
+        Matcher matcher = WORD_FINDER.matcher(text);
+        List<String> words = new ArrayList<>();
+        while (matcher.find()) {
+            words.add(matcher.group(0));
+        }
+        return words;
     }
 }

--- a/backend/services/syson-services/src/test/java/org/eclipse/syson/util/DescriptionNameGeneratorTest.java
+++ b/backend/services/syson-services/src/test/java/org/eclipse/syson/util/DescriptionNameGeneratorTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Name generation-related tests.
+ * 
+ * @author gdaniel
+ */
+public class DescriptionNameGeneratorTest {
+
+    @Test
+    public void testGetCreationToolNameForUsageWithMatchingDefinition() {
+        String creationToolName = DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getAttributeUsage());
+        assertEquals("New Attribute", creationToolName);
+    }
+
+    @Test
+    public void testGetCreationToolNameForUsageWithoutMatchingDefinition() {
+        String creationToolName = DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getConnectorAsUsage());
+        assertEquals("New Connector As Usage", creationToolName);
+    }
+
+    @Test
+    public void testGetCreationToolNameForDefinition() {
+        String creationToolName = DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getAttributeDefinition());
+        assertEquals("New Attribute Definition", creationToolName);
+    }
+
+}

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionProvider.java
@@ -49,6 +49,7 @@ import org.eclipse.syson.diagram.general.view.nodes.FakeNodeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.nodes.PackageNodeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.nodes.UsageNodeDescriptionProvider;
 import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 
 /**
@@ -251,7 +252,7 @@ public class GeneralViewDiagramDescriptionProvider implements IRepresentationDes
                 .children(changeContexMembership.build());
 
         return builder
-                .name("New  " + eClass.getName())
+                .name(DescriptionNameGenerator.getCreationToolName(eClass))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
                 .build();

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/CompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/CompartmentNodeDescriptionProvider.java
@@ -31,6 +31,7 @@ import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
 import org.eclipse.syson.diagram.general.view.GeneralViewDiagramDescriptionProvider;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -173,7 +174,7 @@ public class CompartmentNodeDescriptionProvider extends AbstractNodeDescriptionP
                 .children(changeContextMembership.build());
 
         return builder
-                .name("New " + type.getName())
+                .name(DescriptionNameGenerator.getCreationToolName(type))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
                 .build();

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/EmptyDiagramNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/EmptyDiagramNodeDescriptionProvider.java
@@ -32,6 +32,7 @@ import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
 import org.eclipse.syson.diagram.general.view.GeneralViewDiagramDescriptionProvider;
 import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 
 /**
@@ -151,7 +152,7 @@ public class EmptyDiagramNodeDescriptionProvider implements INodeDescriptionProv
                 .children(changeContexMembership.build());
 
         return builder
-                .name("New  " + eClass.getName())
+                .name(DescriptionNameGenerator.getCreationToolName(eClass))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
                 .build();

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/PackageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/PackageNodeDescriptionProvider.java
@@ -36,6 +36,7 @@ import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysmlcustomnodes.SysMLCustomnodesFactory;
 import org.eclipse.syson.sysmlcustomnodes.SysMLPackageNodeStyleDescription;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -219,7 +220,7 @@ public class PackageNodeDescriptionProvider extends AbstractNodeDescriptionProvi
                 .children(changeContexMembership.build());
 
         return this.diagramBuilderHelper.newNodeTool()
-                .name("New " + eClass.getName())
+                .name(DescriptionNameGenerator.getCreationToolName(eClass))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
                 .build();

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/services/GeneralViewEdgeToolSwitch.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/services/GeneralViewEdgeToolSwitch.java
@@ -29,6 +29,7 @@ import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.Usage;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.SysmlEClassSwitch;
 
@@ -141,7 +142,7 @@ public class GeneralViewEdgeToolSwitch extends SysmlEClassSwitch<Void> {
                 .children(createMembership.build());
 
         return builder
-                .name("New " + SysmlPackage.eINSTANCE.getDependency().getName())
+                .name(DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getDependency()))
                 .iconURLsExpression(METAMODEL_ICONS_PATH + SysmlPackage.eINSTANCE.getDependency().getName() + SVG)
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -186,7 +187,7 @@ public class GeneralViewEdgeToolSwitch extends SysmlEClassSwitch<Void> {
                 .children(createInstance.build());
 
         return builder
-                .name("New " + SysmlPackage.eINSTANCE.getSubclassification().getName())
+                .name(DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getSubclassification()))
                 .iconURLsExpression(METAMODEL_ICONS_PATH + SysmlPackage.eINSTANCE.getSubclassification().getName() + SVG)
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -240,7 +241,7 @@ public class GeneralViewEdgeToolSwitch extends SysmlEClassSwitch<Void> {
                 .children(createInstance.build());
 
         return builder
-                .name("New " + SysmlPackage.eINSTANCE.getRedefinition().getName())
+                .name(DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getRedefinition()))
                 .iconURLsExpression(METAMODEL_ICONS_PATH + SysmlPackage.eINSTANCE.getRedefinition().getName() + SVG)
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -286,7 +287,7 @@ public class GeneralViewEdgeToolSwitch extends SysmlEClassSwitch<Void> {
                 .children(createInstance.build());
 
         return builder
-                .name("New " + SysmlPackage.eINSTANCE.getSubsetting().getName())
+                .name(DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getSubsetting()))
                 .iconURLsExpression(METAMODEL_ICONS_PATH + SysmlPackage.eINSTANCE.getSubsetting().getName() + SVG)
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -300,7 +301,7 @@ public class GeneralViewEdgeToolSwitch extends SysmlEClassSwitch<Void> {
                 .expression(AQLConstants.AQL + EdgeDescription.SEMANTIC_EDGE_SOURCE + ".addAsNestedPart(" + EdgeDescription.SEMANTIC_EDGE_TARGET + ")");
 
         return builder
-                .name("Add Part Usage as nested " + SysmlPackage.eINSTANCE.getPartUsage().getName())
+                .name(DescriptionNameGenerator.getCreationToolName("Add Part as nested ", SysmlPackage.eINSTANCE.getPartUsage()))
                 .iconURLsExpression(METAMODEL_ICONS_PATH + SysmlPackage.eINSTANCE.getMembership().getName() + SVG)
                 .body(callService.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -314,7 +315,7 @@ public class GeneralViewEdgeToolSwitch extends SysmlEClassSwitch<Void> {
                 .expression(AQLConstants.AQL + EdgeDescription.SEMANTIC_EDGE_SOURCE + ".becomeNestedPart(" + EdgeDescription.SEMANTIC_EDGE_TARGET + ")");
 
         return builder
-                .name("Become nested " + SysmlPackage.eINSTANCE.getPartUsage().getName())
+                .name(DescriptionNameGenerator.getCreationToolName("Become nested ", SysmlPackage.eINSTANCE.getPartUsage()))
                 .iconURLsExpression(METAMODEL_ICONS_PATH + SysmlPackage.eINSTANCE.getMembership().getName() + SVG)
                 .body(callService.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/services/GeneralViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/services/GeneralViewNodeToolSectionSwitch.java
@@ -27,6 +27,7 @@ import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
 import org.eclipse.syson.sysml.PartDefinition;
 import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.SysmlEClassSwitch;
 
@@ -122,7 +123,7 @@ public class GeneralViewNodeToolSectionSwitch extends SysmlEClassSwitch<Void> {
                 .children(changeContexMembership.build());
 
         return this.diagramBuilderHelper.newNodeTool()
-                .name("New nested " + eClass.getName())
+                .name(DescriptionNameGenerator.getCreationToolName("New nested ", eClass))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
                 .build();
@@ -161,7 +162,7 @@ public class GeneralViewNodeToolSectionSwitch extends SysmlEClassSwitch<Void> {
                 .children(changeContexMembership.build());
 
         return this.diagramBuilderHelper.newNodeTool()
-                .name("New nested " + SysmlPackage.eINSTANCE.getPartUsage().getName())
+                .name(DescriptionNameGenerator.getCreationToolName("New nested ", SysmlPackage.eINSTANCE.getPartUsage()))
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getPartUsage().getName() + ".svg")
                 .body(createMembership.build())
                 .build();

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ChildPartUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ChildPartUsageNodeDescriptionProvider.java
@@ -33,6 +33,7 @@ import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -162,7 +163,7 @@ public class ChildPartUsageNodeDescriptionProvider implements INodeDescriptionPr
                 .children(changeContexMembership.build());
 
         return builder
-                .name("New " + eClass.getName())
+                .name(DescriptionNameGenerator.getCreationToolName(eClass))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
                 .build();

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/PortUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/PortUsageBorderNodeDescriptionProvider.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.view.diagram.NodeStyleDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -117,7 +118,7 @@ public class PortUsageBorderNodeDescriptionProvider implements INodeDescriptionP
                 .expression(AQLConstants.AQL + EdgeDescription.SEMANTIC_EDGE_SOURCE + ".createBindingConnectorAsUsage(" + EdgeDescription.SEMANTIC_EDGE_TARGET + ")");
 
         return builder
-                .name("New " + SysmlPackage.eINSTANCE.getBindingConnectorAsUsage().getName())
+                .name(DescriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()))
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getBindingConnectorAsUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootPartUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootPartUsageNodeDescriptionProvider.java
@@ -33,6 +33,7 @@ import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -156,7 +157,7 @@ public class RootPartUsageNodeDescriptionProvider implements INodeDescriptionPro
                 .children(changeContexMembership.build());
 
         return builder
-                .name("New " + eClass.getName())
+                .name(DescriptionNameGenerator.getCreationToolName(eClass))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
                 .build();


### PR DESCRIPTION
This PR adds a 2 new public methods in `DescriptionNameGenerator` to get the name of a creation tool. These methods add spaces before capital letters of type names, and removes "Usage" from type names.  

> [!NOTE]
> Let me know if `DescriptionNameGenerator` is not the right place to put these methods. It made sense to me to put them next to the methods that compute the name of Node/Edge Description, but it may not fit the architecture you have in mind.

This PR also updates all the node/edge creation tools to use this new API.

Note that I  am not sure about the updated Edge creation tool for `BindingConnectorAsUsage`, which is now named "Binding Connector As". It doesn't look right to me, so let me know if I should make an exception for this specific edge and keep the "Usage".