### PR TITLE
[118] Subclassification edge is no longer visible

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@
 - Switch to Sirius Web 2024.1.5
 
 === Bug fixes
+- https://github.com/eclipse-syson/syson/issues/118[#118] Subclassification edge has been broken during this release
 
 === Improvements
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSubclassificationEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSubclassificationEdgeDescriptionProvider.java
@@ -85,6 +85,7 @@ public abstract class AbstractSubclassificationEdgeDescriptionProvider extends A
     public void link(DiagramDescription diagramDescription, IViewDiagramElementFinder cache) {
         var optEdgeDescription = cache.getEdgeDescription(this.getName());
         EdgeDescription edgeDescription = optEdgeDescription.get();
+        diagramDescription.getEdgeDescriptions().add(edgeDescription);
 
         edgeDescription.getSourceNodeDescriptions().addAll(this.getSourceNodes(cache));
         edgeDescription.getTargetNodeDescriptions().addAll(this.getTargetNodes(cache));


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/118