### PR TITLE
[160] Add explicit usage of node to call syside javascript file

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@
 === Bug fixes
 
 - https://github.com/eclipse-syson/syson/issues/144[#144] [diagrams] Fix an issue where the "Add existing elements (recursive)" failed on PartUsage.
+- https://github.com/eclipse-syson/syson/issues/160[#160] [syson] Add explicit usage of node to call syside javascript file.
 
 === Improvements
 

--- a/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/SysmlToAst.java
+++ b/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/SysmlToAst.java
@@ -59,8 +59,8 @@ public class SysmlToAst {
             input.close();
             outStream.close();
             Path path = Path.of(this.cliPath);
-            this.logger.info("Call syside application : " + path.toString() + " dump " + temp.toString());
-            String[] args = { path.toString(), "dump", temp.toString() };
+            this.logger.info("Call syside application : node " + path.toString() + " dump " + temp.toString());
+            String[] args = { "node", path.toString(), "dump", temp.toString() };
             ProcessBuilder pb = new ProcessBuilder(args);
             pb = pb.redirectErrorStream(false);
             Process p = pb.start();


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/160
Signed-off-by: Guillaume Escande <guillaume.escande@obeosoft.fr>