### PR TITLE
[151] Add some missing "Become nested XXX" edge tools.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,8 @@
 
 === Improvements
 
+- https://github.com/eclipse-syson/syson/issues/151[#151] [diagrams] Add missing "Become nested" edge tools for AttributeUsage, ItemUsage, PartUsage and PortUsage.
+
 === New features
 
 - https://github.com/eclipse-syson/syson/issues/147[#147] [general-view] Refactor compartments of `RequirementDefinition` and `RequirementUsage` to better fit the specification and examples.

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractDefinitionNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractDefinitionNodeDescriptionProvider.java
@@ -148,7 +148,6 @@ public abstract class AbstractDefinitionNodeDescriptionProvider extends Abstract
 
     private List<EdgeTool> getEdgeTools(NodeDescription nodeDescription, IViewDiagramElementFinder cache) {
         ViewEdgeToolSwitch edgeToolSwitch = new ViewEdgeToolSwitch(nodeDescription, this.getAllNodeDescriptions(cache), this.nameGenerator);
-        edgeToolSwitch.doSwitch(this.eClass);
-        return edgeToolSwitch.getEdgeTools();
+        return edgeToolSwitch.doSwitch(this.eClass);
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPackageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPackageNodeDescriptionProvider.java
@@ -156,8 +156,7 @@ public abstract class AbstractPackageNodeDescriptionProvider extends AbstractNod
 
     private List<EdgeTool> getEdgeTools(NodeDescription nodeDescription, IViewDiagramElementFinder cache) {
         ViewEdgeToolSwitch edgeToolSwitch = new ViewEdgeToolSwitch(nodeDescription, this.getAllNodeDescriptions(cache), this.nameGenerator);
-        edgeToolSwitch.doSwitch(SysmlPackage.eINSTANCE.getPackage());
-        return edgeToolSwitch.getEdgeTools();
+        return edgeToolSwitch.doSwitch(SysmlPackage.eINSTANCE.getPackage());
     }
 
     private DropNodeTool createDropFromDiagramTool(IViewDiagramElementFinder cache) {

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractUsageNodeDescriptionProvider.java
@@ -148,7 +148,6 @@ public abstract class AbstractUsageNodeDescriptionProvider extends AbstractNodeD
 
     private List<EdgeTool> getEdgeTools(NodeDescription nodeDescription, IViewDiagramElementFinder cache) {
         ViewEdgeToolSwitch edgeToolSwitch = new ViewEdgeToolSwitch(nodeDescription, this.getAllNodeDescriptions(cache), this.nameGenerator);
-        edgeToolSwitch.doSwitch(this.eClass);
-        return edgeToolSwitch.getEdgeTools();
+        return edgeToolSwitch.doSwitch(this.eClass);
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
@@ -40,6 +40,7 @@ import org.eclipse.syson.sysml.RequirementDefinition;
 import org.eclipse.syson.sysml.RequirementUsage;
 import org.eclipse.syson.sysml.SubjectMembership;
 import org.eclipse.syson.sysml.SysmlFactory;
+import org.eclipse.syson.sysml.Usage;
 
 /**
  * Tool-related Java services used by all diagrams.
@@ -186,17 +187,17 @@ public class ViewToolService extends ToolService {
         return partDef;
     }
 
-    public PartUsage becomeNestedPart(PartUsage partUsage, Element newContainer) {
-        var eContainer = partUsage.eContainer();
+    public Usage becomeNestedUsage(Usage usage, Element newContainer) {
+        var eContainer = usage.eContainer();
         if (eContainer instanceof FeatureMembership featureMembership) {
             newContainer.getOwnedRelationship().add(featureMembership);
         } else if (eContainer instanceof OwningMembership owningMembership) {
             var newFeatureMembership = SysmlFactory.eINSTANCE.createFeatureMembership();
-            newFeatureMembership.getOwnedRelatedElement().add(partUsage);
+            newFeatureMembership.getOwnedRelatedElement().add(usage);
             newContainer.getOwnedRelationship().add(newFeatureMembership);
             EcoreUtil.delete(owningMembership);
         }
-        return partUsage;
+        return usage;
     }
 
     public PartUsage addAsNestedPart(PartDefinition partDefinition, PartUsage partUsage) {

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionProvider.java
@@ -38,10 +38,10 @@ import org.eclipse.syson.diagram.common.view.tools.ToolSectionDescription;
 import org.eclipse.syson.diagram.general.view.edges.DependencyEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.edges.FeatureTypingEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.edges.PartDefinitionOwnedItemEdgeDescriptionProvider;
-import org.eclipse.syson.diagram.general.view.edges.PartUsageNestedPartEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.edges.RedefinitionEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.edges.SubclassificationEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.edges.SubsettingEdgeDescriptionProvider;
+import org.eclipse.syson.diagram.general.view.edges.UsageNestedUsageEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.nodes.CompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.nodes.FakeNodeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.nodes.GeneralViewEmptyDiagramNodeDescriptionProvider;
@@ -161,7 +161,10 @@ public class GeneralViewDiagramDescriptionProvider extends AbstractDiagramDescri
         diagramElementDescriptionProviders.add(new GeneralViewEmptyDiagramNodeDescriptionProvider(colorProvider));
 
         diagramElementDescriptionProviders.add(new PartDefinitionOwnedItemEdgeDescriptionProvider(colorProvider));
-        diagramElementDescriptionProviders.add(new PartUsageNestedPartEdgeDescriptionProvider(colorProvider));
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getAttributeUsage(), SysmlPackage.eINSTANCE.getUsage_NestedAttribute(), colorProvider));
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getUsage_NestedItem(), colorProvider));
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getPartUsage(), SysmlPackage.eINSTANCE.getUsage_NestedPart(), colorProvider));
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getPortUsage(), SysmlPackage.eINSTANCE.getUsage_NestedPort(), colorProvider));
         diagramElementDescriptionProviders.add(new DependencyEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new SubclassificationEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new RedefinitionEdgeDescriptionProvider(colorProvider));


### PR DESCRIPTION
Add "Become nested ":

- Attribute for all usages,
- Item for all usage,
- Part for all usage and PartDefinition
- Port for all usages

Bug: https://github.com/eclipse-syson/syson/issues/151