### PR TITLE
Fix Export problems and reduce perimeter

### DIFF
--- a/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/utils/Appender.java
+++ b/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/utils/Appender.java
@@ -38,6 +38,10 @@ public class Appender {
         this.indentation = indentation;
     }
     
+    public boolean isEmpty() {
+        return builder.isEmpty() || builder.toString().isBlank();
+    }
+    
     public static String toPrintableName(String initialName) {
         return NameHelper.toPrintableName(initialName);
     }
@@ -45,6 +49,10 @@ public class Appender {
     public Appender appendPrintableName(String name) {
         append(toPrintableName(name));
         return this;
+    }
+    
+    public Appender appendWithSpaceIfNeeded(String content) {
+        return appendSpaceIfNeeded().append(content);
     }
 
     public Appender appendSpaceIfNeeded() {

--- a/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/utils/NameDeresolver.java
+++ b/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/utils/NameDeresolver.java
@@ -202,7 +202,7 @@ public class NameDeresolver {
         if (resolvedElement != null && resolvedElement != element.getOwningMembership()) {
             // Last try if the element is in the containment tree find the shortest qualified name
             String qualifiedName = getQualifiedName(owningNamespace);
-            if (qualifiedName != null && elementQn.startsWith(qualifiedName)) {
+            if (qualifiedName != null && !qualifiedName.isBlank() && elementQn.startsWith(qualifiedName)) {
                 relativeQualifiedName = elementQn.substring(qualifiedName.length() + 2, elementQn.length());
             } else {
                 relativeQualifiedName = elementQn;
@@ -217,16 +217,11 @@ public class NameDeresolver {
         final String qn;
         Element importedElement = m.getMemberElement();
         String importedElementQualifiedName = getQualifiedName(importedElement);
-        int partToRemove;
-        if (importedElementQualifiedName == null) {
-            partToRemove = 0;
+        if (importedElement != element && importedElementQualifiedName != null && !importedElementQualifiedName.isEmpty()) {
+            int partToRemove = importedElementQualifiedName.length() + 2;
+            qn = Appender.toPrintableName(importedElement.getName()) + "::" + elementQn.substring(partToRemove, elementQn.length());
         } else {
-            partToRemove = importedElementQualifiedName.length() + 2;
-        }
-        if (importedElement != element) {
-            qn = Appender.toPrintableName(importedElement.getDeclaredName()) + "::" + elementQn.substring(partToRemove, elementQn.length());
-        } else {
-            qn = Appender.toPrintableName(element.getDeclaredName());
+            qn = Appender.toPrintableName(element.getName());
         }
         return qn;
     }


### PR DESCRIPTION
This commit:

* Fixe an IndexOutOfBound while resolving name
* Remove the generic caseUsage and caseDefinition that all most of defintion and Usage. Instead it declares all case in a separate method. We need to do that because some usage or definition are not handle has "children" but has shorthand notation.