### PR TITLE
[356] The Allocate edge is not displayed in the Action Flow View diagram

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@
 - https://github.com/eclipse-syson/syson/issues/329[#329] [services] Ignore root namespace with no name during qualified name resolution 
 - https://github.com/eclipse-syson/syson/issues/337[#337] [diagrams] Fix direct edit of single digit cardinalities.
 - https://github.com/eclipse-syson/syson/issues/348[#348] [diagrams] The semantic representation of the Succession edge is not correct.
+- https://github.com/eclipse-syson/syson/issues/356[#356] [action-flow-view] The Allocate edge is not displayed in the Action Flow View diagram.
 
 === Improvements
 

--- a/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionProvider.java
+++ b/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionProvider.java
@@ -28,6 +28,7 @@ import org.eclipse.sirius.components.view.diagram.DiagramElementDescription;
 import org.eclipse.sirius.components.view.diagram.DiagramPalette;
 import org.eclipse.sirius.components.view.diagram.DiagramToolSection;
 import org.eclipse.sirius.components.view.diagram.NodeTool;
+import org.eclipse.syson.diagram.actionflow.view.edges.AllocateEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.edges.DependencyEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.edges.FeatureTypingEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.actionflow.view.edges.RedefinitionEdgeDescriptionProvider;
@@ -102,6 +103,7 @@ public class ActionFlowViewDiagramDescriptionProvider extends AbstractDiagramDes
 
         var cache = new ViewDiagramElementFinder();
         var diagramElementDescriptionProviders = new ArrayList<IDiagramElementDescriptionProvider<? extends DiagramElementDescription>>();
+        diagramElementDescriptionProviders.add(new AllocateEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new DependencyEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new FeatureTypingEdgeDescriptionProvider(colorProvider));
         diagramElementDescriptionProviders.add(new RedefinitionEdgeDescriptionProvider(colorProvider));

--- a/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/edges/AllocateEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/edges/AllocateEdgeDescriptionProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.actionflow.view.edges;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.sirius.components.view.builder.IViewDiagramElementFinder;
+import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.syson.diagram.actionflow.view.AFVDescriptionNameGenerator;
+import org.eclipse.syson.diagram.actionflow.view.ActionFlowViewDiagramDescriptionProvider;
+import org.eclipse.syson.diagram.common.view.edges.AbstractAllocateEdgeDescriptionProvider;
+import org.eclipse.syson.util.IDescriptionNameGenerator;
+
+/**
+ * Used to create the Allocate edge description inside the Action Flow View diagram.
+ *
+ * @author Jerome Gout
+ */
+public class AllocateEdgeDescriptionProvider extends AbstractAllocateEdgeDescriptionProvider {
+
+    private final IDescriptionNameGenerator descriptionNameGenerator;
+
+    public AllocateEdgeDescriptionProvider(IColorProvider colorProvider) {
+        super(colorProvider);
+        this.descriptionNameGenerator = new AFVDescriptionNameGenerator();
+    }
+
+    @Override
+    protected String getName() {
+        return this.descriptionNameGenerator.getEdgeName("Allocate");
+    }
+
+    @Override
+    protected List<NodeDescription> getSourceNodes(IViewDiagramElementFinder cache) {
+        return this.getSourceAndTarget(cache);
+    }
+
+    @Override
+    protected List<NodeDescription> getTargetNodes(IViewDiagramElementFinder cache) {
+        return this.getSourceAndTarget(cache);
+    }
+
+    private List<NodeDescription> getSourceAndTarget(IViewDiagramElementFinder cache) {
+        var sourcesAndTargets = new ArrayList<NodeDescription>();
+        ActionFlowViewDiagramDescriptionProvider.USAGES.forEach(usage -> {
+            cache.getNodeDescription(this.descriptionNameGenerator.getNodeName(usage)).ifPresent(sourcesAndTargets::add);
+        });
+        return sourcesAndTargets;
+    }
+
+}

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractAllocateEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractAllocateEdgeDescriptionProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -108,17 +109,15 @@ public abstract class AbstractAllocateEdgeDescriptionProvider extends AbstractEd
 
     @Override
     protected ChangeContextBuilder getSourceReconnectToolBody() {
-        var params = List.of(AQLConstants.SEMANTIC_RECONNECTION_TARGET);
         return this.viewBuilderHelper.newChangeContext()
-                .expression(AQLConstants.AQL + AQLConstants.EDGE_SEMANTIC_ELEMENT + ".reconnectSourceAllocateEdge(" + String.join(",", params) + ")");
+                .expression(AQLUtils.getServiceCallExpression(AQLConstants.EDGE_SEMANTIC_ELEMENT, "reconnectSourceAllocateEdge", AQLConstants.SEMANTIC_RECONNECTION_TARGET));
 
     }
 
     @Override
     protected ChangeContextBuilder getTargetReconnectToolBody() {
-        var params = List.of(AQLConstants.SEMANTIC_RECONNECTION_TARGET);
         return this.viewBuilderHelper.newChangeContext()
-                .expression(AQLConstants.AQL + AQLConstants.EDGE_SEMANTIC_ELEMENT + ".reconnectTargetAlocateEdge(" + String.join(",", params) + ")");
+                .expression(AQLUtils.getServiceCallExpression(AQLConstants.EDGE_SEMANTIC_ELEMENT, "reconnectTargetAllocateEdge", AQLConstants.SEMANTIC_RECONNECTION_TARGET));
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeService.java
@@ -160,7 +160,7 @@ public class ViewEdgeService {
         return self;
     }
 
-    public Element reconnectTargetAlocateEdge(AllocationUsage self, Element newTarget) {
+    public Element reconnectTargetAllocateEdge(AllocationUsage self, Element newTarget) {
         if (newTarget instanceof Usage usage) {
             var features = this.getFeatures(self);
             if (features.size() == 2) {


### PR DESCRIPTION
+ fix a typo in the edge target reconnection service name

Bug: https://github.com/eclipse-syson/syson/issues/356