### PR TITLE
[393] Exhibit States tools on STV

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,13 +16,16 @@
 Please download your existing SysON projects before moving to this new version.
 A reset of the database is needed.
 - https://github.com/eclipse-syson/syson/issues/393[#393] [diagrams] Code refactorings
-  * Move `AbstractDiagramDescriptionProvider.createNodeToolFromDiagramBackground(NodeDescription, EClassifier)` to new `ToolDescriptionService`
-  * Move `AbstractViewElementDescriptionProvider.addExistingElementsTool(boolean)` to new `ToolDescriptionService`
+  * Move `AbstractDiagramDescriptionProvider#createNodeToolFromDiagramBackground(NodeDescription, EClassifier)` to new `ToolDescriptionService`
+  * Move `AbstractViewElementDescriptionProvider#addExistingElementsTool(boolean)` to new `ToolDescriptionService`
   * Remove `AbstractViewElementDescriptionProvider`
   * Move `createDropFromExplorerTool` to new `ToolDescriptionService`
-  * Move and rename `AbstractDiagramDescriptionProvider.addElementsToolSection(IViewDiagramElementFinder)` to `ToolDescriptionService.addElementsDiagramToolSection()`
-  * Move and rename `AbstractNodeDescriptionProvider.addExistingElementsTool()` to `ToolDescriptionService.addElementsNodeToolSection()`
+  * Move and rename `AbstractDiagramDescriptionProvider.addElementsToolSection(IViewDiagramElementFinder)` to `ToolDescriptionService#addElementsDiagramToolSection()`
+  * Move and rename `AbstractNodeDescriptionProvider#addExistingElementsTool()` to `ToolDescriptionService#addElementsNodeToolSection()`
   * Remove `AbstractDiagramDescriptionProvider`
+  * Rename `StateTransitionActionToolProvider` to `StateTransitionActionCompartmentToolProvider`
+  * Move `AbstractViewNodeToolSectionSwitch#buildCreateSection(NodeTool...)` to `ToolDescriptionService#buildCreateSection(NodeTool...)`
+  * Merge `AbstractViewNodeToolSectionSwitch#addElementsToolSection()` and `AbstractViewNodeToolSectionSwitch#addExistingNestedElementsTool()` in `ToolDescriptionService#addElementsNodeToolSection(boolean)`
 - https://github.com/eclipse-syson/syson/issues/423[#423] [diagrams]`ViewLabelService#getCompartmentItemUsageLabel` has been renamed to `ViewLabelService#getCompartmentItemLabel`.
 - https://github.com/eclipse-syson/syson/issues/423[#423] [diagrams]`ViewLabelService#getUsageInitialDirectEditLabel` has been renamed to `ViewLabelService#getInitialDirectEditLabel`.
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/DetailsViewService.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/DetailsViewService.java
@@ -286,6 +286,13 @@ public class DetailsViewService {
         return null;
     }
 
