### PR TITLE
[333] State subaction tools and properties

### DIFF
--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysMLv2PropertiesConfigurer.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysMLv2PropertiesConfigurer.java
@@ -72,6 +72,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
 
     private static final String SUBCLASSIFICATION_PROPERTIES = "Subclassification Properties";
 
+    private static final String STATESUBACTIONKIND_PROPERTIES = "Statesubaction Properties";
+
     private static final String SUBSETTING_PROPERTIES = "Subsetting Properties";
 
     private static final String TYPING_PROPERTIES = "Typing Properties";
@@ -83,6 +85,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
     private static final String ACCEPT_ACTION_USAGE_PROPERTIES = "Accept Action Usage Properties";
 
     private static final String AQL_NOT_SELF_IS_READ_ONLY = "aql:not(self.isReadOnly())";
+
+    private static final String CLOSING_QUOTE_CLOSING_PARENTHESIS = "')";
 
     private final ComposedAdapterFactory composedAdapterFactory;
 
@@ -144,6 +148,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         pageCore.getGroups().add(this.createCorePropertiesGroup());
         pageCore.getGroups().add(this.createExtraMembershipPropertiesGroup());
         pageCore.getGroups().add(this.createExtraRedefinitionPropertiesGroup());
+        pageCore.getGroups().add(this.createExtraStatesubactionMembershipKindPropertiesGroup());
         pageCore.getGroups().add(this.createExtraSubclassificationPropertiesGroup());
         pageCore.getGroups().add(this.createExtraSubsettingPropertiesGroup());
         pageCore.getGroups().add(this.createExtraFeatureTypingPropertiesGroup());
@@ -205,6 +210,29 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         refWidget.getBody().add(setRefWidget);
 
         group.getChildren().add(refWidget);
+
+        return group;
+    }
+
+    private GroupDescription createExtraStatesubactionMembershipKindPropertiesGroup() {
+        GroupDescription group = FormFactory.eINSTANCE.createGroupDescription();
+        group.setDisplayMode(GroupDisplayMode.LIST);
+        group.setName(STATESUBACTIONKIND_PROPERTIES);
+        group.setLabelExpression("");
+        group.setSemanticCandidatesExpression("aql:self.eContainer()->filter(sysml::StateSubactionMembership)");
+
+        RadioDescription radio = FormFactory.eINSTANCE.createRadioDescription();
+        radio.setName("ExtraRadioKindWidget");
+        radio.setLabelExpression("Kind");
+        radio.setCandidatesExpression("aql:self.getEnumCandidates('" + SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName() + CLOSING_QUOTE_CLOSING_PARENTHESIS);
+        radio.setCandidateLabelExpression("aql:candidate.name");
+        radio.setValueExpression("aql:self.getEnumValue('" + SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName() + CLOSING_QUOTE_CLOSING_PARENTHESIS);
+        radio.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
+        ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
+        setNewValueOperation.setExpression("aql:self.setNewValue('" + SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName() + "', newValue.instance)");
+        radio.getBody().add(setNewValueOperation);
+
+        group.getChildren().add(radio);
 
         return group;
     }
@@ -288,9 +316,9 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         RadioDescription radio = FormFactory.eINSTANCE.createRadioDescription();
         radio.setName("ExtraRadioKindWidget");
         radio.setLabelExpression("Kind");
-        radio.setCandidatesExpression("aql:self.getEnumCandidates('" + SysmlPackage.eINSTANCE.getRequirementConstraintMembership_Kind().getName() + "')");
+        radio.setCandidatesExpression("aql:self.getEnumCandidates('" + SysmlPackage.eINSTANCE.getRequirementConstraintMembership_Kind().getName() + CLOSING_QUOTE_CLOSING_PARENTHESIS);
         radio.setCandidateLabelExpression("aql:candidate.name");
