### PR TITLE
[163] Add missing composite edges between usage and compartment content

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@
 - https://github.com/eclipse-syson/syson/issues/153[#153] [syson] Forbid composite usages inside PortDefinition/PortUsage.
 - https://github.com/eclipse-syson/syson/issues/155[#155] [syson] Forbid composite usages inside AttributeDefinition/AttributeUsage.
 - https://github.com/eclipse-syson/syson/issues/154[#154] [diagrams] Add missing node tools inside existing usage elements.
+- https://github.com/eclipse-syson/syson/issues/163[#163] [diagrams] Add missing composite edges between usage and compartment content
 
 === New features
 

--- a/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionProvider.java
+++ b/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionProvider.java
@@ -32,6 +32,7 @@ import org.eclipse.syson.diagram.actionflow.view.edges.FeatureTypingEdgeDescript
 import org.eclipse.syson.diagram.actionflow.view.edges.RedefinitionEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.edges.SubclassificationEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.edges.SubsettingEdgeDescriptionProvider;
+import org.eclipse.syson.diagram.actionflow.view.edges.UsageNestedUsageEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.nodes.ActionFlowViewEmptyDiagramNodeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.nodes.CompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.nodes.DefinitionNodeDescriptionProvider;
@@ -98,6 +99,7 @@ public class ActionFlowViewDiagramDescriptionProvider extends AbstractDiagramDes
         diagramElementDescriptionProviders.add(new RedefinitionEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new SubclassificationEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new SubsettingEdgeDescriptionProvider(colorProvider));
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getActionUsage(), SysmlPackage.eINSTANCE.getUsage_NestedAction(), colorProvider, this.nameGenerator));
 
         diagramElementDescriptionProviders.add(new FakeNodeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new ActionFlowViewEmptyDiagramNodeDescriptionProvider(colorProvider));

--- a/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/edges/UsageNestedUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/edges/UsageNestedUsageEdgeDescriptionProvider.java
@@ -10,19 +10,19 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-package org.eclipse.syson.diagram.general.view.edges;
+package org.eclipse.syson.diagram.actionflow.view.edges;
 
 import java.util.List;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.syson.diagram.actionflow.view.ActionFlowViewDiagramDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.edges.AbstractUsageNestedUsageEdgeDescriptionProvider;
-import org.eclipse.syson.diagram.general.view.GeneralViewDiagramDescriptionProvider;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 
 /**
- * Used to create the edge description between usages and their nested usages in General View.
+ * Used to create the edge description between usages and their nested usages in Action Flow View.
  *
  * @author Jerome Gout
  */
