### PR TITLE
[229] Prevent circular containment of nested parts

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,7 @@
 - https://github.com/eclipse-syson/syson/issues/264[#264] [diagrams] Restore hide capabilities that were missing after the latest Sirius Web update
 - https://github.com/eclipse-syson/syson/issues/274[#274] [import] Namespace.getImportedMemberships method now prevents name collisions
 - https://github.com/eclipse-syson/syson/issues/271[#271] [diagrams] Remove non end Usages from AllocationDefinition ends compartment
+- https://github.com/eclipse-syson/syson/issues/229[#229] [diagrams] Prevent circular containment of nested parts
 
 === Improvements
 

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ToolService.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ToolService.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramContext;
 import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.CollapsingState;
@@ -69,11 +70,14 @@ public class ToolService {
 
     protected final IRepresentationDescriptionSearchService representationDescriptionSearchService;
 
+    protected final IFeedbackMessageService feedbackMessageService;
+
     private final Logger logger = LoggerFactory.getLogger(ToolService.class);
 
-    public ToolService(IObjectService objectService, IRepresentationDescriptionSearchService representationDescriptionSearchService) {
+    public ToolService(IObjectService objectService, IRepresentationDescriptionSearchService representationDescriptionSearchService, IFeedbackMessageService feedbackMessageService) {
         this.objectService = Objects.requireNonNull(objectService);
         this.representationDescriptionSearchService = Objects.requireNonNull(representationDescriptionSearchService);
+        this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
     }
 
     /**

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDefinitionOwnedUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDefinitionOwnedUsageEdgeDescriptionProvider.java
@@ -139,7 +139,7 @@ public abstract class AbstractDefinitionOwnedUsageEdgeDescriptionProvider extend
 
     @Override
     protected ChangeContextBuilder getTargetReconnectToolBody() {
-        var params = List.of(AQLConstants.SEMANTIC_RECONNECTION_SOURCE, AQLConstants.SEMANTIC_RECONNECTION_TARGET);
+        var params = List.of(AQLConstants.SEMANTIC_RECONNECTION_SOURCE, AQLConstants.SEMANTIC_RECONNECTION_TARGET, AQLConstants.SEMANTIC_OTHER_END);
         return this.viewBuilderHelper.newChangeContext()
                 .expression(AQLConstants.AQL + AQLConstants.EDGE_SEMANTIC_ELEMENT + ".reconnnectTargetCompositionEdge(" + String.join(",", params) + ")");
     }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractUsageNestedUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractUsageNestedUsageEdgeDescriptionProvider.java
@@ -122,7 +122,7 @@ public abstract class AbstractUsageNestedUsageEdgeDescriptionProvider extends Ab
 
     @Override
     protected ChangeContextBuilder getTargetReconnectToolBody() {
-        var params = List.of(AQLConstants.SEMANTIC_RECONNECTION_SOURCE, AQLConstants.SEMANTIC_RECONNECTION_TARGET);
+        var params = List.of(AQLConstants.SEMANTIC_RECONNECTION_SOURCE, AQLConstants.SEMANTIC_RECONNECTION_TARGET, AQLConstants.SEMANTIC_OTHER_END);
         return this.viewBuilderHelper.newChangeContext()
                 .expression(AQLConstants.AQL + AQLConstants.EDGE_SEMANTIC_ELEMENT + ".reconnnectTargetCompositionEdge(" + String.join(",", params) + ")");
     }

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewToolService.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewToolService.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramContext;
 import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.CollapsingState;
@@ -67,8 +68,8 @@ public class InterconnectionViewToolService extends ViewToolService {
     private final IDescriptionNameGenerator descriptionNameGenerator;
 
     public InterconnectionViewToolService(IObjectService objectService, IRepresentationDescriptionSearchService representationDescriptionSearchService,
-            IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService) {
-        super(objectService, representationDescriptionSearchService, viewRepresentationDescriptionSearchService);
+            IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService, IFeedbackMessageService feedbackMessageService) {
+        super(objectService, representationDescriptionSearchService, viewRepresentationDescriptionSearchService, feedbackMessageService);
         this.elementInitializerSwitch = new ElementInitializerSwitch();
         this.descriptionNameGenerator = new IVDescriptionNameGenerator();
     }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewToolService.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewToolService.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramContext;
 import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.core.api.IRepresentationDescriptionSearchService;
 import org.eclipse.sirius.components.diagrams.Node;
@@ -45,8 +46,8 @@ public class StateTransitionViewToolService extends ViewToolService {
     private final ElementInitializerSwitch elementInitializerSwitch;
 
     public StateTransitionViewToolService(IObjectService objectService, IRepresentationDescriptionSearchService representationDescriptionSearchService,
-            IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService) {
-        super(objectService, representationDescriptionSearchService, viewRepresentationDescriptionSearchService);
+            IViewRepresentationDescriptionSearchService viewRepresentationDescriptionSearchService, IFeedbackMessageService feedbackMessageService) {
+        super(objectService, representationDescriptionSearchService, viewRepresentationDescriptionSearchService, feedbackMessageService);
         this.elementInitializerSwitch = new ElementInitializerSwitch();
     }
 


### PR DESCRIPTION
The `ViewToolService` doesn't attempt to change the container of a part if it would create a circular containment reference. This includes "Become Nested Part" tool as well as nested part edge reconnection tools.
An error message is logged in the console and in the workbench via the `IFeedbackMessageService`.

Bug: https://github.com/eclipse-syson/syson/issues/229