-        radio.setValueExpression("aql:self.getEnumValue('" + SysmlPackage.eINSTANCE.getRequirementConstraintMembership_Kind().getName() + "')");
+        radio.setValueExpression("aql:self.getEnumValue('" + SysmlPackage.eINSTANCE.getRequirementConstraintMembership_Kind().getName() + CLOSING_QUOTE_CLOSING_PARENTHESIS);
         radio.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
         setNewValueOperation.setExpression("aql:self.setNewValue('" + SysmlPackage.eINSTANCE.getRequirementConstraintMembership_Kind().getName() + "', newValue.instance)");
@@ -311,9 +339,9 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         RadioDescription radio = FormFactory.eINSTANCE.createRadioDescription();
         radio.setName("ExtraRadioVisibilityWidget");
         radio.setLabelExpression("Visibility");
-        radio.setCandidatesExpression("aql:self.getEnumCandidates('" + SysmlPackage.eINSTANCE.getMembership_Visibility().getName() + "')");
+        radio.setCandidatesExpression("aql:self.getEnumCandidates('" + SysmlPackage.eINSTANCE.getMembership_Visibility().getName() + CLOSING_QUOTE_CLOSING_PARENTHESIS);
         radio.setCandidateLabelExpression("aql:candidate.name");
-        radio.setValueExpression("aql:self.getEnumValue('" + SysmlPackage.eINSTANCE.getMembership_Visibility().getName() + "')");
+        radio.setValueExpression("aql:self.getEnumValue('" + SysmlPackage.eINSTANCE.getMembership_Visibility().getName() + CLOSING_QUOTE_CLOSING_PARENTHESIS);
         radio.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
         setNewValueOperation.setExpression("aql:self.setNewValue('" + SysmlPackage.eINSTANCE.getMembership_Visibility().getName() + "', newValue.instance)");

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/CoreFeaturesSwitch.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/CoreFeaturesSwitch.java
@@ -37,6 +37,7 @@ import org.eclipse.syson.sysml.ReferenceSubsetting;
 import org.eclipse.syson.sysml.RequirementConstraintMembership;
 import org.eclipse.syson.sysml.Specialization;
 import org.eclipse.syson.sysml.StateDefinition;
+import org.eclipse.syson.sysml.StateSubactionMembership;
 import org.eclipse.syson.sysml.StateUsage;
 import org.eclipse.syson.sysml.Subclassification;
 import org.eclipse.syson.sysml.Subsetting;
