### PR TITLE
[333] State entry/do/exit actions items in dedicated container

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@
 - https://github.com/eclipse-syson/syson/issues/307[#307] [diagrams] Fix parallel states tooling conditions
 - https://github.com/eclipse-syson/syson/issues/269[#269] [diagrams] Handle start and done actions in Action Flow View & General View diagrams
 - https://github.com/eclipse-syson/syson/issues/344[#344] [metamodel] Improve implementation of getName and getShortName
+- https://github.com/eclipse-syson/syson/issues/333[#333] [state-transition] Improve actions compartment for states
 
 === New features
 

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/StateDefinitionImpl.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/StateDefinitionImpl.java
@@ -23,6 +23,8 @@ import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.emf.ecore.util.EcoreEList;
 import org.eclipse.syson.sysml.ActionUsage;
 import org.eclipse.syson.sysml.StateDefinition;
+import org.eclipse.syson.sysml.StateSubactionKind;
+import org.eclipse.syson.sysml.StateSubactionMembership;
 import org.eclipse.syson.sysml.StateUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.Usage;
@@ -97,13 +99,18 @@ public class StateDefinitionImpl extends ActionDefinitionImpl implements StateDe
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @generated
+     * @generated NOT
      */
     public ActionUsage basicGetDoAction() {
-        // TODO: implement this method to return the 'Do Action' reference
-        // -> do not perform proxy resolution
-        // Ensure that you remove @generated or mark it @generated NOT
-        return null;
+        return this.getOwnedRelationship().stream()
+                .filter(StateSubactionMembership.class::isInstance)
+                .map(StateSubactionMembership.class::cast)
+                .filter(ssm -> ssm.getKind().equals(StateSubactionKind.DO))
+                .map(StateSubactionMembership::getAction)
+                .filter(ActionUsage.class::isInstance)
+                .map(ActionUsage.class::cast)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -120,13 +127,18 @@ public class StateDefinitionImpl extends ActionDefinitionImpl implements StateDe
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @generated
+     * @generated NOT
      */
     public ActionUsage basicGetEntryAction() {
-        // TODO: implement this method to return the 'Entry Action' reference
-        // -> do not perform proxy resolution
-        // Ensure that you remove @generated or mark it @generated NOT
-        return null;
+        return this.getOwnedRelationship().stream()
+                .filter(StateSubactionMembership.class::isInstance)
+                .map(StateSubactionMembership.class::cast)
+                .filter(ssm -> ssm.getKind().equals(StateSubactionKind.ENTRY))
+                .map(StateSubactionMembership::getAction)
+                .filter(ActionUsage.class::isInstance)
+                .map(ActionUsage.class::cast)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -143,13 +155,18 @@ public class StateDefinitionImpl extends ActionDefinitionImpl implements StateDe
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @generated
+     * @generated NOT
      */
     public ActionUsage basicGetExitAction() {
-        // TODO: implement this method to return the 'Exit Action' reference
-        // -> do not perform proxy resolution
-        // Ensure that you remove @generated or mark it @generated NOT
-        return null;
+        return this.getOwnedRelationship().stream()
+                .filter(StateSubactionMembership.class::isInstance)
+                .map(StateSubactionMembership.class::cast)
+                .filter(ssm -> ssm.getKind().equals(StateSubactionKind.EXIT))
+                .map(StateSubactionMembership::getAction)
+                .filter(ActionUsage.class::isInstance)
+                .map(ActionUsage.class::cast)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -171,8 +188,9 @@ public class StateDefinitionImpl extends ActionDefinitionImpl implements StateDe
     public void setIsParallel(boolean newIsParallel) {
         boolean oldIsParallel = this.isParallel;
         this.isParallel = newIsParallel;
-        if (this.eNotificationRequired())
+        if (this.eNotificationRequired()) {
             this.eNotify(new ENotificationImpl(this, Notification.SET, SysmlPackage.STATE_DEFINITION__IS_PARALLEL, oldIsParallel, this.isParallel));
+        }
     }
 
     /**
@@ -197,16 +215,19 @@ public class StateDefinitionImpl extends ActionDefinitionImpl implements StateDe
             case SysmlPackage.STATE_DEFINITION__IS_PARALLEL:
                 return this.isIsParallel();
             case SysmlPackage.STATE_DEFINITION__DO_ACTION:
-                if (resolve)
+                if (resolve) {
                     return this.getDoAction();
+                }
                 return this.basicGetDoAction();
             case SysmlPackage.STATE_DEFINITION__ENTRY_ACTION:
-                if (resolve)
+                if (resolve) {
                     return this.getEntryAction();
+                }
                 return this.basicGetEntryAction();
             case SysmlPackage.STATE_DEFINITION__EXIT_ACTION:
-                if (resolve)
+                if (resolve) {
                     return this.getExitAction();
+                }
                 return this.basicGetExitAction();
             case SysmlPackage.STATE_DEFINITION__STATE:
                 return this.getState();
@@ -274,8 +295,9 @@ public class StateDefinitionImpl extends ActionDefinitionImpl implements StateDe
      */
     @Override
     public String toString() {
-        if (this.eIsProxy())
+        if (this.eIsProxy()) {
             return super.toString();
+        }
 
         StringBuilder result = new StringBuilder(super.toString());
         result.append(" (isParallel: ");

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/StateSubactionMembershipImpl.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/StateSubactionMembershipImpl.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.InternalEObject;
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 import org.eclipse.syson.sysml.ActionUsage;
+import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.StateSubactionKind;
 import org.eclipse.syson.sysml.StateSubactionMembership;
 import org.eclipse.syson.sysml.SysmlPackage;
@@ -75,7 +76,11 @@ public class StateSubactionMembershipImpl extends FeatureMembershipImpl implemen
     }
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * <!-- begin-user-doc -->
+     *
+     * The ActionUsage that is the ownedMemberFeature of this StateSubactionMembership.
+     *
+     * <!-- end-user-doc -->
      *
      * @generated
      */
@@ -86,14 +91,19 @@ public class StateSubactionMembershipImpl extends FeatureMembershipImpl implemen
     }
 
     /**
-     * <!-- begin-user-doc --> <!-- end-user-doc -->
+     * <!-- begin-user-doc -->
      *
-     * @generated
+     * The ActionUsage that is the ownedMemberFeature of this StateSubactionMembership.
+     *
+     * <!-- end-user-doc -->
+     *
+     * @generated NOT
      */
     public ActionUsage basicGetAction() {
-        // TODO: implement this method to return the 'Action' reference
-        // -> do not perform proxy resolution
-        // Ensure that you remove @generated or mark it @generated NOT
+        Feature ownedMemberFeature = this.getOwnedMemberFeature();
+        if (ownedMemberFeature instanceof ActionUsage au) {
+            return au;
+        }
         return null;
     }
 
@@ -116,8 +126,9 @@ public class StateSubactionMembershipImpl extends FeatureMembershipImpl implemen
     public void setKind(StateSubactionKind newKind) {
         StateSubactionKind oldKind = this.kind;
         this.kind = newKind == null ? KIND_EDEFAULT : newKind;
-        if (this.eNotificationRequired())
+        if (this.eNotificationRequired()) {
             this.eNotify(new ENotificationImpl(this, Notification.SET, SysmlPackage.STATE_SUBACTION_MEMBERSHIP__KIND, oldKind, this.kind));
+        }
     }
 
     /**
@@ -131,8 +142,9 @@ public class StateSubactionMembershipImpl extends FeatureMembershipImpl implemen
             case SysmlPackage.STATE_SUBACTION_MEMBERSHIP__KIND:
                 return this.getKind();
             case SysmlPackage.STATE_SUBACTION_MEMBERSHIP__ACTION:
-                if (resolve)
+                if (resolve) {
                     return this.getAction();
+                }
                 return this.basicGetAction();
         }
         return super.eGet(featureID, resolve, coreType);
@@ -191,8 +203,9 @@ public class StateSubactionMembershipImpl extends FeatureMembershipImpl implemen
      */
     @Override
     public String toString() {
-        if (this.eIsProxy())
+        if (this.eIsProxy()) {
             return super.toString();
+        }
 
         StringBuilder result = new StringBuilder(super.toString());
         result.append(" (kind: ");

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/StateUsageImpl.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/StateUsageImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.syson.sysml.ActionUsage;
 import org.eclipse.syson.sysml.Behavior;
 import org.eclipse.syson.sysml.FeatureTyping;
 import org.eclipse.syson.sysml.StateDefinition;
+import org.eclipse.syson.sysml.StateSubactionKind;
 import org.eclipse.syson.sysml.StateSubactionMembership;
 import org.eclipse.syson.sysml.StateUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
@@ -100,13 +101,18 @@ public class StateUsageImpl extends ActionUsageImpl implements StateUsage {
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @generated
+     * @generated NOT
      */
     public ActionUsage basicGetDoAction() {
-        // TODO: implement this method to return the 'Do Action' reference
-        // -> do not perform proxy resolution
-        // Ensure that you remove @generated or mark it @generated NOT
-        return null;
+        return this.getOwnedRelationship().stream()
+                .filter(StateSubactionMembership.class::isInstance)
+                .map(StateSubactionMembership.class::cast)
+                .filter(ssm -> ssm.getKind().equals(StateSubactionKind.DO))
+                .map(StateSubactionMembership::getAction)
+                .filter(ActionUsage.class::isInstance)
+                .map(ActionUsage.class::cast)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -123,13 +129,18 @@ public class StateUsageImpl extends ActionUsageImpl implements StateUsage {
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @generated
+     * @generated NOT
      */
     public ActionUsage basicGetEntryAction() {
-        // TODO: implement this method to return the 'Entry Action' reference
-        // -> do not perform proxy resolution
-        // Ensure that you remove @generated or mark it @generated NOT
-        return null;
+        return this.getOwnedRelationship().stream()
+                .filter(StateSubactionMembership.class::isInstance)
+                .map(StateSubactionMembership.class::cast)
+                .filter(ssm -> ssm.getKind().equals(StateSubactionKind.ENTRY))
+                .map(StateSubactionMembership::getAction)
+                .filter(ActionUsage.class::isInstance)
+                .map(ActionUsage.class::cast)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -146,13 +157,18 @@ public class StateUsageImpl extends ActionUsageImpl implements StateUsage {
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @generated
+     * @generated NOT
      */
     public ActionUsage basicGetExitAction() {
-        // TODO: implement this method to return the 'Exit Action' reference
-        // -> do not perform proxy resolution
-        // Ensure that you remove @generated or mark it @generated NOT
-        return null;
+        return this.getOwnedRelationship().stream()
+                .filter(StateSubactionMembership.class::isInstance)
+                .map(StateSubactionMembership.class::cast)
+                .filter(ssm -> ssm.getKind().equals(StateSubactionKind.EXIT))
+                .map(StateSubactionMembership::getAction)
+                .filter(ActionUsage.class::isInstance)
+                .map(ActionUsage.class::cast)
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -174,8 +190,9 @@ public class StateUsageImpl extends ActionUsageImpl implements StateUsage {
     public void setIsParallel(boolean newIsParallel) {
         boolean oldIsParallel = this.isParallel;
         this.isParallel = newIsParallel;
-        if (this.eNotificationRequired())
+        if (this.eNotificationRequired()) {
             this.eNotify(new ENotificationImpl(this, Notification.SET, SysmlPackage.STATE_USAGE__IS_PARALLEL, oldIsParallel, this.isParallel));
+        }
     }
 
     /**
@@ -240,16 +257,19 @@ public class StateUsageImpl extends ActionUsageImpl implements StateUsage {
             case SysmlPackage.STATE_USAGE__IS_PARALLEL:
                 return this.isIsParallel();
             case SysmlPackage.STATE_USAGE__DO_ACTION:
-                if (resolve)
+                if (resolve) {
                     return this.getDoAction();
+                }
                 return this.basicGetDoAction();
             case SysmlPackage.STATE_USAGE__ENTRY_ACTION:
-                if (resolve)
+                if (resolve) {
                     return this.getEntryAction();
+                }
                 return this.basicGetEntryAction();
             case SysmlPackage.STATE_USAGE__EXIT_ACTION:
-                if (resolve)
+                if (resolve) {
                     return this.getExitAction();
+                }
                 return this.basicGetExitAction();
             case SysmlPackage.STATE_USAGE__STATE_DEFINITION:
                 return this.getStateDefinition();
@@ -331,8 +351,9 @@ public class StateUsageImpl extends ActionUsageImpl implements StateUsage {
      */
     @Override
     public String toString() {
-        if (this.eIsProxy())
+        if (this.eIsProxy()) {
             return super.toString();
+        }
 
         StringBuilder result = new StringBuilder(super.toString());
         result.append(" (isParallel: ");

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/util/DescriptionNameGenerator.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/util/DescriptionNameGenerator.java
@@ -32,7 +32,7 @@ import org.eclipse.syson.sysml.SysmlPackage;
  */
 public class DescriptionNameGenerator implements IDescriptionNameGenerator {
 
-    private static final String SPACE = " ";
+    protected static final String SPACE = " ";
 
     private static final Pattern WORD_FINDER = Pattern.compile("(([A-Z]?[a-z]+)|([A-Z]))");
 
@@ -133,7 +133,7 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getNodeName(String type) {
-        return this.getNodeName(this.diagramPrefix, type);
+        return this.getNodeName(this.getDiagramPrefix(), type);
     }
 
     /**
@@ -146,7 +146,7 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getNodeName(EClass eClass) {
-        return this.getNodeName(this.diagramPrefix, eClass.getName());
+        return this.getNodeName(this.getDiagramPrefix(), eClass.getName());
     }
 
     /**
@@ -159,7 +159,7 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getBorderNodeName(String type) {
-        return this.getBorderNodeName(this.diagramPrefix, type);
+        return this.getBorderNodeName(this.getDiagramPrefix(), type);
     }
 
     /**
@@ -172,7 +172,7 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getBorderNodeName(EClass eClass) {
-        return this.getBorderNodeName(this.diagramPrefix, eClass.getName());
+        return this.getBorderNodeName(this.getDiagramPrefix(), eClass.getName());
     }
 
     /**
@@ -188,12 +188,12 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getCompartmentName(EClass eClass, EReference eReference) {
-        return this.getCompartmentName(this.diagramPrefix, eClass.getName() + SPACE + eReference.getName());
+        return this.getCompartmentName(this.getDiagramPrefix(), eClass.getName() + SPACE + eReference.getName());
     }
 
     @Override
     public String getFreeFormCompartmentName(EClass eClass, EReference eReference) {
-        return this.getCompartmentName(this.diagramPrefix, eClass.getName() + SPACE + eReference.getName() + " FreeForm");
+        return this.getCompartmentName(this.getDiagramPrefix(), eClass.getName() + SPACE + eReference.getName() + " FreeForm");
     }
 
     /**
@@ -209,7 +209,7 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getCompartmentItemName(EClass eClass, EReference eReference) {
-        return this.getCompartmentItemName(this.diagramPrefix, eClass.getName() + SPACE + eReference.getName());
+        return this.getCompartmentItemName(this.getDiagramPrefix(), eClass.getName() + SPACE + eReference.getName());
     }
 
     /**
@@ -225,7 +225,7 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getInheritedCompartmentItemName(EClass eClass, EReference eReference) {
-        return this.getInheritedCompartmentItemName(this.diagramPrefix, eClass.getName() + SPACE + eReference.getName());
+        return this.getInheritedCompartmentItemName(this.getDiagramPrefix(), eClass.getName() + SPACE + eReference.getName());
     }
 
     /**
@@ -238,7 +238,7 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getEdgeName(EClass eClass) {
-        return this.getEdgeName(this.diagramPrefix, eClass.getName());
+        return this.getEdgeName(this.getDiagramPrefix(), eClass.getName());
     }
 
     /**
@@ -251,6 +251,11 @@ public class DescriptionNameGenerator implements IDescriptionNameGenerator {
      */
     @Override
     public String getEdgeName(String type) {
-        return this.getEdgeName(this.diagramPrefix, type);
+        return this.getEdgeName(this.getDiagramPrefix(), type);
+    }
+
+    @Override
+    public String getDiagramPrefix() {
+        return this.diagramPrefix;
     }
 }

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/util/IDescriptionNameGenerator.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/util/IDescriptionNameGenerator.java
@@ -15,6 +15,7 @@ package org.eclipse.syson.util;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.sirius.components.diagrams.description.EdgeDescription;
 import org.eclipse.sirius.components.diagrams.description.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.NodeTool;
 
@@ -159,5 +160,10 @@ public interface IDescriptionNameGenerator {
      */
     String getEdgeName(String type);
 
-
+    /**
+     * Returns the prefix to be used during the computation of the {@link NodeDescription} and {@link EdgeDescription}.
+     *
+     * @return a string used to name a {@link NodeDescription} or a {@link EdgeDescription}.
+     */
+    String getDiagramPrefix();
 }

--- a/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/edges/SuccessionEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/edges/SuccessionEdgeDescriptionProvider.java
@@ -39,7 +39,7 @@ public class SuccessionEdgeDescriptionProvider extends AbstractSuccessionEdgeDes
         var sourcesAndTargets = new ArrayList<NodeDescription>();
 
         ActionFlowViewDiagramDescriptionProvider.USAGES.forEach(usage -> {
-            cache.getNodeDescription(this.nameGenerator.getNodeName(usage)).ifPresent(sourcesAndTargets::add);
+            cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(usage)).ifPresent(sourcesAndTargets::add);
         });
 
         return sourcesAndTargets;
@@ -49,7 +49,7 @@ public class SuccessionEdgeDescriptionProvider extends AbstractSuccessionEdgeDes
     protected List<NodeDescription> getSourceNodes(IViewDiagramElementFinder cache) {
         var sources = this.getAllUsages(cache);
         // the start node can be the source of a succession
-        cache.getNodeDescription(this.nameGenerator.getNodeName(StartActionNodeDescriptionProvider.START_ACTION_NAME)).ifPresent(sources::add);
+        cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(StartActionNodeDescriptionProvider.START_ACTION_NAME)).ifPresent(sources::add);
         return sources;
     }
 
@@ -57,7 +57,7 @@ public class SuccessionEdgeDescriptionProvider extends AbstractSuccessionEdgeDes
     protected List<NodeDescription> getTargetNodes(IViewDiagramElementFinder cache) {
         var targets = this.getAllUsages(cache);
         // the done node can be the target of a succession
-        cache.getNodeDescription(this.nameGenerator.getNodeName(DoneActionNodeDescriptionProvider.DONE_ACTION_NAME)).ifPresent(targets::add);
+        cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(DoneActionNodeDescriptionProvider.DONE_ACTION_NAME)).ifPresent(targets::add);
         return targets;
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDefinitionOwnedUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDefinitionOwnedUsageEdgeDescriptionProvider.java
@@ -44,7 +44,7 @@ import org.eclipse.syson.util.ViewConstants;
  */
 public abstract class AbstractDefinitionOwnedUsageEdgeDescriptionProvider extends AbstractEdgeDescriptionProvider {
 
-    private final IDescriptionNameGenerator nameGenerator;
+    private final IDescriptionNameGenerator descriptionNameGenerator;
 
     private final EClass eClass;
 
@@ -52,7 +52,7 @@ public abstract class AbstractDefinitionOwnedUsageEdgeDescriptionProvider extend
 
     public AbstractDefinitionOwnedUsageEdgeDescriptionProvider(EClass eClass, EReference eReference, IColorProvider colorProvider, IDescriptionNameGenerator nameGenerator) {
         super(colorProvider);
-        this.nameGenerator = Objects.requireNonNull(nameGenerator);
+        this.descriptionNameGenerator = Objects.requireNonNull(nameGenerator);
         this.eClass = Objects.requireNonNull(eClass);
         this.eReference = Objects.requireNonNull(eReference);
     }
@@ -72,7 +72,7 @@ public abstract class AbstractDefinitionOwnedUsageEdgeDescriptionProvider extend
                 .domainType(domainType)
                 .isDomainBasedEdge(false)
                 .centerLabelExpression(AQLConstants.AQL + org.eclipse.sirius.components.diagrams.description.EdgeDescription.SEMANTIC_EDGE_TARGET + ".getMultiplicityLabel()")
-                .name(this.nameGenerator.getEdgeName("Definition Owned " + this.eClass.getName()))
+                .name(this.descriptionNameGenerator.getEdgeName("Definition Owned " + this.eClass.getName()))
                 .sourceNodesExpression(AQLConstants.AQL_SELF)
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
@@ -82,12 +82,12 @@ public abstract class AbstractDefinitionOwnedUsageEdgeDescriptionProvider extend
 
     @Override
     public void link(DiagramDescription diagramDescription, IViewDiagramElementFinder cache) {
-        var optEdgeDescription = cache.getEdgeDescription(this.nameGenerator.getEdgeName("Definition Owned " + this.eClass.getName()));
-        var optUsageNodeDescription = cache.getNodeDescription(this.nameGenerator.getNodeName(this.eClass));
+        var optEdgeDescription = cache.getEdgeDescription(this.descriptionNameGenerator.getEdgeName("Definition Owned " + this.eClass.getName()));
+        var optUsageNodeDescription = cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(this.eClass));
         var sourceNodes = new ArrayList<NodeDescription>();
 
         this.getEdgeSources().forEach(definition -> {
-            cache.getNodeDescription(this.nameGenerator.getNodeName(definition)).ifPresent(sourceNodes::add);
+            cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(definition)).ifPresent(sourceNodes::add);
         });
 
         EdgeDescription edgeDescription = optEdgeDescription.get();

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSuccessionEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSuccessionEdgeDescriptionProvider.java
@@ -38,11 +38,11 @@ import org.eclipse.syson.util.ViewConstants;
  */
 public abstract class AbstractSuccessionEdgeDescriptionProvider extends AbstractEdgeDescriptionProvider {
 
-    protected final IDescriptionNameGenerator nameGenerator;
+    protected final IDescriptionNameGenerator descriptionNameGenerator;
 
-    public AbstractSuccessionEdgeDescriptionProvider(IColorProvider colorProvider, IDescriptionNameGenerator nameGenerator) {
+    public AbstractSuccessionEdgeDescriptionProvider(IColorProvider colorProvider, IDescriptionNameGenerator descriptionNameGenerator) {
         super(colorProvider);
-        this.nameGenerator = nameGenerator;
+        this.descriptionNameGenerator = descriptionNameGenerator;
     }
 
     /**
@@ -72,7 +72,7 @@ public abstract class AbstractSuccessionEdgeDescriptionProvider extends Abstract
                 .domainType(domainType)
                 .isDomainBasedEdge(true)
                 .centerLabelExpression(AQLUtils.getSelfServiceCallExpression("getSuccessionLabel"))
-                .name(this.nameGenerator.getEdgeName(SysmlPackage.eINSTANCE.getSuccession()))
+                .name(this.descriptionNameGenerator.getEdgeName(SysmlPackage.eINSTANCE.getSuccession()))
                 .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
@@ -83,7 +83,7 @@ public abstract class AbstractSuccessionEdgeDescriptionProvider extends Abstract
 
     @Override
     public void link(DiagramDescription diagramDescription, IViewDiagramElementFinder cache) {
-        cache.getEdgeDescription(this.nameGenerator.getEdgeName(SysmlPackage.eINSTANCE.getSuccession())).ifPresent(ed -> {
+        cache.getEdgeDescription(this.descriptionNameGenerator.getEdgeName(SysmlPackage.eINSTANCE.getSuccession())).ifPresent(ed -> {
             diagramDescription.getEdgeDescriptions().add(ed);
             ed.getSourceNodeDescriptions().addAll(this.getSourceNodes(cache));
             ed.getTargetNodeDescriptions().addAll(this.getTargetNodes(cache));

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/MergedReferencesCompartmentItemNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/MergedReferencesCompartmentItemNodeDescriptionProvider.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.common.view.nodes;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.sirius.components.view.diagram.InsideLabelDescription;
+import org.eclipse.sirius.components.view.diagram.InsideLabelPosition;
+import org.eclipse.sirius.components.view.diagram.InsideLabelStyle;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.sirius.components.view.diagram.NodePalette;
+import org.eclipse.sirius.components.view.diagram.NodeStyleDescription;
+import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.SysMLMetamodelHelper;
+import org.eclipse.syson.util.ViewConstants;
+
+/**
+ * Used to create the Compartment item node description.
+ *
+ * @author adieumegard
+ */
+public class MergedReferencesCompartmentItemNodeDescriptionProvider extends AbstractNodeDescriptionProvider {
+
+    private final EClass eClass;
+
+    private final List<EReference> eReferences;
+
+    private final IDescriptionNameGenerator descriptionNameGenerator;
+
+    public MergedReferencesCompartmentItemNodeDescriptionProvider(EClass eClass, List<EReference> eReferences, IColorProvider colorProvider, IDescriptionNameGenerator descriptionNameGenerator) {
+        super(colorProvider);
+        this.eClass = Objects.requireNonNull(eClass);
+        this.eReferences = Objects.requireNonNull(eReferences);
+        this.descriptionNameGenerator = Objects.requireNonNull(descriptionNameGenerator);
+    }
+
+    @Override
+    public NodeDescription create() {
+        return this.diagramBuilderHelper.newNodeDescription()
+                .defaultHeightExpression(ViewConstants.DEFAULT_COMPARTMENT_NODE_ITEM_HEIGHT)
+                .defaultWidthExpression(ViewConstants.DEFAULT_NODE_WIDTH)
+                .domainType(SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getElement()))
+                .insideLabel(this.createInsideLabelDescription())
+                .name(this.descriptionNameGenerator.getCompartmentItemName(this.eClass, this.eReferences.get(0)))
+                .semanticCandidatesExpression(
+                        AQLUtils.getSelfServiceCallExpression("getAllContentsByReferences",
+                                "Sequence{" + this.eReferences.stream().map(ref -> "self." + ref.getName()).reduce((a, b) -> a + ',' + b).get() + "})"))
+                .style(this.createCompartmentItemNodeStyle())
+                .userResizable(false)
+                .palette(this.createCompartmentItemNodePalette())
+                .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
+                .build();
+    }
+
+    protected InsideLabelDescription createInsideLabelDescription() {
+        return this.diagramBuilderHelper.newInsideLabelDescription()
+                .labelExpression(AQLUtils.getSelfServiceCallExpression("getCompartmentItemUsageLabel"))
+                .position(InsideLabelPosition.TOP_CENTER)
+                .style(this.createInsideLabelStyle())
+                .build();
+    }
+
+    protected InsideLabelStyle createInsideLabelStyle() {
+        return this.diagramBuilderHelper.newInsideLabelStyle()
+                .displayHeaderSeparator(false)
+                .labelColor(this.colorProvider.getColor(ViewConstants.DEFAULT_LABEL_COLOR))
+                .showIcon(true)
+                .withHeader(false)
+                .build();
+    }
+
+    private NodeStyleDescription createCompartmentItemNodeStyle() {
+        return this.diagramBuilderHelper.newIconLabelNodeStyleDescription()
+                .borderColor(this.colorProvider.getColor(ViewConstants.DEFAULT_BORDER_COLOR))
+                .borderRadius(0)
+                .background(this.colorProvider.getColor(ViewConstants.DEFAULT_BACKGROUND_COLOR))
+                .build();
+    }
+
+    private NodePalette createCompartmentItemNodePalette() {
+        var callDeleteService = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLUtils.getSelfServiceCallExpression("deleteFromModel"));
+
+        var deleteTool = this.diagramBuilderHelper.newDeleteTool()
+                .name("Delete from Model")
+                .body(callDeleteService.build());
+
+        var callEditService = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLUtils.getSelfServiceCallExpression("directEdit", "newLabel"));
+
+        var editTool = this.diagramBuilderHelper.newLabelEditTool()
+                .name("Edit")
+                .initialDirectEditLabelExpression(AQLUtils.getSelfServiceCallExpression("getUsageInitialDirectEditLabel"))
+                .body(callEditService.build());
+
+        return this.diagramBuilderHelper.newNodePalette()
+                .deleteTool(deleteTool.build())
+                .labelEditTool(editTool.build())
+                .toolSections(this.defaultToolsFactory.createDefaultHideRevealNodeToolSection())
+                .build();
+    }
+}

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
@@ -205,4 +205,25 @@ public class ViewNodeService {
         }
         return null;
     }
+
+    /**
+     * Retrieves all the {@link Element} elements from {@code contents} removing the null content.
+     *
+     * @param self
+     *            The elements onto which the content is gathered
+     * @param contents
+     *            The content to assemble
+     * @return
+     */
+    public List<Element> getAllContentsByReferences(Element self, List<Element> contents) {
+        List<Element> result = new ArrayList<>();
+        contents.stream().filter(Objects::nonNull).forEach(object -> {
+            if (object instanceof List<?> l) {
+                l.stream().filter(Element.class::isInstance).map(Element.class::cast).map(result::add);
+            } else {
+                result.add(object);
+            }
+        });
+        return result;
+    }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/edges/SuccessionEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/edges/SuccessionEdgeDescriptionProvider.java
@@ -39,7 +39,7 @@ public class SuccessionEdgeDescriptionProvider extends AbstractSuccessionEdgeDes
         var sourcesAndTargets = new ArrayList<NodeDescription>();
 
         GeneralViewDiagramDescriptionProvider.USAGES.forEach(usage -> {
-            cache.getNodeDescription(this.nameGenerator.getNodeName(usage)).ifPresent(sourcesAndTargets::add);
+            cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(usage)).ifPresent(sourcesAndTargets::add);
         });
 
         return sourcesAndTargets;
@@ -49,7 +49,7 @@ public class SuccessionEdgeDescriptionProvider extends AbstractSuccessionEdgeDes
     protected List<NodeDescription> getSourceNodes(IViewDiagramElementFinder cache) {
         var sources = this.getAllUsages(cache);
         // the start node can be the source of a succession
-        cache.getNodeDescription(this.nameGenerator.getNodeName(StartActionNodeDescriptionProvider.START_ACTION_NAME)).ifPresent(sources::add);
+        cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(StartActionNodeDescriptionProvider.START_ACTION_NAME)).ifPresent(sources::add);
         return sources;
     }
 
@@ -57,7 +57,7 @@ public class SuccessionEdgeDescriptionProvider extends AbstractSuccessionEdgeDes
     protected List<NodeDescription> getTargetNodes(IViewDiagramElementFinder cache) {
         var targets = this.getAllUsages(cache);
         // the done node can be the target of a succession
-        cache.getNodeDescription(this.nameGenerator.getNodeName(DoneActionNodeDescriptionProvider.DONE_ACTION_NAME)).ifPresent(targets::add);
+        cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(DoneActionNodeDescriptionProvider.DONE_ACTION_NAME)).ifPresent(targets::add);
         return targets;
     }
 }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/STVDescriptionNameGenerator.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/STVDescriptionNameGenerator.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.statetransition.view;
 
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.syson.diagram.statetransition.view.tools.StateTransitionActionToolProvider;
 import org.eclipse.syson.util.DescriptionNameGenerator;
 
 /**
@@ -21,7 +24,29 @@ import org.eclipse.syson.util.DescriptionNameGenerator;
  */
 public class STVDescriptionNameGenerator extends DescriptionNameGenerator {
 
+    public static final String ACTION = "action";
+
+    public static final String ACTIONS = "actions";
+    
     public STVDescriptionNameGenerator() {
         super("STV");
+    }
+    
+    @Override
+    public String getCompartmentName(EClass eClass, EReference eReference) {
+        if (new StateTransitionActionToolProvider(eReference).isHandledAction()) {
+            return this.getCompartmentName(this.getDiagramPrefix(), eClass.getName() + SPACE + ACTIONS);
+        } else {
+            return this.getCompartmentName(this.getDiagramPrefix(), eClass.getName() + SPACE + eReference.getName());
+        }
+    }
+    
+    @Override
+    public String getCompartmentItemName(EClass eClass, EReference eReference) {
+        if (new StateTransitionActionToolProvider(eReference).isHandledAction()) {
+            return this.getCompartmentItemName(this.getDiagramPrefix(), eClass.getName() + SPACE + ACTION);
+        } else {
+            return this.getCompartmentItemName(this.getDiagramPrefix(), eClass.getName() + SPACE + eReference.getName());
+        }
     }
 }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/CompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/CompartmentNodeDescriptionProvider.java
@@ -39,10 +39,10 @@ public class CompartmentNodeDescriptionProvider extends AbstractCompartmentNodeD
     protected List<NodeDescription> getDroppableNodes(IViewDiagramElementFinder cache) {
         var acceptedNodeTypes = new ArrayList<NodeDescription>();
 
-        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_LIST_ITEMS.forEach((type, listItems) -> {
-            listItems.forEach(ref -> {
-                if (this.eReference.getEType().equals(ref.getEType())) {
-                    var optCompartmentItemNodeDescription = cache.getNodeDescription(this.descriptionNameGenerator.getCompartmentItemName(type, ref));
+        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_MERGED_LIST_ITEMS.forEach((type, listItems) -> {
+            listItems.forEach(eReference -> {
+                if (this.eReference.getEType().equals(eReference.getEType())) {
+                    var optCompartmentItemNodeDescription = cache.getNodeDescription(this.descriptionNameGenerator.getCompartmentItemName(type, eReference));
                     if (optCompartmentItemNodeDescription.isPresent()) {
                         acceptedNodeTypes.add(optCompartmentItemNodeDescription.get());
                     }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/DefinitionNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/DefinitionNodeDescriptionProvider.java
@@ -41,7 +41,7 @@ public class DefinitionNodeDescriptionProvider extends AbstractDefinitionNodeDes
     protected List<NodeDescription> getReusedChildren(IViewDiagramElementFinder cache) {
         var reusedChildren = new ArrayList<NodeDescription>();
 
-        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_LIST_ITEMS.forEach((type, listItems) -> {
+        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_MERGED_LIST_ITEMS.forEach((type, listItems) -> {
             if (type.equals(this.eClass)) {
                 listItems.forEach(eReference -> {
                     // list compartment

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/FakeNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/FakeNodeDescriptionProvider.java
@@ -48,8 +48,10 @@ public class FakeNodeDescriptionProvider extends AbstractFakeNodeDescriptionProv
     protected List<NodeDescription> getChildrenDescription(IViewDiagramElementFinder cache) {
         var childrenNodes = new ArrayList<NodeDescription>();
 
-        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_LIST_ITEMS.forEach((type, listItems) -> {
-            listItems.forEach(eReference -> cache.getNodeDescription(this.descriptionNameGenerator.getCompartmentName(type, eReference)).ifPresent(childrenNodes::add));
+        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_MERGED_LIST_ITEMS.forEach((type, listItems) -> {
+            listItems.forEach(eReference -> {
+                cache.getNodeDescription(this.descriptionNameGenerator.getCompartmentName(type, eReference)).ifPresent(childrenNodes::add);   
+            });
         });
 
         // don't forget to add custom compartments

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/StateTransitionCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/StateTransitionCompartmentNodeDescriptionProvider.java
@@ -80,7 +80,7 @@ public class StateTransitionCompartmentNodeDescriptionProvider extends AbstractC
     protected List<NodeDescription> getDroppableNodes(IViewDiagramElementFinder cache) {
         List<NodeDescription> droppableNodes = new ArrayList<>();
         cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getStateUsage())).ifPresent(droppableNodes::add);
-        cache.getNodeDescription(this.descriptionNameGenerator.getCompartmentItemName(this.eClass, this.eReference)).ifPresent(droppableNodes::add);
+        cache.getNodeDescription(this.descriptionNameGenerator.getCompartmentItemName(this.eClass, this.eReference)).ifPresent(droppableNodes::add);        
         return droppableNodes;
     }
 

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/UsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/UsageNodeDescriptionProvider.java
@@ -41,7 +41,7 @@ public class UsageNodeDescriptionProvider extends AbstractUsageNodeDescriptionPr
     protected List<NodeDescription> getReusedChildren(IViewDiagramElementFinder cache) {
         var reusedChildren = new ArrayList<NodeDescription>();
 
-        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_LIST_ITEMS.forEach((type, listItems) -> {
+        StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_MERGED_LIST_ITEMS.forEach((type, listItems) -> {
             if (type.equals(this.eClass)) {
                 listItems.forEach(eReference -> {
                     // list compartment

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewNodeToolSectionSwitch.java
@@ -12,19 +12,24 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.statetransition.view.services;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.syson.diagram.common.view.services.AbstractViewNodeToolSectionSwitch;
+import org.eclipse.syson.diagram.common.view.tools.CompartmentNodeToolProvider;
 import org.eclipse.syson.diagram.statetransition.view.StateTransitionViewDiagramDescriptionProvider;
+import org.eclipse.syson.diagram.statetransition.view.tools.StateTransitionActionToolProvider;
 import org.eclipse.syson.diagram.statetransition.view.tools.StateTransitionCompartmentNodeToolProvider;
 import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.StateDefinition;
 import org.eclipse.syson.sysml.StateUsage;
+import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.Usage;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 
@@ -45,12 +50,22 @@ public class StateTransitionViewNodeToolSectionSwitch extends AbstractViewNodeTo
 
     @Override
     protected List<EReference> getElementCompartmentReferences(Element element) {
-        List<EReference> refs = StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_LIST_ITEMS.get(element.eClass());
+        List<EReference> refs = StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_MERGED_LIST_ITEMS.get(element.eClass());
         if (refs != null) {
             return refs;
         } else {
             return List.of();
         }
+    }
+
+    @Override
+    protected List<NodeTool> createToolsForCompartmentItems(Element object) {
+        List<NodeTool> compartmentNodeTools = new ArrayList<>();
+        this.getElementCompartmentReferences(object).forEach(eReference -> {
+            CompartmentNodeToolProvider provider = new CompartmentNodeToolProvider(eReference, this.descriptionNameGenerator);
+            compartmentNodeTools.add(provider.create(null));
+        });
+        return compartmentNodeTools;
     }
 
     @Override
@@ -69,7 +84,10 @@ public class StateTransitionViewNodeToolSectionSwitch extends AbstractViewNodeTo
     public List<NodeToolSection> caseStateDefinition(StateDefinition object) {
         var createSection = this.buildCreateSection(
                 new StateTransitionCompartmentNodeToolProvider(true).create(null),
-                new StateTransitionCompartmentNodeToolProvider(false).create(null));
+                new StateTransitionCompartmentNodeToolProvider(false).create(null),
+                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_EntryAction()).create(null),
+                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_DoAction()).create(null),
+                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_ExitAction()).create(null));
         return List.of(createSection, this.addElementsToolSection());
     }
 
@@ -77,7 +95,10 @@ public class StateTransitionViewNodeToolSectionSwitch extends AbstractViewNodeTo
     public List<NodeToolSection> caseStateUsage(StateUsage object) {
         var createSection = this.buildCreateSection(
                 new StateTransitionCompartmentNodeToolProvider(true).create(null),
-                new StateTransitionCompartmentNodeToolProvider(false).create(null));
+                new StateTransitionCompartmentNodeToolProvider(false).create(null),
+                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateUsage_EntryAction()).create(null),
+                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateUsage_DoAction()).create(null),
+                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateUsage_ExitAction()).create(null));
         return List.of(createSection, this.addElementsToolSection());
     }
 

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewToolService.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewToolService.java
@@ -24,10 +24,14 @@ import org.eclipse.sirius.components.diagrams.description.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.DiagramDescription;
 import org.eclipse.sirius.components.view.emf.IViewRepresentationDescriptionSearchService;
 import org.eclipse.syson.diagram.common.view.services.ViewToolService;
+import org.eclipse.syson.diagram.statetransition.view.STVDescriptionNameGenerator;
 import org.eclipse.syson.diagram.statetransition.view.StateTransitionViewDiagramDescriptionProvider;
 import org.eclipse.syson.diagram.statetransition.view.nodes.StateTransitionCompartmentNodeDescriptionProvider;
+import org.eclipse.syson.sysml.ActionUsage;
 import org.eclipse.syson.sysml.Definition;
+import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.StateDefinition;
+import org.eclipse.syson.sysml.StateSubactionKind;
 import org.eclipse.syson.sysml.StateUsage;
 import org.eclipse.syson.sysml.SysmlFactory;
 import org.eclipse.syson.sysml.Usage;
@@ -98,7 +102,7 @@ public class StateTransitionViewToolService extends ViewToolService {
      *            a variable accessible from the variable manager.
      * @param isParallel
      *            whether or not the created State is set as parallel.
-     * @return the given {@link StateDefinition}.
+     * @return the created {@link StateUsage}.
      */
     public StateUsage createChildState(StateDefinition stateDefinition, IEditingContext editingContext, IDiagramContext diagramContext, Node selectedNode,
             Map<org.eclipse.sirius.components.view.diagram.NodeDescription, NodeDescription> convertedNodes, boolean isParallel) {
@@ -116,6 +120,27 @@ public class StateTransitionViewToolService extends ViewToolService {
         return childState;
     }
 
+    /**
+     * Called by "New State" tool from StateTransition View StateUsage node.
+     *
+     * @param stateUsage
+     *            the {@link StateUsage} corresponding to the target object on which the tool has been called.
+     * @param editingContext
+     *            the {@link IEditingContext} of the tool. It corresponds to a variable accessible from the variable
+     *            manager.
+     * @param diagramContext
+     *            the {@link IDiagramContext} of the tool. It corresponds to a variable accessible from the variable
+     *            manager.
+     * @param selectedNode
+     *            the selected node on which the tool has been called. It corresponds to a variable accessible from the
+     *            variable manager.
+     * @param convertedNodes
+     *            the map of all existing node descriptions in the DiagramDescription of this Diagram. It corresponds to
+     *            a variable accessible from the variable manager.
+     * @param isParallel
+     *            whether or not the created State is set as parallel.
+     * @return the created {@link StateUsage}.
+     */
     public StateUsage createChildState(StateUsage stateUsage, IEditingContext editingContext, IDiagramContext diagramContext, Node selectedNode,
             Map<org.eclipse.sirius.components.view.diagram.NodeDescription, NodeDescription> convertedNodes, boolean isParallel) {
         StateUsage childState = this.createChildState(stateUsage, isParallel);
@@ -133,40 +158,92 @@ public class StateTransitionViewToolService extends ViewToolService {
     }
 
     /**
+     * Create a new {@link ActionUsage} as a child of {@code parentState}. The {@code actionKind} string is matched
+     * against possible {@link StateSubactionKind} values to set the new {@link ActionUsage} of the correct kind.
+     * 
+     * @param parentState
+     *            The state onto which the action is added
+     * @param editingContext
+     *            the {@link IEditingContext} of the tool. It corresponds to a variable accessible from the variable
+     *            manager.
+     * @param diagramContext
+     *            the {@link IDiagramContext} of the tool. It corresponds to a variable accessible from the variable
+     *            manager.
+     * @param selectedNode
+     *            the selected node on which the tool has been called. It corresponds to a variable accessible from the
+     *            variable manager.
+     * @param convertedNodes
+     *            the map of all existing node descriptions in the DiagramDescription of this Diagram. It corresponds to
+     *            a variable accessible from the variable manager.
+     * @param actionKind
+     *            The value against which the {@link StateSubactionKind} of the {@link ActionUsage} membership is set.
+     * @return
+     */
+    public ActionUsage createOwnedAction(Element parentState, IEditingContext editingContext, IDiagramContext diagramContext, Node selectedNode,
+            Map<org.eclipse.sirius.components.view.diagram.NodeDescription, NodeDescription> convertedNodes, String actionKind) {
+        ActionUsage childAction = this.createChildAction(parentState, actionKind);
+
+        if (childAction != null) {
+            if (selectedNode.getInsideLabel().getText().equals(STVDescriptionNameGenerator.ACTIONS)) {
+                this.createView(childAction, editingContext, diagramContext, selectedNode, convertedNodes);
+            } else {
+                selectedNode.getChildNodes().stream().filter(child -> child.getInsideLabel().getText().equals(STVDescriptionNameGenerator.ACTIONS)).findFirst()
+                    .ifPresent(compartmentNode -> {
+                        this.createView(childAction, editingContext, diagramContext, compartmentNode, convertedNodes);
+                    });
+            }
+        }
+
+        return childAction;
+    }
+
+    /**
      * Create a child State onto {@code stateDefinition}.
      *
-     * @param stateDefinition
-     *            The parent {@link StateDefinition}
+     * @param parentState
+     *            The parent {@link StateDefinition} or {@link StateUsage}
      * @param isParallel
      *            Whether the created state is parallel or not
      * @return the created {@link StateUsage}.
      */
-    private StateUsage createChildState(StateDefinition stateDefinition, boolean isParallel) {
+    private StateUsage createChildState(Element parentState, boolean isParallel) {
         var owningMembership = SysmlFactory.eINSTANCE.createFeatureMembership();
         StateUsage childState = SysmlFactory.eINSTANCE.createStateUsage();
         childState.setIsParallel(isParallel);
         owningMembership.getOwnedRelatedElement().add(childState);
-        stateDefinition.getOwnedRelationship().add(owningMembership);
+        parentState.getOwnedRelationship().add(owningMembership);
         this.elementInitializerSwitch.doSwitch(childState);
         return childState;
     }
-
+    
     /**
-     * Creates a child State onto {@code stateUsage}.
+     * Create a child Action onto {@code stateDefinition}.
      * 
-     * @param stateUsage
-     *            the parent {@link StateUsage}
-     * @param isParallel
-     *            whether the created state is parallel or not
-     * @return the created {@link StateUsage}
+     * @param parentState
+     *            The parent {@link StateDefinition} or {@link StateUsage}
+     * @param actionKind
+     *            The string value representing the kind of Action. Expected values are "Entry", "Do" or "Exit".
+     * @return The created {@link ActionUsage} or null if the kind value is not correct
      */
-    private StateUsage createChildState(StateUsage stateUsage, boolean isParallel) {
-        var owningMembership = SysmlFactory.eINSTANCE.createFeatureMembership();
-        StateUsage childState = SysmlFactory.eINSTANCE.createStateUsage();
-        childState.setIsParallel(isParallel);
-        owningMembership.getOwnedRelatedElement().add(childState);
-        stateUsage.getOwnedRelationship().add(owningMembership);
-        this.elementInitializerSwitch.doSwitch(childState);
-        return childState;
+    private ActionUsage createChildAction(Element parentState, String actionKind) {
+        var owningMembership = SysmlFactory.eINSTANCE.createStateSubactionMembership();
+        switch (actionKind) {
+            case "Entry":
+                owningMembership.setKind(StateSubactionKind.ENTRY);
+                break;
+            case "Do":
+                owningMembership.setKind(StateSubactionKind.DO);
+                break;
+            case "Exit":
+                owningMembership.setKind(StateSubactionKind.EXIT);
+                break;
+            default:
+                return null;
+        }
+        ActionUsage childAction = SysmlFactory.eINSTANCE.createActionUsage();
+        owningMembership.getOwnedRelatedElement().add(childAction);
+        parentState.getOwnedRelationship().add(owningMembership);
+        this.elementInitializerSwitch.doSwitch(childAction);
+        return childAction;
     }
 }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/tools/StateTransitionActionToolProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/tools/StateTransitionActionToolProvider.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.statetransition.view.tools;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.syson.diagram.common.view.tools.AbstractCompartmentNodeToolProvider;
+import org.eclipse.syson.sysml.StateSubactionKind;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.AQLUtils;
+
+/**
+ * Node tool provider for creating nested/owned states in the "state transition" State compartment.
+ *
+ * @author adieumegard
+ */
+public class StateTransitionActionToolProvider extends AbstractCompartmentNodeToolProvider {
+
+    private EStructuralFeature actionStructuralFeature;
+
+    public StateTransitionActionToolProvider(EStructuralFeature actionStructuralFeature) {
+        super();
+        this.actionStructuralFeature = actionStructuralFeature;
+    }
+
+    @Override
+    protected String getServiceCallExpression() {
+        return AQLUtils.getSelfServiceCallExpression("createOwnedAction", List.of("editingContext", "diagramContext", "selectedNode", "convertedNodes", "'" + getActionKindValue() + "'"));
+    }
+
+    private String getActionKindValue() {
+        String switchValue = "";
+        if (isEntryAction()) {
+            switchValue = StateSubactionKind.ENTRY.getLiteral();   
+        } else if (isDoAction()) {
+            switchValue = StateSubactionKind.DO.getLiteral();
+        } else if (isExitAction()) {
+            switchValue = StateSubactionKind.EXIT.getLiteral();
+        }
+        if (switchValue.length() > 1) {
+            switchValue = switchValue.substring(0, 1).toUpperCase() + switchValue.substring(1, switchValue.length());
+        }
+        return switchValue;
+    }
+
+    @Override
+    protected String getNodeToolName() {
+        return "New " + getActionKindValue() + " Action";
+    }
+
+    @Override
+    protected String getNodeToolIconURLsExpression() {
+        return "/icons/full/obj16/ActionUsage.svg";
+    }
+
+    @Override
+    protected boolean revealOnCreate() {
+        return true;
+    }
+    
+    public boolean isHandledAction() {
+        return isEntryAction() || isDoAction() || isExitAction();
+    }
+    
+    private boolean isEntryAction() {
+        return SysmlPackage.eINSTANCE.getStateDefinition_EntryAction().equals(actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_EntryAction().equals(actionStructuralFeature);
+    }
+    
+    private boolean isDoAction() {
+        return SysmlPackage.eINSTANCE.getStateDefinition_DoAction().equals(actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_DoAction().equals(actionStructuralFeature);
+    }
+    
+    private boolean isExitAction() {
+        return SysmlPackage.eINSTANCE.getStateDefinition_ExitAction().equals(actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_ExitAction().equals(actionStructuralFeature);
+    }
+}


### PR DESCRIPTION
- M2 implementation of get[Entry|Do|Exit]Action on
  StateUsage and StateDefinition
- M2 implementation of getAction on StateSubactionMembership
- New CompartmentItem NodeDescription to handle multiple EReferences
  instead of only one EReference
- Update State Transition list items to use the entry/do/exit actions
  references from StateUsage and StateDefinition.
- Add action creation tools on StateUsage and StateDefinition.
- Add necessary services for actions creation. Refactor existing code.

Remains to be done in this task:
- Drag'n'Drop of actions
- Limit creation of actions to one of each entry/do/exit per state
- Add action creation tools to actions container

Bug: https://github.com/eclipse-syson/syson/issues/333