### PR TITLE
[fix] Edge tool preconditions are not properly supported

### DIFF
--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeToolSwitch.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeToolSwitch.java
@@ -510,9 +510,6 @@ public class ViewEdgeToolSwitch extends SysmlEClassSwitch<List<EdgeTool>> {
                 .name(this.nameGenerator.getCreationToolName("Become objective", SysmlPackage.eINSTANCE.getRequirementUsage()))
                 .iconURLsExpression(METAMODEL_ICONS_PATH + "Objective.svg")
                 .body(callService.build())
-                // maybe in a near future, the following precondition will be active when edge preconditions will be implemented
-                // follow this at https://github.com/eclipse-sirius/sirius-web/issues/2930
-                .preconditionExpression(AQLConstants.AQL + EdgeDescription.SEMANTIC_EDGE_TARGET + ".isEmptyObjectiveRequirementCompartment()")
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
                 .build();
     }


### PR DESCRIPTION
At the moment, the edge tool preconditions are evaluated as soon as the node that contains the edge tool is selected. Since no edges are built at this stage, edge variables are not instantiated and accessing these variables raises errors.
A proposal (https://github.com/eclipse-sirius/sirius-web/issues/2930) is made to evaluate preconditions when the edge target is selected. That way, the edge variables will be set and could be used in services.

The fix consists to remove the precondition in the edge tool to avoid errors.

Bug: https://github.com/eclipse-syson/syson/issues/169