### PR TITLE
[237] Fix child nested and owned usage node localisation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@
 - https://github.com/eclipse-syson/syson/issues/188[#188] [import] Fix an issue where some Memberships were contained in their parent through `ownedRelatedElement` instead of `ownedRelationship` reference.
 - https://github.com/eclipse-syson/syson/issues/199[#199] [explorer] Fix an issue where the rename action was not renaming tree items anymore
 - https://github.com/eclipse-syson/syson/issues/209[#209] [diagrams] EnumerationDefinition was created without any name
+- https://github.com/eclipse-syson/syson/issues/237[#237] [diagrams] Fix an issue where `Add existing element (recursive)` creates child nodes for nested and owned usages at the root of the diagram instead of in their parent node
 
 === Improvements
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
@@ -295,9 +295,9 @@ public class ViewToolService extends ToolService {
 
         nestedUsages.stream()
                 .forEach(subUsage -> {
-                    this.createView(subUsage, editingContext, diagramContext, parentNode, convertedNodes);
-                    Node fakeNode = this.createFakeNode(subUsage, parentNode, diagramContext, diagramDescription, convertedNodes);
-                    this.addExistingSubElements(subUsage, editingContext, diagramContext, fakeNode, parentNode, diagramDescription, convertedNodes);
+                    this.createView(subUsage, editingContext, diagramContext, selectedNode, convertedNodes);
+                    Node fakeNode = this.createFakeNode(subUsage, selectedNode, diagramContext, diagramDescription, convertedNodes);
+                    this.addExistingSubElements(subUsage, editingContext, diagramContext, fakeNode, selectedNode, diagramDescription, convertedNodes);
                 });
         return usage;
     }
@@ -308,9 +308,9 @@ public class ViewToolService extends ToolService {
 
         ownedUsages.stream()
                 .forEach(subUsage -> {
-                    this.createView(subUsage, editingContext, diagramContext, parentNode, convertedNodes);
-                    Node fakeNode = this.createFakeNode(subUsage, parentNode, diagramContext, diagramDescription, convertedNodes);
-                    this.addExistingSubElements(subUsage, editingContext, diagramContext, fakeNode, parentNode, diagramDescription, convertedNodes);
+                    this.createView(subUsage, editingContext, diagramContext, selectedNode, convertedNodes);
+                    Node fakeNode = this.createFakeNode(subUsage, selectedNode, diagramContext, diagramDescription, convertedNodes);
+                    this.addExistingSubElements(subUsage, editingContext, diagramContext, fakeNode, selectedNode, diagramDescription, convertedNodes);
                 });
         return definition;
     }


### PR DESCRIPTION
Create nested and owned usage nodes in the parent semantic element node instead of at the root of the diagram.

Bug: https://github.com/eclipse-syson/syson/issues/237