### PR TITLE
[196] Extract deresolving name logic so it can be used during import

### DIFF
--- a/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/utils/NameDeresolver.java
+++ b/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/utils/NameDeresolver.java
@@ -26,18 +26,11 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.UniqueEList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.syson.sysml.Conjugation;
 import org.eclipse.syson.sysml.Element;
-import org.eclipse.syson.sysml.Feature;
-import org.eclipse.syson.sysml.FeatureChainExpression;
-import org.eclipse.syson.sysml.FeatureChaining;
-import org.eclipse.syson.sysml.FeatureReferenceExpression;
-import org.eclipse.syson.sysml.Import;
 import org.eclipse.syson.sysml.Membership;
 import org.eclipse.syson.sysml.Namespace;
-import org.eclipse.syson.sysml.Specialization;
-import org.eclipse.syson.sysml.Type;
 import org.eclipse.syson.sysml.VisibilityKind;
+import org.eclipse.syson.sysml.helper.DeresolvingNamespaceProvider;
 import org.eclipse.syson.sysml.helper.EMFUtils;
 import org.eclipse.syson.sysml.helper.MembershipComputer;
 import org.slf4j.Logger;
@@ -70,6 +63,8 @@ public class NameDeresolver {
      * Keeps a cache of the qualified name of an element identified by its elementId.
      */
     private Map<String, String> qualifiedNameCache = new HashMap<>();
+    
+    private DeresolvingNamespaceProvider deresolvingNamespaceProvider = new DeresolvingNamespaceProvider();
 
     public String getDeresolvedName(Element element, Element context) {
 
@@ -77,7 +72,7 @@ public class NameDeresolver {
             return null;
         }
 
-        Namespace deresolvingNamespace = this.getDeresolvingNamespace(context);
+        Namespace deresolvingNamespace = deresolvingNamespaceProvider.getDeresolvingNamespace(context);
 
         final String qualifiedName;
         if (deresolvingNamespace == null) {
@@ -226,95 +221,5 @@ public class NameDeresolver {
         return qn;
     }
 
-    private Namespace getDeresolvingNamespace(Element element) {
-        // See 8.2.3.5.2 Local and Global Namespaces
-        final Namespace result;
-        if (element instanceof Import aImport) {
-            result = aImport.getImportOwningNamespace();
-        } else if (element instanceof Membership membership) {
-            result = this.getDeresolvingNamespaceForMembership(membership);
-        } else if (element instanceof Specialization specialization) {
-            result = this.getDeresolvingNamespaceForSpecialization(specialization);
-        } else if (element instanceof Conjugation conjugation) {
-            result = this.getDeresolvingNamespaceForConjugation(element, conjugation);
-        } else if (element instanceof FeatureChaining featureChaining) {
-            result = this.getDeresolvingNamespaceFeatureChaining(element, featureChaining);
-        } else {
-            result = element.getOwningNamespace();
-        }
-
-        return result;
-    }
-
-    private Namespace getDeresolvingNamespaceForMembership(Membership membership) {
-        Namespace ns = membership.getMembershipOwningNamespace();
-        if (ns instanceof FeatureReferenceExpression featureRef) {
-            // If the membershipOwningNamespace is a FeatureReferenceExpression (see 8.3.4.8.4), then the
-            // local Namespace is the non-invocation Namespace for the membershipOwningNamespace, which is
-            // defined to be the nearest containing Namespace that is none of the following:
-            // FeatureReferenceExpression
-            // InvocationExpression
-            // ownedFeature of an InvocationExpression
-        } else if (membership instanceof FeatureChainExpression featureChainExpression) {
-            // If the membershipOwningNamespace is a FeatureChainExpression see 8.3.4.8.3, then the local
-            // Namespace is the result parameter of the argument Expression of the FeatureChainExpression.
-            Feature resultFeature = featureChainExpression.getResult();
-            if (resultFeature != null) {
-                ns = resultFeature;
-            }
-        }
-
-        return ns;
-    }
-
-    private Namespace getDeresolvingNamespaceForConjugation(Element element, Conjugation conjugation) {
-        final Namespace result;
-        // If the owningType is not null, the local Namespace is the owningNamespace of the owningType.
-        // Otherwise, the local Namespace is the owningNamespace of the Conjugation.
-        Type type = conjugation.getOwningType();
-        if (type != null) {
-            result = type.getOwningNamespace();
-        } else {
-            result = element.getOwningNamespace();
-        }
-        return result;
-    }
-
-    private Namespace getDeresolvingNamespaceForSpecialization(Specialization element) {
-        // If the Specialization is a ReferenceSubsetting (see 8.3.3.3.9), and its referencingFeature is
-        // an end Feature whose owningType is a Connector, then the local Namespace is the
-        // owningNamespace of the Connector.
-        // If the Specialization is a FeatureTyping (see 8.3.3.3.6), and its owningFeature is an
-        // InvocationExpression, then the local Namespace is the non-invocation Namespace for the
-        // owningFeature (determined as for a FeatureReferenceExpression under Membership above).
-        // Otherwise, if the owningType is not null, then the local Namespace is the owningNamespace of the
-        // owningType.
-        // Otherwise, the local Namespace is the owningNamespace of the Specialization.
-
-        return element.getOwningNamespace();
-    }
-
-    private Namespace getDeresolvingNamespaceFeatureChaining(Element element, FeatureChaining featureChaining) {
-        final Namespace result;
-        // If the FeatureChaining is the first ownedFeatureChaining of its featureChained, then the local
-        // Namespace is determined as if the owningRelationship of the featureChained (which will be a
-        // Membership, Subsetting or Conjugation) was the context Relationship (see above).
-        // Otherwise, the local Namespace is the chainingFeature of the previous FeatureChaining in the
-        // ownedFeatureChaining list.
-        Feature featureChained = featureChaining.getFeatureChained();
-        int indexOf = featureChained.getOwnedFeatureChaining().indexOf(featureChaining);
-        if (indexOf != -1) {
-
-            if (indexOf == 0) {
-                result = this.getDeresolvingNamespace(featureChained.getOwningRelationship());
-            } else {
-                result = this.getDeresolvingNamespace(featureChained.getOwnedFeatureChaining().get(indexOf - 1));
-            }
-        } else {
-            result = element.getOwningNamespace();
-        }
-
-        return result;
-    }
 
 }

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/helper/DeresolvingNamespaceProvider.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/helper/DeresolvingNamespaceProvider.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.sysml.helper;
+
+import org.eclipse.syson.sysml.Conjugation;
+import org.eclipse.syson.sysml.Element;
+import org.eclipse.syson.sysml.Feature;
+import org.eclipse.syson.sysml.FeatureChainExpression;
+import org.eclipse.syson.sysml.FeatureChaining;
+import org.eclipse.syson.sysml.FeatureReferenceExpression;
+import org.eclipse.syson.sysml.Import;
+import org.eclipse.syson.sysml.Membership;
+import org.eclipse.syson.sysml.Namespace;
+import org.eclipse.syson.sysml.Specialization;
+import org.eclipse.syson.sysml.Type;
+
+/**
+ * Provides a {@link Namespace} that needs to be used to resolve/deresolve a name from an Element.
+ *
+ * @author Arthur Daussy
+ */
+public class DeresolvingNamespaceProvider {
+
+    public Namespace getDeresolvingNamespace(Element element) {
+        // See 8.2.3.5.2 Local and Global Namespaces
+        final Namespace result;
+        if (element instanceof Import aImport) {
+            result = aImport.getImportOwningNamespace();
+        } else if (element instanceof Membership membership) {
+            result = this.getDeresolvingNamespaceForMembership(membership);
+        } else if (element instanceof Specialization specialization) {
+            result = this.getDeresolvingNamespaceForSpecialization(specialization);
+        } else if (element instanceof Conjugation conjugation) {
+            result = this.getDeresolvingNamespaceForConjugation(element, conjugation);
+        } else if (element instanceof FeatureChaining featureChaining) {
+            result = this.getDeresolvingNamespaceFeatureChaining(element, featureChaining);
+        } else {
+            result = element.getOwningNamespace();
+        }
+
+        return result;
+    }
+
+    private Namespace getDeresolvingNamespaceForMembership(Membership membership) {
+        Namespace ns = membership.getMembershipOwningNamespace();
+        if (ns instanceof FeatureReferenceExpression featureRef) {
+            // If the membershipOwningNamespace is a FeatureReferenceExpression (see 8.3.4.8.4), then the
+            // local Namespace is the non-invocation Namespace for the membershipOwningNamespace, which is
+            // defined to be the nearest containing Namespace that is none of the following:
+            // FeatureReferenceExpression
+            // InvocationExpression
+            // ownedFeature of an InvocationExpression
+        } else if (membership instanceof FeatureChainExpression featureChainExpression) {
+            // If the membershipOwningNamespace is a FeatureChainExpression see 8.3.4.8.3, then the local
+            // Namespace is the result parameter of the argument Expression of the FeatureChainExpression.
+            Feature resultFeature = featureChainExpression.getResult();
+            if (resultFeature != null) {
+                ns = resultFeature;
+            }
+        }
+
+        return ns;
+    }
+
+    private Namespace getDeresolvingNamespaceForConjugation(Element element, Conjugation conjugation) {
+        final Namespace result;
+        // If the owningType is not null, the local Namespace is the owningNamespace of the owningType.
+        // Otherwise, the local Namespace is the owningNamespace of the Conjugation.
+        Type type = conjugation.getOwningType();
+        if (type != null) {
+            result = type.getOwningNamespace();
+        } else {
+            result = element.getOwningNamespace();
+        }
+        return result;
+    }
+
+    private Namespace getDeresolvingNamespaceForSpecialization(Specialization element) {
+        // If the Specialization is a ReferenceSubsetting (see 8.3.3.3.9), and its referencingFeature is
+        // an end Feature whose owningType is a Connector, then the local Namespace is the
+        // owningNamespace of the Connector.
+        // If the Specialization is a FeatureTyping (see 8.3.3.3.6), and its owningFeature is an
+        // InvocationExpression, then the local Namespace is the non-invocation Namespace for the
+        // owningFeature (determined as for a FeatureReferenceExpression under Membership above).
+        // Otherwise, if the owningType is not null, then the local Namespace is the owningNamespace of the
+        // owningType.
+        // Otherwise, the local Namespace is the owningNamespace of the Specialization.
+
+        return element.getOwningNamespace();
+    }
+
+    private Namespace getDeresolvingNamespaceFeatureChaining(Element element, FeatureChaining featureChaining) {
+        final Namespace result;
+        // If the FeatureChaining is the first ownedFeatureChaining of its featureChained, then the local
+        // Namespace is determined as if the owningRelationship of the featureChained (which will be a
+        // Membership, Subsetting or Conjugation) was the context Relationship (see above).
+        // Otherwise, the local Namespace is the chainingFeature of the previous FeatureChaining in the
+        // ownedFeatureChaining list.
+        Feature featureChained = featureChaining.getFeatureChained();
+        int indexOf = featureChained.getOwnedFeatureChaining().indexOf(featureChaining);
+        if (indexOf != -1) {
+
+            if (indexOf == 0) {
+                result = this.getDeresolvingNamespace(featureChained.getOwningRelationship());
+            } else {
+                result = this.getDeresolvingNamespace(featureChained.getOwnedFeatureChaining().get(indexOf - 1));
+            }
+        } else {
+            result = element.getOwningNamespace();
+        }
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/196