### PR TITLE
[199] Fix rename element action in Explorer view

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@
 - https://github.com/eclipse-syson/syson/issues/174[#174] [details] Fix an issue where an error raised when setting a valid new value (with primitive type) in the Details view.
 - https://github.com/eclipse-syson/syson/issues/192[#192] [import] Fix an issue where the /* and */ of a Comment's body were imported while importing a textual SysML file. 
 - https://github.com/eclipse-syson/syson/issues/188[#188] [import] Fix an issue where some Memberships were contained in their parent through `ownedRelatedElement` instead of `ownedRelationship` reference.
+- https://github.com/eclipse-syson/syson/issues/199[#199] [explorer] Fix an issue where the rename action was not renaming tree items anymore
 
 === Improvements
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/SysMLv2LabelService.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/SysMLv2LabelService.java
@@ -83,6 +83,9 @@ public class SysMLv2LabelService implements ILabelServiceDelegate {
 
     @Override
     public Optional<String> getLabelField(Object object) {
+        if (object instanceof Element) {
+            return Optional.of(SysmlPackage.eINSTANCE.getElement_DeclaredName().getName());
+        }
         return this.defaultLabelService.getLabelField(object);
     }
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/199