### PR TITLE
[459] Correct Documentation import

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -60,6 +60,7 @@ A reset of the database is needed.
 - https://github.com/eclipse-syson/syson/issues/364[#364] [export] Fix names used during export in FeatureChainExpression
 - https://github.com/eclipse-syson/syson/issues/363[#363] [export] Fix the first part of the InvocationExpression during export
 - https://github.com/eclipse-syson/syson/issues/341[#341] [export] Fix missing element names in the expressions during export
+- https://github.com/eclipse-syson/syson/issues/459[#459] [import] Fix documentation import to remove /* */ around texts
 
 === Improvements
 

--- a/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/parser/AstObjectParser.java
+++ b/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/parser/AstObjectParser.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class AstObjectParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AstObjectParser.class);
-    
+
     public void setObjectAttribute(final EObject eObject, final JsonNode astJson) {
         for (final EAttribute attribute : eObject.eClass().getEAllAttributes()) {
             if (attribute.isDerived() || attribute.isUnsettable()) {
@@ -72,9 +72,12 @@ public class AstObjectParser {
                             eObject.eSet(attribute, astJson.get(mappedName).asBoolean());
                             break;
                         case "EString":
-                            final String name = AstConstant.asCleanedText(astJson.get(mappedName));
-                            if (!name.equals("null")) {
-                                eObject.eSet(attribute, name);
+                            String textContent = AstConstant.asCleanedText(astJson.get(mappedName));
+                            if (attribute.equals(SysmlPackage.eINSTANCE.getComment_Body())) {
+                                textContent = textContent.replaceFirst("^/\\*", "").replaceFirst("\\*/", "").trim();
+                            }
+                            if (!textContent.equals("null")) {
+                                eObject.eSet(attribute, textContent);
                             }
                             break;
                         case "FeatureDirectionKind":
@@ -93,8 +96,7 @@ public class AstObjectParser {
 
     public EObject createObject(final JsonNode astJson) {
         String type = astJson.findValue(AstConstant.TYPE_CONST).textValue();
-    
-    
+
         if (type.equals("MembershipReference")) {
             type = "Membership";
         }
@@ -119,8 +121,7 @@ public class AstObjectParser {
         if (type.equals("MembershipReference")) {
             type = "Membership";
         }
-        
-    
+
         if (type.equals("NamespaceReference")) {
             type = "Namespace";
         }
@@ -136,11 +137,10 @@ public class AstObjectParser {
                 }
             }
         }
-        
-    
+
         final EClassifier classif = SysmlPackage.eINSTANCE.getEClassifier(type);
         final EClassImpl eclassImpl = (EClassImpl) classif;
-    
+
         if (classif == null) {
             return null;
         } else {
@@ -152,9 +152,7 @@ public class AstObjectParser {
         String computedAttributeName = attributeName;
         if (eObject instanceof LiteralInteger && "value".equals(attributeName)) {
             computedAttributeName = "literal";
-        }   
+        }
         return computedAttributeName;
     }
 }
-
-

--- a/backend/application/syson-sysml-import/src/test/java/org/eclipse/syson/sysml/ASTTransformerTest.java
+++ b/backend/application/syson-sysml-import/src/test/java/org/eclipse/syson/sysml/ASTTransformerTest.java
@@ -455,6 +455,44 @@ public class ASTTransformerTest {
     }
 
     /**
+     * Test Containement reference
+     */
+    @Test
+    void convertDocumentationTest() {
+        ASTTransformer transformer = new ASTTransformer();
+        String fileContent = """
+            {
+                "$type": "Namespace",
+                "children": [
+                    {
+                        "$type": "OwningMembership",
+                        "target": {
+                            "$type": "Documentation",
+                            "body": "/* TEST */"
+                        }
+                    }
+                ]
+            }
+            """;
+        Resource result = transformer.convertResource(new ByteArrayInputStream(fileContent.getBytes()), new ResourceSetImpl());
+
+        var content = result.getContents();
+        assertEquals(1, content.size());
+        EObject object = content.get(0);
+        assertInstanceOf(Namespace.class, object);
+
+        Namespace namespace = (Namespace) object;
+        assertEquals(1, namespace.getOwnedElement().size());
+        assertNotNull(namespace.getOwnedRelationship().get(0).getOwnedElement());
+        assertEquals(1, namespace.getMember().size());
+        EObject documentationObject = namespace.getMember().get(0);
+        assertInstanceOf(Documentation.class, documentationObject);
+
+        assertEquals("TEST", ((Documentation) documentationObject).getBody());
+    }
+
+
+    /**
      * Test convertAssignmentTEst
      */
     @Test


### PR DESCRIPTION
When documentation is imported from a textual sysml file, the useful text is framed by /*  */, which, according to the sysml specification, should not be part of the documentation itself.

This should be fixed in the import module, by only adding the content of the textual documentation.