@@ -34,6 +34,6 @@ public class UsageNestedUsageEdgeDescriptionProvider extends AbstractUsageNested
 
     @Override
     protected List<EClass> getUsages() {
-        return GeneralViewDiagramDescriptionProvider.USAGES;
+        return ActionFlowViewDiagramDescriptionProvider.USAGES;
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractUsageNestedUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractUsageNestedUsageEdgeDescriptionProvider.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.common.view.edges;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.sirius.components.view.builder.IViewDiagramElementFinder;
+import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.sirius.components.view.diagram.ArrowStyle;
+import org.eclipse.sirius.components.view.diagram.DiagramDescription;
+import org.eclipse.sirius.components.view.diagram.EdgeDescription;
+import org.eclipse.sirius.components.view.diagram.EdgeStyle;
+import org.eclipse.sirius.components.view.diagram.LineStyle;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
+import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.SysMLMetamodelHelper;
+import org.eclipse.syson.util.ViewConstants;
+
+/**
+ * Used to create the edge description between usages and their nested usages.
+ *
+ * @author arichard
+ */
+public abstract class AbstractUsageNestedUsageEdgeDescriptionProvider extends AbstractEdgeDescriptionProvider {
+
+    private final IDescriptionNameGenerator nameGenerator;
+
+    private final EClass eClass;
+
+    private final EReference eReference;
+
+    public AbstractUsageNestedUsageEdgeDescriptionProvider(EClass eClass, EReference eReference, IColorProvider colorProvider, IDescriptionNameGenerator nameGenerator) {
+        super(colorProvider);
+        this.nameGenerator = Objects.requireNonNull(nameGenerator);
+        this.eClass = Objects.requireNonNull(eClass);
+        this.eReference = Objects.requireNonNull(eReference);
+    }
+
+    /**
+     * Implementers should provide the list of {@link EClass} that represent the set of known usages concepts for the diagram.
+     * @return the list of usage class
+     */
+    protected abstract List<EClass>getUsages();
+
+    @Override
+    public EdgeDescription create() {
+        String domainType = SysMLMetamodelHelper.buildQualifiedName(this.eClass);
+        return this.diagramBuilderHelper.newEdgeDescription()
+                .domainType(domainType)
+                .isDomainBasedEdge(false)
+                .labelExpression(AQLConstants.AQL + org.eclipse.sirius.components.diagrams.description.EdgeDescription.SEMANTIC_EDGE_TARGET + ".getMultiplicityLabel()")
+                .name(this.nameGenerator.getEdgeName("Usage Nested " + this.eClass.getName()))
+                .sourceNodesExpression(AQLConstants.AQL_SELF)
+                .style(this.createEdgeStyle())
+                .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
+                .targetNodesExpression(AQLConstants.AQL_SELF + "." + this.eReference.getName())
+                .build();
+    }
+
+    @Override
+    public void link(DiagramDescription diagramDescription, IViewDiagramElementFinder cache) {
+        var optEdgeDescription = cache.getEdgeDescription(this.nameGenerator.getEdgeName("Usage Nested " + this.eClass.getName()));
+        var optUsageNodeDescription = cache.getNodeDescription(this.nameGenerator.getNodeName(this.eClass));
+        var sourceNodes = new ArrayList<NodeDescription>();
+
+        this.getUsages().forEach(usage -> {
+            cache.getNodeDescription(this.nameGenerator.getNodeName(usage)).ifPresent(sourceNodes::add);
+        });
+
+        EdgeDescription edgeDescription = optEdgeDescription.get();
+        diagramDescription.getEdgeDescriptions().add(edgeDescription);
+        edgeDescription.getSourceNodeDescriptions().addAll(sourceNodes);
+        edgeDescription.getTargetNodeDescriptions().add(optUsageNodeDescription.get());
+    }
+
+    private EdgeStyle createEdgeStyle() {
+        return this.diagramBuilderHelper.newEdgeStyle()
+                .color(this.colorProvider.getColor(ViewConstants.DEFAULT_EDGE_COLOR))
+                .edgeWidth(1)
+                .lineStyle(LineStyle.SOLID)
+                .sourceArrowStyle(ArrowStyle.FILL_DIAMOND)
+                .targetArrowStyle(ArrowStyle.NONE)
+                .build();
+    }
+}

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionProvider.java
@@ -166,11 +166,14 @@ public class GeneralViewDiagramDescriptionProvider extends AbstractDiagramDescri
         diagramElementDescriptionProviders.add(new DefinitionOwnedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getPortUsage(), SysmlPackage.eINSTANCE.getDefinition_OwnedPort(), colorProvider, this.nameGenerator));
         diagramElementDescriptionProviders.add(new DefinitionOwnedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getRequirementUsage(), SysmlPackage.eINSTANCE.getDefinition_OwnedRequirement(), colorProvider, this.nameGenerator));
 
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getActionUsage(), SysmlPackage.eINSTANCE.getUsage_NestedAction(), colorProvider, this.nameGenerator));
         diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getAttributeUsage(), SysmlPackage.eINSTANCE.getUsage_NestedAttribute(), colorProvider, this.nameGenerator));
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getConstraintUsage(), SysmlPackage.eINSTANCE.getUsage_NestedConstraint(), colorProvider, this.nameGenerator));
         diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getUsage_NestedItem(), colorProvider, this.nameGenerator));
         diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getPartUsage(), SysmlPackage.eINSTANCE.getUsage_NestedPart(), colorProvider, this.nameGenerator));
         diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getPortUsage(), SysmlPackage.eINSTANCE.getUsage_NestedPort(), colorProvider, this.nameGenerator));
         diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getRequirementUsage(), SysmlPackage.eINSTANCE.getUsage_NestedRequirement(), colorProvider, this.nameGenerator));
+        diagramElementDescriptionProviders.add(new UsageNestedUsageEdgeDescriptionProvider(SysmlPackage.eINSTANCE.getRequirementUsage(), SysmlPackage.eINSTANCE.getUsage_NestedConstraint(), colorProvider, this.nameGenerator));
         diagramElementDescriptionProviders.add(new DependencyEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new SubclassificationEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new RedefinitionEdgeDescriptionProvider(colorProvider));


### PR DESCRIPTION
Missing cases:
 - Nested Actions of Actions
 - Nested Constraints of Constraints
 - Nested Constraints of Requirements

Bug:  https://github.com/eclipse-syson/syson/issues/163