### PR TITLE
[93] Tool sections should appear always in the same order

### DIFF
--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/ToolSectionDescription.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/ToolSectionDescription.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.general.view;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EClass;
+
+/**
+ * This record is used to describe tool sections. 
+ * 
+ * @author Jerome Gout
+ */
+public record ToolSectionDescription(String name, List<EClass> elements) { }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/EmptyDiagramNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/EmptyDiagramNodeDescriptionProvider.java
@@ -164,10 +164,10 @@ public class EmptyDiagramNodeDescriptionProvider implements INodeDescriptionProv
     private NodeToolSection[] createToolSections(IViewDiagramElementFinder cache) {
         var sections = new ArrayList<NodeToolSection>();
         
-        GeneralViewDiagramDescriptionProvider.TOOL_SECTIONS.forEach((sectionName, elements) -> {
+        GeneralViewDiagramDescriptionProvider.TOOL_SECTIONS.forEach(sectionTool -> {
             NodeToolSectionBuilder sectionBuilder = this.diagramBuilderHelper.newNodeToolSection()
-                    .name(sectionName)
-                    .nodeTools(this.createElementsOfToolSection(cache, elements));
+                    .name(sectionTool.name())
+                    .nodeTools(this.createElementsOfToolSection(cache, sectionTool.elements()));
             sections.add(sectionBuilder.build());
         });
         

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/PackageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/PackageNodeDescriptionProvider.java
@@ -227,10 +227,10 @@ public class PackageNodeDescriptionProvider extends AbstractNodeDescriptionProvi
     private NodeToolSection[] createToolSections(IViewDiagramElementFinder cache) {
         var sections = new ArrayList<NodeToolSection>();
         
-        GeneralViewDiagramDescriptionProvider.TOOL_SECTIONS.forEach((sectionName, elements) -> {
+        GeneralViewDiagramDescriptionProvider.TOOL_SECTIONS.forEach(sectionTool -> {
             NodeToolSectionBuilder sectionBuilder = this.diagramBuilderHelper.newNodeToolSection()
-                    .name(sectionName)
-                    .nodeTools(this.createElementsOfToolSection(cache, elements));
+                    .name(sectionTool.name())
+                    .nodeTools(this.createElementsOfToolSection(cache, sectionTool.elements()));
             sections.add(sectionBuilder.build());
         });
         


### PR DESCRIPTION
Using Java.lang.Map to describe tool sections does not guarantee the order of its entries.
Since we want to control the palette sections' order we need to change how the tool sections are expressed.

Bug: https://github.com/eclipse-syson/syson/issues/93