### PR TITLE
[105] Show standard libraries in Reference Widget's model browser dialog

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,9 @@ Also allow the creation of elements with their containing Membership in one clic
 - https://github.com/eclipse-syson/syson/issues/88[#88] [diagrams] Improves creation tool names by adding spaces between type words and removing "Usage" from tool names.
 - https://github.com/eclipse-syson/syson/issues/91[#91] [general-view] Add NodeTools to create compartment elements from the compartment's parent node. For example, it is now possible to create an `AttributeUsage` in the `PartDefinition` palette.
 - https://github.com/eclipse-syson/syson/issues/93[#93] [diagrams] Reorganize General View diagram palette with several tool sections.
+- https://github.com/eclipse-syson/syson/issues/105[#105] [details] In the Details view, display the standard libraries in Reference Widget's model browser dialog.
+Also remove the standard libraries elements in Reference Widget's candidates (when you click in the background part of the widget) for now as it leads to performance issues.
+They will be only accessible through the model browser dialog.
 
 === New features
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysONReferenceWidgetRootCandidateSearchProvider.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysONReferenceWidgetRootCandidateSearchProvider.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.configuration;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
+import org.eclipse.sirius.components.widget.reference.IReferenceWidgetRootCandidateSearchProvider;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provides the list of root elements used to select or add a reference value.
+ * ElementItemProvider hided KerML and SysML standard libraries elements from Reference Widget candidates.
+ * This implementation allows to show these candidates through the Reference Widget's "..." action.
+ *
+ * @author arichard
+ */
+@Service
+public class SysONReferenceWidgetRootCandidateSearchProvider implements IReferenceWidgetRootCandidateSearchProvider {
+
+    @Override
+    public boolean canHandle(String descriptionId) {
+        return true;
+    }
+
+    @Override
+    public List<? extends Object> getRootElementsForReference(Object targetElement, String descriptionId, IEditingContext editingContext) {
+        var optionalResourceSet = Optional.of(editingContext)
+                .filter(IEMFEditingContext.class::isInstance)
+                .map(IEMFEditingContext.class::cast)
+                .map(IEMFEditingContext::getDomain)
+                .map(EditingDomain::getResourceSet);
+
+        if (optionalResourceSet.isPresent()) {
+            var resourceSet = optionalResourceSet.get();
+            return resourceSet.getResources().stream()
+                    .sorted(Comparator.nullsLast(Comparator.comparing(this::getResourceLabel, String.CASE_INSENSITIVE_ORDER)))
+                    .toList();
+        }
+
+        return List.of();
+    }
+
+    private String getResourceLabel(Resource resource) {
+        return resource.eAdapters().stream()
+                .filter(ResourceMetadataAdapter.class::isInstance)
+                .map(ResourceMetadataAdapter.class::cast)
+                .findFirst()
+                .map(ResourceMetadataAdapter::getName)
+                .orElse(resource.getURI().lastSegment());
+    }
+}

--- a/backend/metamodel/syson-sysml-metamodel-edit/src/main/java/org/eclipse/syson/sysml/provider/ElementItemProvider.java
+++ b/backend/metamodel/syson-sysml-metamodel-edit/src/main/java/org/eclipse/syson/sysml/provider/ElementItemProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Obeo.
+ * Copyright (c) 2023, 2024 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -61,6 +61,33 @@ public class ElementItemProvider
      */
     public ElementItemProvider(AdapterFactory adapterFactory) {
         super(adapterFactory);
+    }
+
+    /**
+     * Allow to hide KerML and SysML standard libraries elements from Reference Widget candidates.
+     * These candidates are still available through Reference Widget's "..." action.
+     *
+     * @generated NOT
+     */
+    @Override
+    protected ItemPropertyDescriptor createItemPropertyDescriptor(AdapterFactory adapterFactory, ResourceLocator resourceLocator, String displayName, String description, EStructuralFeature feature,
+            boolean isSettable, boolean multiLine, boolean sortChoices, Object staticImage, String category, String[] filterFlags) {
+        ItemPropertyDescriptor itemPropertyDescriptor = new ItemPropertyDescriptor(adapterFactory, resourceLocator, displayName, description, feature, isSettable, multiLine, sortChoices, staticImage, category, filterFlags) {
+            @Override
+            public Collection<?> getChoiceOfValues(Object object) {
+                Collection<?> choiceOfValues = super.getChoiceOfValues(object);
+                if (object instanceof Element element) {
+                    return choiceOfValues.stream().filter(candidate -> {
+                        if (candidate instanceof Element elt && !(elt.eResource().getURI().toString().startsWith("kermllibrary://") || elt.eResource().getURI().toString().startsWith("sysmllibrary://"))) {
+                            return true;
+                        }
+                        return false;
+                    }).toList();
+                }
+                return choiceOfValues;
+            }
+        };
+        return itemPropertyDescriptor;
     }
 
     /**


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/105