@@ -220,6 +221,14 @@ public class CoreFeaturesSwitch extends SysmlSwitch<List<EStructuralFeature>> {
         var features = new ArrayList<EStructuralFeature>();
         features.addAll(this.caseOccurrenceDefinition(object));
         features.add(SysmlPackage.eINSTANCE.getStateDefinition_IsParallel());
+        return features;
+    }
+
+    @Override
+    public List<EStructuralFeature> caseStateSubactionMembership(StateSubactionMembership object) {
+        var features = new ArrayList<EStructuralFeature>();
+        features.addAll(this.caseMembership(object));
+        features.add(SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind());
         return features;
     }
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/MergedReferencesCompartmentItemNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/MergedReferencesCompartmentItemNodeDescriptionProvider.java
@@ -71,7 +71,7 @@ public class MergedReferencesCompartmentItemNodeDescriptionProvider extends Abst
 
     protected InsideLabelDescription createInsideLabelDescription() {
         return this.diagramBuilderHelper.newInsideLabelDescription()
-                .labelExpression(AQLUtils.getSelfServiceCallExpression("getCompartmentItemUsageLabel"))
+                .labelExpression(AQLUtils.getSelfServiceCallExpression("getPrefixedCompartmentItemUsageLabel"))
                 .position(InsideLabelPosition.TOP_CENTER)
                 .style(this.createInsideLabelStyle())
                 .build();

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
@@ -52,6 +52,9 @@ import org.eclipse.syson.sysml.RequirementConstraintMembership;
 import org.eclipse.syson.sysml.RequirementDefinition;
 import org.eclipse.syson.sysml.RequirementUsage;
 import org.eclipse.syson.sysml.Specialization;
+import org.eclipse.syson.sysml.StateDefinition;
+import org.eclipse.syson.sysml.StateSubactionMembership;
+import org.eclipse.syson.sysml.StateUsage;
 import org.eclipse.syson.sysml.SubjectMembership;
 import org.eclipse.syson.sysml.SysmlFactory;
 import org.eclipse.syson.sysml.SysmlPackage;
@@ -296,6 +299,25 @@ public class ViewCreateService {
                 .filter(ObjectiveMembership.class::isInstance)
                 .map(ObjectiveMembership.class::cast)
                 .findFirst().isEmpty();
+    }
+
+    /**
+     * Service to check whether the given element has a subaction of Kind {@code kind} subject defined or not.
+     *
+     * @param self
+     *            a {@link StateUsage} or a {@link StateDefinition}
+     * @return {@code true} if {@code self} contains a subaction of the specified kind and {@code false} otherwise.
+     */
+    public boolean isEmptyOfActionKindCompartment(Element self, String kind) {
+        if (self instanceof StateUsage
+                || self instanceof StateDefinition) {
+            return !self.getOwnedRelationship().stream()
+                    .filter(StateSubactionMembership.class::isInstance)
+                    .map(StateSubactionMembership.class::cast)
+                    .anyMatch(mem -> mem.getKind().getLiteral().equalsIgnoreCase(kind));
+        }
+        // irrelevant case, this service should only be used upon a StateUsage/StateDefinition
+        return true;
     }
 
     /**

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewLabelService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewLabelService.java
@@ -18,10 +18,12 @@ import org.eclipse.emf.common.util.EList;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.syson.services.LabelService;
 import org.eclipse.syson.sysml.AcceptActionUsage;
+import org.eclipse.syson.sysml.ActionUsage;
 import org.eclipse.syson.sysml.Dependency;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.Expression;
 import org.eclipse.syson.sysml.FeatureValue;
+import org.eclipse.syson.sysml.StateSubactionMembership;
 import org.eclipse.syson.sysml.Succession;
 import org.eclipse.syson.sysml.Usage;
 import org.eclipse.syson.sysml.helper.LabelConstants;
@@ -61,6 +63,22 @@ public class ViewLabelService extends LabelService {
                 .append(this.getRedefinitionLabel(usage))
                 .append(this.getSubsettingLabel(usage))
                 .append(this.getValueLabel(usage));
+        return label.toString();
+    }
+
+    /**
+     * Return the label for the given {@link Usage} prefixed with additional content.
+     *
+     * @param usage
+     *            the given {@link Usage}.
+     * @return the label for the given {@link Usage}.
+     */
+    public String getPrefixedCompartmentItemUsageLabel(Usage usage) {
+        StringBuilder label = new StringBuilder();
+        if (usage instanceof ActionUsage au && usage.eContainer() instanceof StateSubactionMembership ssm) {
+            label.append(ssm.getKind() + " ");
+        }
+        label.append(this.getCompartmentItemUsageLabel(usage));
         return label.toString();
     }
 

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/CompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/CompartmentNodeDescriptionProvider.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sirius.components.view.builder.IViewDiagramElementFinder;
 import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.sirius.components.view.builder.providers.INodeToolProvider;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.statetransition.view.StateTransitionViewDiagramDescriptionProvider;
@@ -51,5 +52,10 @@ public class CompartmentNodeDescriptionProvider extends AbstractCompartmentNodeD
         });
 
         return acceptedNodeTypes;
+    }
+
+    @Override
+    protected INodeToolProvider getItemCreationToolProvider() {
+        return null;
     }
 }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewToolService.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewToolService.java
