### PR TITLE
[305] Fix performance issue when using EcoreUtil.delete

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,7 @@
 - https://github.com/eclipse-syson/syson/issues/274[#274] [import] Namespace.getImportedMemberships method now prevents name collisions
 - https://github.com/eclipse-syson/syson/issues/271[#271] [diagrams] Remove non end Usages from AllocationDefinition ends compartment
 - https://github.com/eclipse-syson/syson/issues/229[#229] [diagrams] Prevent circular containment of nested parts including self containment
+- https://github.com/eclipse-syson/syson/issues/305[#305] [diagrams] Fix performance issue when using EcoreUtil.delete
 
 === Improvements
 

--- a/backend/tests/syson-tests/src/main/java/org/eclipse/syson/tests/architecture/AbstractCodingRulesTests.java
+++ b/backend/tests/syson-tests/src/main/java/org/eclipse/syson/tests/architecture/AbstractCodingRulesTests.java
@@ -164,6 +164,18 @@ public abstract class AbstractCodingRulesTests {
         rule.check(this.getClasses());
     }
 
+    public void noClassesShouldUseEcoreUtilDelete() {
+        ArchRule rule = ArchRuleDefinition.noClasses()
+                .that()
+                .resideInAPackage(this.getProjectRootPackage())
+                .should()
+                .callMethod("org.eclipse.emf.ecore.util.EcoreUtil", "delete", "org.eclipse.emf.ecore.EObject")
+                .orShould()
+                .callMethod("org.eclipse.emf.ecore.util.EcoreUtil", "delete", "org.eclipse.emf.ecore.EObject", "boolean")
+                .because("EcoreUtil.delete doesn't work well with Sysml Standard Libraries in the ResourceSet, use DeleteService instead");
+        rule.check(this.getClasses());
+    }
+
     public void noClassesShouldUseApacheCommons() {
         // @formatter:off
         ArchRule rule = ArchRuleDefinition.noClasses()

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramContext;
 import org.eclipse.sirius.components.collaborative.diagrams.api.IDiagramService;
 import org.eclipse.sirius.components.core.api.IEditingContext;
@@ -28,6 +27,7 @@ import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.sirius.components.diagrams.ViewCreationRequest;
 import org.eclipse.sirius.components.view.emf.diagram.api.IViewDiagramDescriptionSearchService;
+import org.eclipse.syson.services.DeleteService;
 import org.eclipse.syson.services.ElementInitializerSwitch;
 import org.eclipse.syson.sysml.AcceptActionUsage;
 import org.eclipse.syson.sysml.AllocationDefinition;
@@ -69,10 +69,13 @@ public class ViewCreateService {
 
     private final ElementInitializerSwitch elementInitializerSwitch;
 
+    private final DeleteService deleteService;
+
     public ViewCreateService(IViewDiagramDescriptionSearchService viewDiagramDescriptionSearchService, IObjectService objectService) {
         this.viewDiagramDescriptionSearchService = Objects.requireNonNull(viewDiagramDescriptionSearchService);
         this.objectService = Objects.requireNonNull(objectService);
         this.elementInitializerSwitch = new ElementInitializerSwitch();
+        this.deleteService = new DeleteService();
     }
 
     /**
@@ -441,7 +444,7 @@ public class ViewCreateService {
                 var oldParameterContent = parameterMembership.getOwnedMemberParameter();
                 if (oldParameterContent != null) {
                     // there is already a playload parameter, we need to delete it.
-                    EcoreUtil.delete(oldParameterContent);
+                    this.deleteService.deleteFromModel(oldParameterContent);
                 }
                 parameterMembership.getOwnedRelatedElement().add(referenceUsage);
                 self.getOwnedRelationship().add(parameterMembership);
@@ -517,7 +520,7 @@ public class ViewCreateService {
         Feature oldParameterContent = parameterMembership.getOwnedMemberParameter();
         if (oldParameterContent != null) {
             // there is already an element, we need to delete this element
-            EcoreUtil.delete(oldParameterContent);
+            this.deleteService.deleteFromModel(oldParameterContent);
         }
         parameterMembership.getOwnedRelatedElement().add(referenceUsage);
         self.getOwnedRelationship().add(parameterMembership);


### PR DESCRIPTION
`EcoreUtil.delete` looks for all the crossReferences of the element to delete. This takes a lot of time when all the Sysml standard libraries are loaded in the resource set. We can replace `EcoreUtil.delete` with `DeleteService.deleteFromModel`, which is way faster. This shouldn't be an issue because `DeleteService.deleteFromModel` is already used in various places in the code to delete elements.

This PR also adds a check in the `AbstractCodingRulesTests` class, although it is not used at the moment, it will be useful to check that no class uses `EcoreUtil.delete` once we enforce the coding rules.

Bug: https://github.com/eclipse-syson/syson/issues/305