+    public StateUsage getStateUsage(Element self) {
+        if (self instanceof StateUsage su) {
+            return su;
+        }
+        return null;
+    }
+
     public TransitionUsage getTransitionUsage(Element self) {
         if (self instanceof TransitionUsage transition) {
             return transition;

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/MultiLineLabelSwitch.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/MultiLineLabelSwitch.java
@@ -27,7 +27,6 @@ import org.eclipse.syson.sysml.ConstraintUsage;
 import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.EnumerationDefinition;
-import org.eclipse.syson.sysml.ExhibitStateUsage;
 import org.eclipse.syson.sysml.Expression;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureMembership;
@@ -336,24 +335,6 @@ public class MultiLineLabelSwitch extends SysmlSwitch<String> {
                 .append(LabelConstants.CR)
                 .append(this.caseElement(object))
                 .append(this.subclassification(object));
-        return label.toString();
-    }
-
-    @Override
-    public String caseExhibitStateUsage(ExhibitStateUsage object) {
-        StringBuilder label = new StringBuilder();
-        label
-                .append(this.abstractType(object))
-                .append(this.getIsParallel(object.isIsParallel()))
-                .append(LabelConstants.OPEN_QUOTE)
-                .append("exhibit state")
-                .append(LabelConstants.CLOSE_QUOTE)
-                .append(LabelConstants.CR)
-                .append(this.caseElement(object))
-                .append(this.multiplicityRange(object))
-                .append(this.featureTyping(object))
-                .append(this.redefinition(object))
-                .append(this.subsetting(object));
         return label.toString();
     }
 

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/RelatedElementsSwitch.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/RelatedElementsSwitch.java
@@ -23,6 +23,7 @@ import org.eclipse.syson.sysml.ActionUsage;
 import org.eclipse.syson.sysml.Dependency;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.EndFeatureMembership;
+import org.eclipse.syson.sysml.ExhibitStateUsage;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureMembership;
 import org.eclipse.syson.sysml.FeatureTyping;
@@ -92,11 +93,15 @@ public class RelatedElementsSwitch extends SysmlSwitch<Set<EObject>> {
     @Override
     public Set<EObject> caseReferenceSubsetting(ReferenceSubsetting object) {
         Set<EObject> relatedElements = new HashSet<>();
-        if (object.getReferencedFeature() instanceof ActionUsage && object.eContainer() instanceof Feature feat) {
+        if (object.getReferencedFeature() instanceof ActionUsage au && object.eContainer() instanceof Feature feat) {
             if (feat.eContainer() instanceof EndFeatureMembership efm && efm.eContainer() instanceof Succession succ) {
                 if (succ.eContainer() instanceof FeatureMembership fm && fm.eContainer() instanceof TransitionUsage tu) {
                     relatedElements.add(tu);
                 }
+            }
+
+            if (feat instanceof ExhibitStateUsage esu && esu.getExhibitedState().equals(au)) {
+                relatedElements.add(esu);
             }
         }
         return relatedElements;

--- a/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/services/ActionFlowViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/services/ActionFlowViewNodeToolSectionSwitch.java
@@ -24,6 +24,7 @@ import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.syson.diagram.actionflow.view.AFVDescriptionNameGenerator;
 import org.eclipse.syson.diagram.actionflow.view.ActionFlowViewDiagramDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.services.AbstractViewNodeToolSectionSwitch;
+import org.eclipse.syson.diagram.common.view.services.description.ToolDescriptionService;
 import org.eclipse.syson.diagram.common.view.tools.AcceptActionNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.AcceptActionPayloadNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.AcceptActionPortUsageReceiverToolNodeProvider;
@@ -56,6 +57,8 @@ public class ActionFlowViewNodeToolSectionSwitch extends AbstractViewNodeToolSec
 
     private final IViewDiagramElementFinder cache;
 
+    private final ToolDescriptionService toolDescriptionService = new ToolDescriptionService();
+
     public ActionFlowViewNodeToolSectionSwitch(IViewDiagramElementFinder cache, List<NodeDescription> allNodeDescriptions) {
         super(new AFVDescriptionNameGenerator());
         this.cache = Objects.requireNonNull(cache);
@@ -79,17 +82,17 @@ public class ActionFlowViewNodeToolSectionSwitch extends AbstractViewNodeToolSec
 
     @Override
     public List<NodeToolSection> caseAcceptActionUsage(AcceptActionUsage object) {
-        var createSection = this.buildCreateSection(
+        var createSection = this.toolDescriptionService.buildCreateSection(
                 this.createPayloadNodeTool(SysmlPackage.eINSTANCE.getItemDefinition()),
                 this.createPayloadNodeTool(SysmlPackage.eINSTANCE.getPartDefinition()),
                 this.createPortUsageAsReceiverNodeTool());
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
-        return List.of(createSection, this.addElementsToolSection());
+        return List.of(createSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 
     @Override
     public List<NodeToolSection> caseActionUsage(ActionUsage object) {
-        var createSection = this.buildCreateSection(new StartActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionUsage(), this.descriptionNameGenerator).create(this.cache),
+        var createSection = this.toolDescriptionService.buildCreateSection(new StartActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionUsage(), this.descriptionNameGenerator).create(this.cache),
                 new DoneActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionUsage(), this.descriptionNameGenerator).create(this.cache),
                 new JoinActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionUsage(), this.descriptionNameGenerator).create(this.cache),
                 new ForkActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionUsage(), this.descriptionNameGenerator).create(this.cache),
@@ -101,12 +104,13 @@ public class ActionFlowViewNodeToolSectionSwitch extends AbstractViewNodeToolSec
                 new ActionFlowCompartmentNodeToolProvider(SysmlPackage.eINSTANCE.getActionUsage(), this.descriptionNameGenerator).create(this.cache),
                 new CompartmentNodeToolProvider(SysmlPackage.eINSTANCE.getElement_Documentation(), this.descriptionNameGenerator).create(this.cache),
                 new AssignmentActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionUsage(), this.descriptionNameGenerator).create(this.cache));
-        return List.of(createSection, this.addElementsToolSection());
+        return List.of(createSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 
     @Override
     public List<NodeToolSection> caseActionDefinition(ActionDefinition object) {
-        var createSection = this.buildCreateSection(new StartActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionDefinition(), this.descriptionNameGenerator).create(this.cache),
+        var createSection = this.toolDescriptionService.buildCreateSection(
+                new StartActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionDefinition(), this.descriptionNameGenerator).create(this.cache),
                 new DoneActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionDefinition(), this.descriptionNameGenerator).create(this.cache),
                 new JoinActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionDefinition(), this.descriptionNameGenerator).create(this.cache),
                 new ForkActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionDefinition(), this.descriptionNameGenerator).create(this.cache),
@@ -116,28 +120,28 @@ public class ActionFlowViewNodeToolSectionSwitch extends AbstractViewNodeToolSec
                 new CompartmentNodeToolProvider(SysmlPackage.eINSTANCE.getElement_Documentation(), this.descriptionNameGenerator).create(this.cache),
                 new AcceptActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionDefinition(), this.descriptionNameGenerator).create(this.cache),
                 new AssignmentActionNodeToolProvider(SysmlPackage.eINSTANCE.getActionDefinition(), this.descriptionNameGenerator).create(this.cache));
-        return List.of(createSection, this.addElementsToolSection());
+        return List.of(createSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 
     @Override
     public List<NodeToolSection> caseAssignmentActionUsage(AssignmentActionUsage object) {
         // Define here the set of node tools that should be added to the Assignment action palette,
         // such as "Set assigned element" and "Set value".
-        return List.of(this.addElementsToolSection());
+        return List.of(this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 
     @Override
     public List<NodeToolSection> caseDefinition(Definition object) {
-        var createSection = this.buildCreateSection();
+        var createSection = this.toolDescriptionService.buildCreateSection();
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
         return List.of(createSection);
     }
 
     @Override
     public List<NodeToolSection> caseUsage(Usage object) {
-        var createSection = this.buildCreateSection();
+        var createSection = this.toolDescriptionService.buildCreateSection();
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
-        return List.of(createSection, this.addElementsToolSection());
+        return List.of(createSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 
     private NodeTool createPayloadNodeTool(EClass payloadType) {

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractEmptyDiagramNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractEmptyDiagramNodeDescriptionProvider.java
@@ -169,7 +169,7 @@ public abstract class AbstractEmptyDiagramNodeDescriptionProvider extends Abstra
             sections.add(sectionBuilder.build());
         });
 
-        sections.add(this.toolDescriptionService.addElementsNodeToolSection());
+        sections.add(this.toolDescriptionService.addElementsNodeToolSection(true));
 
         return sections.toArray(NodeToolSection[]::new);
     }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPackageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPackageNodeDescriptionProvider.java
@@ -242,7 +242,7 @@ public abstract class AbstractPackageNodeDescriptionProvider extends AbstractNod
             sections.add(sectionBuilder.build());
         });
 
-        sections.add(this.toolDescriptionService.addElementsNodeToolSection());
+        sections.add(this.toolDescriptionService.addElementsNodeToolSection(true));
         sections.add(this.defaultToolsFactory.createDefaultHideRevealNodeToolSection());
 
         return sections.toArray(NodeToolSection[]::new);

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/ExhibitStatesCompartmentItemNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/ExhibitStatesCompartmentItemNodeDescriptionProvider.java
@@ -15,6 +15,8 @@ package org.eclipse.syson.diagram.common.view.nodes;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.syson.diagram.common.view.tools.StateTransitionToggleExhibitStateToolProvider;
 import org.eclipse.syson.sysml.ExhibitStateUsage;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
@@ -33,6 +35,16 @@ public class ExhibitStatesCompartmentItemNodeDescriptionProvider extends Compart
     @Override
     protected String getSemanticCandidateExpression() {
         return AQLUtils.getSelfServiceCallExpression("getAllReachableExhibitedStates");
+    }
+
+    @Override
+    public NodeDescription create() {
+        NodeDescription nd = super.create();
+        var editSection = this.toolDescriptionService.buildEditSection(
+                new StateTransitionToggleExhibitStateToolProvider(true).create(null),
+                new StateTransitionToggleExhibitStateToolProvider(false).create(null));
+        nd.getPalette().getToolSections().add(editSection);
+        return nd;
     }
 
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/AbstractViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/AbstractViewNodeToolSectionSwitch.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.sirius.components.diagrams.tools.ToolSection;
 import org.eclipse.sirius.components.view.builder.generated.DiagramBuilders;
 import org.eclipse.sirius.components.view.builder.generated.ViewBuilders;
 import org.eclipse.sirius.components.view.diagram.NodeContainmentKind;
@@ -68,28 +67,6 @@ public abstract class AbstractViewNodeToolSectionSwitch extends SysmlEClassSwitc
      */
     protected abstract List<NodeDescription> getAllNodeDescriptions();
 
-    /**
-     * Return a tool section used to new children creation.
-     *
-     * @param nodeTools
-     *            optional list of {@link NodeTool}
-     *
-     * @return the {@link ToolSection} grouping all creations of children.
-     */
-    protected NodeToolSection buildCreateSection(NodeTool... nodeTools) {
-        return this.diagramBuilderHelper.newNodeToolSection()
-                .name("Create")
-                .nodeTools(nodeTools)
-                .build();
-    }
-
-    protected NodeToolSection addElementsToolSection() {
-        return this.diagramBuilderHelper.newNodeToolSection()
-                .name("Add")
-                .nodeTools(this.addExistingNestedElementsTool(false), this.addExistingNestedElementsTool(true))
-                .build();
-    }
-
     protected List<NodeTool> createToolsForCompartmentItems(Element object) {
         List<NodeTool> compartmentNodeTools = new ArrayList<>();
         this.getElementCompartmentReferences(object).forEach(eReference -> {
@@ -131,26 +108,6 @@ public abstract class AbstractViewNodeToolSectionSwitch extends SysmlEClassSwitc
                 .name(this.descriptionNameGenerator.getCreationToolName("New ", eClass))
                 .iconURLsExpression("/icons/full/obj16/" + eClass.getName() + ".svg")
                 .body(createMembership.build())
-                .build();
-    }
-
-    private NodeTool addExistingNestedElementsTool(boolean recursive) {
-        var builder = this.diagramBuilderHelper.newNodeTool();
-
-        var addExistingelements = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getSelfServiceCallExpression("addExistingNestedElements", List.of("editingContext", "diagramContext", "selectedNode", "convertedNodes", "" + recursive)));
-
-        String title = "Add existing nested elements";
-        String iconURL = "/icons/AddExistingElements.svg";
-        if (recursive) {
-            title += " (recursive)";
-            iconURL = "/icons/AddExistingElementsRecursive.svg";
-        }
-
-        return builder
-                .name(title)
-                .iconURLsExpression(iconURL)
-                .body(addExistingelements.build())
                 .build();
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ViewNodeService {
 
-    private final Logger logger = LoggerFactory.getLogger(ViewCreateService.class);
+    private final Logger logger = LoggerFactory.getLogger(ViewNodeService.class);
 
     private final IObjectService objectService;
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
@@ -716,7 +716,7 @@ public class ViewToolService extends ToolService {
      */
     public ActionUsage createOwnedAction(Element parentState, IEditingContext editingContext, IDiagramContext diagramContext, Node selectedNode,
             Map<org.eclipse.sirius.components.view.diagram.NodeDescription, NodeDescription> convertedNodes, String actionKind) {
-        ActionUsage childAction = this.createChildAction(parentState, actionKind);
+        ActionUsage childAction = this.utilService.createChildAction(parentState, actionKind);
 
         if (childAction != null) {
             if (diagramContext.getDiagram().getLabel().equals("General View")) {
@@ -731,37 +731,6 @@ public class ViewToolService extends ToolService {
             }
         }
 
-        return childAction;
-    }
-
-    /**
-     * Create a child Action onto {@code stateDefinition}.
-     *
-     * @param parentState
-     *            The parent {@link StateDefinition} or {@link StateUsage}
-     * @param actionKind
-     *            The string value representing the kind of Action. Expected values are "Entry", "Do" or "Exit".
-     * @return The created {@link ActionUsage} or null if the kind value is not correct
-     */
-    private ActionUsage createChildAction(Element parentState, String actionKind) {
-        var owningMembership = SysmlFactory.eINSTANCE.createStateSubactionMembership();
-        switch (actionKind) {
-            case "Entry":
-                owningMembership.setKind(StateSubactionKind.ENTRY);
-                break;
-            case "Do":
-                owningMembership.setKind(StateSubactionKind.DO);
-                break;
-            case "Exit":
-                owningMembership.setKind(StateSubactionKind.EXIT);
-                break;
-            default:
-                return null;
-        }
-        ActionUsage childAction = SysmlFactory.eINSTANCE.createActionUsage();
-        owningMembership.getOwnedRelatedElement().add(childAction);
-        parentState.getOwnedRelationship().add(owningMembership);
-        this.elementInitializerSwitch.doSwitch(childAction);
         return childAction;
     }
 
@@ -790,7 +759,7 @@ public class ViewToolService extends ToolService {
      */
     public StateUsage createChildState(Element parentState, IEditingContext editingContext, IDiagramContext diagramContext, Node selectedNode,
             Map<org.eclipse.sirius.components.view.diagram.NodeDescription, NodeDescription> convertedNodes, boolean isParallel, boolean isExhibit) {
-        StateUsage childState = this.createChildState(parentState, isParallel, isExhibit);
+        StateUsage childState = this.utilService.createChildState(parentState, isParallel, isExhibit);
 
         if (diagramContext.getDiagram().getLabel().equals("General View")) {
             this.createView(childState, editingContext, diagramContext, diagramContext.getDiagram(), convertedNodes);
@@ -803,32 +772,6 @@ public class ViewToolService extends ToolService {
                     });
         }
 
-        return childState;
-    }
-
-    /**
-     * Create a child State onto {@code stateDefinition}.
-     *
-     * @param parentState
-     *            The parent {@link StateDefinition} or {@link StateUsage}
-     * @param isParallel
-     *            Whether the created state is parallel or not
-     * @param isExhibit
-     *            Whether the created state is exhibited or not
-     * @return the created {@link StateUsage}.
-     */
-    private StateUsage createChildState(Element parentState, boolean isParallel, boolean isExhibit) {
-        var owningMembership = SysmlFactory.eINSTANCE.createFeatureMembership();
-        StateUsage childState = null;
-        if (isExhibit) {
-            childState = SysmlFactory.eINSTANCE.createExhibitStateUsage();
-        } else {
-            childState = SysmlFactory.eINSTANCE.createStateUsage();
-        }
-        childState.setIsParallel(isParallel);
-        owningMembership.getOwnedRelatedElement().add(childState);
-        parentState.getOwnedRelationship().add(owningMembership);
-        this.elementInitializerSwitch.doSwitch(childState);
         return childState;
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/description/ToolDescriptionService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/description/ToolDescriptionService.java
@@ -15,6 +15,7 @@ package org.eclipse.syson.diagram.common.view.services.description;
 import java.util.List;
 
 import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.sirius.components.diagrams.tools.ToolSection;
 import org.eclipse.sirius.components.view.builder.generated.DiagramBuilders;
 import org.eclipse.sirius.components.view.builder.generated.ViewBuilders;
 import org.eclipse.sirius.components.view.diagram.DiagramToolSection;
@@ -23,7 +24,6 @@ import org.eclipse.sirius.components.view.diagram.NodeContainmentKind;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
-import org.eclipse.syson.diagram.common.view.ViewDiagramElementFinder;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.DescriptionNameGenerator;
@@ -49,21 +49,21 @@ public class ToolDescriptionService {
     public DiagramToolSection addElementsDiagramToolSection() {
         return this.diagramBuilderHelper.newDiagramToolSection()
                 .name("Add")
-                .nodeTools(this.addExistingElementsTool(false), this.addExistingElementsTool(true))
+                .nodeTools(this.addExistingElementsTool(false, false), this.addExistingElementsTool(true, false))
                 .build();
     }
 
     /**
      * Create a {@link NodeToolSection} containing the {@code Add Existing Elements} tools.
      *
-     * @param cache
-     *            The {@link ViewDiagramElementFinder} cache
+     * @param nested
+     *            Whether the created tools adds nested elements
      * @return The created {@link NodeToolSection}
      */
-    public NodeToolSection addElementsNodeToolSection() {
+    public NodeToolSection addElementsNodeToolSection(boolean nested) {
         return this.diagramBuilderHelper.newNodeToolSection()
                 .name("Add")
-                .nodeTools(this.addExistingElementsTool(false), this.addExistingElementsTool(true))
+                .nodeTools(this.addExistingElementsTool(false, nested), this.addExistingElementsTool(true, nested))
                 .build();
     }
 
@@ -73,15 +73,23 @@ public class ToolDescriptionService {
      *
      * @param recursive
      *            Whether or not the created tool is recursive
+     * @param nested
+     *            Whether or not the creation tool is adding nested elements
      * @return The created {@link NodeTool}
      */
-    public NodeTool addExistingElementsTool(boolean recursive) {
+    public NodeTool addExistingElementsTool(boolean recursive, boolean nested) {
         var builder = this.diagramBuilderHelper.newNodeTool();
 
-        var addExistingelements = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getSelfServiceCallExpression("addExistingElements", List.of("editingContext", "diagramContext", "selectedNode", "convertedNodes", "" + recursive)));
-
+        String serviceName = "addExistingElements";
         String title = "Add existing elements";
+        if (nested) {
+            serviceName = "addExistingNestedElements";
+            title = "Add existing nested elements";
+        }
+
+        var addExistingelements = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLUtils.getSelfServiceCallExpression(serviceName, List.of("editingContext", "diagramContext", "selectedNode", "convertedNodes", "" + recursive)));
+
         String iconURL = "/icons/AddExistingElements.svg";
         if (recursive) {
             title += " (recursive)";
@@ -95,6 +103,41 @@ public class ToolDescriptionService {
                 .build();
     }
 
+    /**
+     * Return a tool section used to new children creation.
+     *
+     * @param nodeTools
+     *            optional list of {@link NodeTool}
+     *
+     * @return the {@link ToolSection} grouping all creations of children.
+     */
+    public NodeToolSection buildCreateSection(NodeTool... nodeTools) {
+        return this.diagramBuilderHelper.newNodeToolSection()
+                .name("Create")
+                .nodeTools(nodeTools)
+                .build();
+    }
+
+    /**
+     * Return a tool section used to edit elements.
+     *
+     * @param nodeTools
+     *            optional list of {@link NodeTool}
+     *
+     * @return the {@link ToolSection} grouping all editions of elements.
+     */
+    public NodeToolSection buildEditSection(NodeTool... nodeTools) {
+        return this.diagramBuilderHelper.newNodeToolSection()
+                .name("Edit")
+                .nodeTools(nodeTools)
+                .build();
+    }
+
+    /**
+     * Create a generic {@link DropTool} to handle drop from Explorer View.
+     *
+     * @return the created {@link DropTool}
+     */
     public DropTool createDropFromExplorerTool() {
         var dropElementFromExplorer = this.viewBuilderHelper.newChangeContext()
                 .expression(AQLUtils.getSelfServiceCallExpression("dropElementFromExplorer", List.of("editingContext", "diagramContext", "selectedNode", "convertedNodes")));

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StateTransitionActionCompartmentToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StateTransitionActionCompartmentToolProvider.java
@@ -24,11 +24,11 @@ import org.eclipse.syson.util.AQLUtils;
  *
  * @author adieumegard
  */
-public class StateTransitionActionToolProvider extends AbstractCompartmentNodeToolProvider {
+public class StateTransitionActionCompartmentToolProvider extends AbstractCompartmentNodeToolProvider {
 
     private EStructuralFeature actionStructuralFeature;
 
-    public StateTransitionActionToolProvider(EStructuralFeature actionStructuralFeature) {
+    public StateTransitionActionCompartmentToolProvider(EStructuralFeature actionStructuralFeature) {
         super();
         this.actionStructuralFeature = actionStructuralFeature;
     }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StateTransitionToggleExhibitStateToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StateTransitionToggleExhibitStateToolProvider.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.common.view.tools;
+
+import org.eclipse.sirius.components.view.builder.IViewDiagramElementFinder;
+import org.eclipse.sirius.components.view.builder.generated.DiagramBuilders;
+import org.eclipse.sirius.components.view.builder.generated.ViewBuilders;
+import org.eclipse.sirius.components.view.builder.providers.INodeToolProvider;
+import org.eclipse.sirius.components.view.diagram.NodeTool;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.AQLUtils;
+
+/**
+ * Tool used to (un)set whether a StateUsage is exhibited or not.
+ *
+ * @author adieumegard
+ */
+public class StateTransitionToggleExhibitStateToolProvider implements INodeToolProvider {
+
+    private final DiagramBuilders diagramBuilderHelper = new DiagramBuilders();
+
+    private final ViewBuilders viewBuilderHelper = new ViewBuilders();
+
+    private final boolean exhibit;
+
+    public StateTransitionToggleExhibitStateToolProvider(boolean exhibit) {
+        this.exhibit = exhibit;
+
+    }
+
+    @Override
+    public NodeTool create(IViewDiagramElementFinder cache) {
+        var builder = this.diagramBuilderHelper.newNodeTool();
+
+        var setUnsetAsExhibitedServiceCall = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLUtils.getSelfServiceCallExpression("setUnsetAsExhibit"))
+                .build();
+
+        var rootChangContext = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLConstants.AQL_SELF)
+                .children(setUnsetAsExhibitedServiceCall)
+                .build();
+
+        String toolName = "Exhibit";
+        String preconditionServiceName = "canBeExhibitedStateUsage";
+        if (!this.exhibit) {
+            toolName = "Set as not exhibited";
+            preconditionServiceName = "isExhibitedStateUsage";
+        }
+
+        return builder.name(toolName)
+                .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getExhibitStateUsage().getName() + ".svg")
+                .body(rootChangContext)
+                .preconditionExpression(AQLUtils.getSelfServiceCallExpression(preconditionServiceName))
+                .build();
+    }
+}

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GVDescriptionNameGenerator.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/GVDescriptionNameGenerator.java
@@ -15,7 +15,7 @@ package org.eclipse.syson.diagram.general.view;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractActionsCompartmentNodeDescriptionProvider;
-import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionToolProvider;
+import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionCompartmentToolProvider;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.DescriptionNameGenerator;
 
@@ -45,7 +45,7 @@ public class GVDescriptionNameGenerator extends DescriptionNameGenerator {
 
     @Override
     public String getCompartmentName(EClass eClass, EReference eReference) {
-        if (new StateTransitionActionToolProvider(eReference).isHandledAction()) {
+        if (new StateTransitionActionCompartmentToolProvider(eReference).isHandledAction()) {
             return this.getCompartmentName(this.getDiagramPrefix(), eClass.getName() + SPACE + AbstractActionsCompartmentNodeDescriptionProvider.ACTIONS_COMPARTMENT_LABEL);
         } else {
             return super.getCompartmentName(eClass, eReference);
@@ -54,7 +54,7 @@ public class GVDescriptionNameGenerator extends DescriptionNameGenerator {
 
     @Override
     public String getCompartmentItemName(EClass eClass, EReference eReference) {
-        if (new StateTransitionActionToolProvider(eReference).isHandledAction()) {
+        if (new StateTransitionActionCompartmentToolProvider(eReference).isHandledAction()) {
             return this.getCompartmentItemName(this.getDiagramPrefix(), eClass.getName() + SPACE + AbstractActionsCompartmentNodeDescriptionProvider.ACTION);
         } else {
             return super.getCompartmentItemName(eClass, eReference);

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/ActionsCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/ActionsCompartmentNodeDescriptionProvider.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.NodePalette;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractActionsCompartmentNodeDescriptionProvider;
-import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionToolProvider;
+import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionCompartmentToolProvider;
 import org.eclipse.syson.diagram.general.view.GeneralViewDiagramDescriptionProvider;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 
@@ -73,7 +73,7 @@ public class ActionsCompartmentNodeDescriptionProvider extends AbstractActionsCo
 
         List<EReference> refList = GeneralViewDiagramDescriptionProvider.COMPARTMENTS_WITH_MERGED_LIST_ITEMS.get(this.eClass);
         if (refList != null) {
-            refList.stream().map(eReference -> new StateTransitionActionToolProvider(eReference).create(cache)).forEach(nodeTool -> {
+            refList.stream().map(eReference -> new StateTransitionActionCompartmentToolProvider(eReference).create(cache)).forEach(nodeTool -> {
                 nodeToolSection.getNodeTools().add(nodeTool);
             });
         }

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ChildPartUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ChildPartUsageNodeDescriptionProvider.java
@@ -155,7 +155,7 @@ public class ChildPartUsageNodeDescriptionProvider extends AbstractNodeDescripti
                 .dropNodeTool(this.createDropFromDiagramTool(cache))
                 .labelEditTool(editTool.build())
                 .toolSections(this.createNodeToolSection(cache),
-                        this.toolDescriptionService.addElementsNodeToolSection(),
+                        this.toolDescriptionService.addElementsNodeToolSection(true),
                         this.defaultToolsFactory.createDefaultHideRevealNodeToolSection())
                 .build();
     }

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/FirstLevelChildPartUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/FirstLevelChildPartUsageNodeDescriptionProvider.java
@@ -159,7 +159,7 @@ public class FirstLevelChildPartUsageNodeDescriptionProvider extends AbstractNod
                 .dropNodeTool(this.createDropFromDiagramTool(cache))
                 .labelEditTool(editTool.build())
                 .toolSections(this.createNodeToolSection(cache),
-                        this.toolDescriptionService.addElementsNodeToolSection(),
+                        this.toolDescriptionService.addElementsNodeToolSection(true),
                         this.defaultToolsFactory.createDefaultHideRevealNodeToolSection())
                 .build();
     }

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootDefinitionNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootDefinitionNodeDescriptionProvider.java
@@ -128,7 +128,7 @@ public class RootDefinitionNodeDescriptionProvider extends AbstractNodeDescripti
         return this.diagramBuilderHelper.newNodePalette()
                 .labelEditTool(editTool.build())
                 .dropNodeTool(this.createDropFromDiagramTool(cache))
-                .toolSections(this.createNodeToolSection(cache), this.toolDescriptionService.addElementsNodeToolSection())
+                .toolSections(this.createNodeToolSection(cache), this.toolDescriptionService.addElementsNodeToolSection(true))
                 .build();
     }
 

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootUsageNodeDescriptionProvider.java
@@ -128,7 +128,7 @@ public class RootUsageNodeDescriptionProvider extends AbstractNodeDescriptionPro
         return this.diagramBuilderHelper.newNodePalette()
                 .labelEditTool(editTool.build())
                 .dropNodeTool(this.createDropFromDiagramTool(cache))
-                .toolSections(this.createNodeToolSection(cache), this.toolDescriptionService.addElementsNodeToolSection())
+                .toolSections(this.createNodeToolSection(cache), this.toolDescriptionService.addElementsNodeToolSection(true))
                 .build();
     }
 

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/STVDescriptionNameGenerator.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/STVDescriptionNameGenerator.java
@@ -15,7 +15,7 @@ package org.eclipse.syson.diagram.statetransition.view;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractActionsCompartmentNodeDescriptionProvider;
-import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionToolProvider;
+import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionCompartmentToolProvider;
 import org.eclipse.syson.util.DescriptionNameGenerator;
 
 /**
@@ -31,7 +31,7 @@ public class STVDescriptionNameGenerator extends DescriptionNameGenerator {
     
     @Override
     public String getCompartmentName(EClass eClass, EReference eReference) {
-        if (new StateTransitionActionToolProvider(eReference).isHandledAction()) {
+        if (new StateTransitionActionCompartmentToolProvider(eReference).isHandledAction()) {
             return this.getCompartmentName(this.getDiagramPrefix(), eClass.getName() + SPACE + AbstractActionsCompartmentNodeDescriptionProvider.ACTIONS_COMPARTMENT_LABEL);
         } else {
             return super.getCompartmentName(eClass, eReference);
@@ -40,7 +40,7 @@ public class STVDescriptionNameGenerator extends DescriptionNameGenerator {
     
     @Override
     public String getCompartmentItemName(EClass eClass, EReference eReference) {
-        if (new StateTransitionActionToolProvider(eReference).isHandledAction()) {
+        if (new StateTransitionActionCompartmentToolProvider(eReference).isHandledAction()) {
             return this.getCompartmentItemName(this.getDiagramPrefix(), eClass.getName() + SPACE + AbstractActionsCompartmentNodeDescriptionProvider.ACTION);
         } else {
             return super.getCompartmentItemName(eClass, eReference);

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/StateTransitionViewDiagramDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/StateTransitionViewDiagramDescriptionProvider.java
@@ -64,8 +64,7 @@ public class StateTransitionViewDiagramDescriptionProvider implements IRepresent
             );
 
     public static  final List<EClass> USAGES = List.of(
-            SysmlPackage.eINSTANCE.getStateUsage(),
-            SysmlPackage.eINSTANCE.getExhibitStateUsage()
+            SysmlPackage.eINSTANCE.getStateUsage()
             );
     
     public static  final Map<EClass, List<EReference>> COMPARTMENTS_WITH_LIST_ITEMS = Map.ofEntries(
@@ -125,6 +124,13 @@ public class StateTransitionViewDiagramDescriptionProvider implements IRepresent
             diagramElementDescriptionProviders.add(new UsageNodeDescriptionProvider(usage, colorProvider, this.getDescriptionNameGenerator()));
         });
 
+        COMPARTMENTS_WITH_MERGED_LIST_ITEMS.forEach((eClass, listItems) -> {
+            listItems.forEach(eReference -> {
+                diagramElementDescriptionProviders.add(new StateTransitionActionsCompartmentNodeDescriptionProvider(eClass, eReference, colorProvider, this.getDescriptionNameGenerator()));
+            });
+            diagramElementDescriptionProviders.add(new MergedReferencesCompartmentItemNodeDescriptionProvider(eClass, listItems, colorProvider, this.getDescriptionNameGenerator()));
+        });
+
         COMPARTMENTS_WITH_LIST_ITEMS.forEach((eClass, listItems) -> {
             listItems.forEach(eReference -> {
                 if (SysmlPackage.eINSTANCE.getStateUsage().equals(eClass) && SysmlPackage.eINSTANCE.getUsage_NestedState().equals(eReference)) {
@@ -138,13 +144,6 @@ public class StateTransitionViewDiagramDescriptionProvider implements IRepresent
                     diagramElementDescriptionProviders.add(new CompartmentItemNodeDescriptionProvider(eClass, eReference, colorProvider, this.getDescriptionNameGenerator()));
                 }
             });
-        });
-
-        COMPARTMENTS_WITH_MERGED_LIST_ITEMS.forEach((eClass, listItems) -> {
-            listItems.forEach(eReference -> {
-                diagramElementDescriptionProviders.add(new StateTransitionActionsCompartmentNodeDescriptionProvider(eClass, eReference, colorProvider, this.getDescriptionNameGenerator()));
-            });
-            diagramElementDescriptionProviders.add(new MergedReferencesCompartmentItemNodeDescriptionProvider(eClass, listItems, colorProvider, this.getDescriptionNameGenerator()));
         });
 
         diagramElementDescriptionProviders.stream().

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/DefinitionNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/DefinitionNodeDescriptionProvider.java
@@ -74,7 +74,6 @@ public class DefinitionNodeDescriptionProvider extends AbstractDefinitionNodeDes
                 });
             }
         });
-
         return reusedChildren;
     }
 

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/FakeNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/FakeNodeDescriptionProvider.java
@@ -69,7 +69,8 @@ public class FakeNodeDescriptionProvider extends AbstractFakeNodeDescriptionProv
                 .ifPresent(childrenNodes::add);
         cache.getNodeDescription(this.descriptionNameGenerator.getFreeFormCompartmentName(SysmlPackage.eINSTANCE.getStateUsage(), SysmlPackage.eINSTANCE.getUsage_NestedState()))
                 .ifPresent(childrenNodes::add);
-
+        cache.getNodeDescription(this.descriptionNameGenerator.getFreeFormCompartmentName(SysmlPackage.eINSTANCE.getExhibitStateUsage(), SysmlPackage.eINSTANCE.getUsage_NestedState()))
+                .ifPresent(childrenNodes::add);
         return childrenNodes;
     }
 }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/StateTransitionActionsCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/StateTransitionActionsCompartmentNodeDescriptionProvider.java
@@ -24,7 +24,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.NodePalette;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractActionsCompartmentNodeDescriptionProvider;
-import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionToolProvider;
+import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionCompartmentToolProvider;
 import org.eclipse.syson.diagram.statetransition.view.StateTransitionViewDiagramDescriptionProvider;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 
@@ -73,7 +73,7 @@ public class StateTransitionActionsCompartmentNodeDescriptionProvider extends Ab
         
         List<EReference> refList = StateTransitionViewDiagramDescriptionProvider.COMPARTMENTS_WITH_MERGED_LIST_ITEMS.get(eClass);
         if (refList != null) {
-            refList.stream().map(eReference -> new StateTransitionActionToolProvider(eReference).create(cache)).forEach(nodeTool -> {
+            refList.stream().map(eReference -> new StateTransitionActionCompartmentToolProvider(eReference).create(cache)).forEach(nodeTool -> {
                 nodeToolSection.getNodeTools().add(nodeTool);
             });
         }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/UsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/UsageNodeDescriptionProvider.java
@@ -74,7 +74,6 @@ public class UsageNodeDescriptionProvider extends AbstractUsageNodeDescriptionPr
                 });
             }
         });
-
         return reusedChildren;
     }
 

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/services/StateTransitionViewNodeToolSectionSwitch.java
@@ -21,9 +21,11 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.syson.diagram.common.view.services.AbstractViewNodeToolSectionSwitch;
+import org.eclipse.syson.diagram.common.view.services.description.ToolDescriptionService;
 import org.eclipse.syson.diagram.common.view.tools.CompartmentNodeToolProvider;
-import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionToolProvider;
+import org.eclipse.syson.diagram.common.view.tools.StateTransitionActionCompartmentToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.StateTransitionCompartmentNodeToolProvider;
+import org.eclipse.syson.diagram.common.view.tools.StateTransitionToggleExhibitStateToolProvider;
 import org.eclipse.syson.diagram.statetransition.view.StateTransitionViewDiagramDescriptionProvider;
 import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Element;
@@ -42,6 +44,8 @@ import org.eclipse.syson.util.IDescriptionNameGenerator;
 public class StateTransitionViewNodeToolSectionSwitch extends AbstractViewNodeToolSectionSwitch {
 
     private final List<NodeDescription> allNodeDescriptions;
+
+    private final ToolDescriptionService toolDescriptionService = new ToolDescriptionService();
 
     public StateTransitionViewNodeToolSectionSwitch(List<NodeDescription> allNodeDescriptions, IDescriptionNameGenerator descriptionNameGenerator) {
         super(descriptionNameGenerator);
@@ -79,43 +83,46 @@ public class StateTransitionViewNodeToolSectionSwitch extends AbstractViewNodeTo
 
     @Override
     public List<NodeToolSection> caseDefinition(Definition object) {
-        var createSection = this.buildCreateSection();
+        var createSection = this.toolDescriptionService.buildCreateSection();
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
         return List.of(createSection);
     }
 
     @Override
     public List<NodeToolSection> caseStateDefinition(StateDefinition object) {
-        var createSection = this.buildCreateSection(
+        var createSection = this.toolDescriptionService.buildCreateSection(
                 new StateTransitionCompartmentNodeToolProvider(false, false).create(null),
                 new StateTransitionCompartmentNodeToolProvider(true, false).create(null),
                 new StateTransitionCompartmentNodeToolProvider(false, true).create(null),
                 new StateTransitionCompartmentNodeToolProvider(true, true).create(null),
-                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_EntryAction()).create(null),
-                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_DoAction()).create(null),
-                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_ExitAction()).create(null),
+                new StateTransitionActionCompartmentToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_EntryAction()).create(null),
+                new StateTransitionActionCompartmentToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_DoAction()).create(null),
+                new StateTransitionActionCompartmentToolProvider(SysmlPackage.eINSTANCE.getStateDefinition_ExitAction()).create(null),
                 new CompartmentNodeToolProvider(SysmlPackage.eINSTANCE.getElement_Documentation(), this.descriptionNameGenerator).create(null));
-        return List.of(createSection, this.addElementsToolSection());
+        return List.of(createSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 
     @Override
     public List<NodeToolSection> caseStateUsage(StateUsage object) {
-        var createSection = this.buildCreateSection(
+        var createSection = this.toolDescriptionService.buildCreateSection(
                 new StateTransitionCompartmentNodeToolProvider(false, false).create(null),
                 new StateTransitionCompartmentNodeToolProvider(true, false).create(null),
                 new StateTransitionCompartmentNodeToolProvider(false, true).create(null),
                 new StateTransitionCompartmentNodeToolProvider(true, true).create(null),
-                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateUsage_EntryAction()).create(null),
-                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateUsage_DoAction()).create(null),
-                new StateTransitionActionToolProvider(SysmlPackage.eINSTANCE.getStateUsage_ExitAction()).create(null),
+                new StateTransitionActionCompartmentToolProvider(SysmlPackage.eINSTANCE.getStateUsage_EntryAction()).create(null),
+                new StateTransitionActionCompartmentToolProvider(SysmlPackage.eINSTANCE.getStateUsage_DoAction()).create(null),
+                new StateTransitionActionCompartmentToolProvider(SysmlPackage.eINSTANCE.getStateUsage_ExitAction()).create(null),
                 new CompartmentNodeToolProvider(SysmlPackage.eINSTANCE.getElement_Documentation(), this.descriptionNameGenerator).create(null));
-        return List.of(createSection, this.addElementsToolSection());
+        var editSection = this.toolDescriptionService.buildEditSection(
+                new StateTransitionToggleExhibitStateToolProvider(true).create(null),
+                new StateTransitionToggleExhibitStateToolProvider(false).create(null));
+        return List.of(createSection, editSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 
     @Override
     public List<NodeToolSection> caseUsage(Usage object) {
-        var createSection = this.buildCreateSection();
+        var createSection = this.toolDescriptionService.buildCreateSection();
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
-        return List.of(createSection, this.addElementsToolSection());
+        return List.of(createSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
 }


### PR DESCRIPTION
- Add contextual palette tools to "Exhibit" or "Set as not exhibited" a state
- Add properties view checkbox "is Exhibited" to exhibit or unexhibit a state
- Modify the way to directly create an exhibit state, now creates a State and and ExhibitState and adds the relation instead of relying on an ExhibitState without setting "exhibitedState".
- Refactor services
- GeneralView diagram still requires adjustments on the display of states and exhibit

Bug: https://github.com/eclipse-syson/syson/issues/393