@@ -51,18 +51,17 @@ public class StateTransitionViewToolService extends ViewToolService {
     @Override
     public Usage addExistingSubElements(Usage usage, IEditingContext editingContext, IDiagramContext diagramContext, Node selectedNode, Object parentNode, DiagramDescription diagramDescription,
             Map<org.eclipse.sirius.components.view.diagram.NodeDescription, NodeDescription> convertedNodes) {
-        if (!(usage instanceof StateUsage)) {
-            var nestedUsages = usage.getNestedUsage();
-    
-            nestedUsages.stream()
-                .forEach(subUsage -> {
-                    this.createView(subUsage, editingContext, diagramContext, selectedNode, convertedNodes);
-                    Node fakeNode = this.createFakeNode(subUsage, selectedNode, diagramContext, diagramDescription, convertedNodes);
-                    if (fakeNode != null) {
-                        this.addExistingSubElements(subUsage, editingContext, diagramContext, fakeNode, selectedNode, diagramDescription, convertedNodes);
-                    }
-                });
-        }
+        var nestedUsages = usage.getNestedUsage();
+
+        nestedUsages.stream().forEach(subUsage -> {
+            if (subUsage instanceof StateUsage || subUsage instanceof ActionUsage) {
+                this.createView(subUsage, editingContext, diagramContext, selectedNode, convertedNodes);
+                Node fakeNode = this.createFakeNode(subUsage, selectedNode, diagramContext, diagramDescription, convertedNodes);
+                if (fakeNode != null) {
+                    this.addExistingSubElements(subUsage, editingContext, diagramContext, fakeNode, selectedNode, diagramDescription, convertedNodes);
+                }
+            }
+        });
         return usage;
     }
 
@@ -72,7 +71,7 @@ public class StateTransitionViewToolService extends ViewToolService {
         var ownedUsages = definition.getOwnedUsage();
 
         ownedUsages.stream().forEach(subUsage -> {
-            if (subUsage instanceof StateUsage) {
+            if (subUsage instanceof StateUsage || subUsage instanceof ActionUsage) {
                 this.createView(subUsage, editingContext, diagramContext, selectedNode, convertedNodes);
                 Node fakeNode = this.createFakeNode(subUsage, selectedNode, diagramContext, diagramDescription, convertedNodes);
                 if (fakeNode != null) {

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/tools/StateTransitionActionToolProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/tools/StateTransitionActionToolProvider.java
@@ -72,16 +72,21 @@ public class StateTransitionActionToolProvider extends AbstractCompartmentNodeTo
     public boolean isHandledAction() {
         return isEntryAction() || isDoAction() || isExitAction();
     }
+
+    @Override
+    protected String getPreconditionExpression() {
+        return AQLUtils.getSelfServiceCallExpression("isEmptyOfActionKindCompartment", "'" + getActionKindValue() + "'");
+    }
     
     private boolean isEntryAction() {
-        return SysmlPackage.eINSTANCE.getStateDefinition_EntryAction().equals(actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_EntryAction().equals(actionStructuralFeature);
+        return SysmlPackage.eINSTANCE.getStateDefinition_EntryAction().equals(this.actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_EntryAction().equals(this.actionStructuralFeature);
     }
     
     private boolean isDoAction() {
-        return SysmlPackage.eINSTANCE.getStateDefinition_DoAction().equals(actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_DoAction().equals(actionStructuralFeature);
+        return SysmlPackage.eINSTANCE.getStateDefinition_DoAction().equals(this.actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_DoAction().equals(this.actionStructuralFeature);
     }
     
     private boolean isExitAction() {
-        return SysmlPackage.eINSTANCE.getStateDefinition_ExitAction().equals(actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_ExitAction().equals(actionStructuralFeature);
+        return SysmlPackage.eINSTANCE.getStateDefinition_ExitAction().equals(this.actionStructuralFeature) || SysmlPackage.eINSTANCE.getStateUsage_ExitAction().equals(this.actionStructuralFeature);
     }
 }


### PR DESCRIPTION
- Make Kind property from StateSubactionMembership visible from Action
- Make kind property from StateSubactionMembership visible on Core properties
- Prefix the label of the entry/do/exit actions with entry/do/exit
- Add Entry/Do/Exit action creation tools on StateUsage and StateDefinition. Tools only allow the creation of one of each kind of actions.
- Deactivated the tools on the "actions" container as it requires additional modifications.
- Improved the "Add existing elements" tool for diagram initialisation. Limited as sub states are not handled in the recursive call.

Bug: https://github.com/eclipse-syson/syson/issues/333