### PR TITLE
[doc] Fix errors in documentation

### DIFF
--- a/doc/content/modules/installation-guide/pages/troubleshooting.adoc
+++ b/doc/content/modules/installation-guide/pages/troubleshooting.adoc
@@ -28,4 +28,4 @@ Make sure you have included the correct argument to your `java` command accordin
 
 TIP: Check that you are consulting the documentation version that matches the JAR version you are trying to run.
 
-Refer to the xref:installation-guide:install.adoc#start-app[] section for detailed instructions according to your version.
+Refer to the xref:installation-guide:how-tos/install.adoc#start-app[] section for detailed instructions according to your version.

--- a/doc/content/modules/user-manual/pages/features/action-flow-view.adoc
+++ b/doc/content/modules/user-manual/pages/features/action-flow-view.adoc
@@ -1,6 +1,6 @@
 = {afv}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {afv} describes input and output flows between different actions within a system.
 This type of diagram is useful for understanding and analyzing the dynamic behavior of a system, focusing on action sequences and interaction between system elements.

--- a/doc/content/modules/user-manual/pages/features/details.adoc
+++ b/doc/content/modules/user-manual/pages/features/details.adoc
@@ -1,6 +1,6 @@
 = {details}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {details} view provides a comprehensive overview of the selected element, presenting distinct _Property_ sections for each _characteristic_ of the semantic object.
 

--- a/doc/content/modules/user-manual/pages/features/editor.adoc
+++ b/doc/content/modules/user-manual/pages/features/editor.adoc
@@ -1,6 +1,6 @@
 = {editor}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 == What's the {editor}?
 

--- a/doc/content/modules/user-manual/pages/features/explorer.adoc
+++ b/doc/content/modules/user-manual/pages/features/explorer.adoc
@@ -1,6 +1,6 @@
 = {explorer}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {explorer} presents a hierarchical view of all models and their contents within the project, displayed as a tree structure with expandable and collapsible items.
 

--- a/doc/content/modules/user-manual/pages/features/general-view.adoc
+++ b/doc/content/modules/user-manual/pages/features/general-view.adoc
@@ -1,6 +1,6 @@
 = {gv}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {gv} is employed to display any members of exposed model elements.
 it's the most general view, enabling presentation of any model element.

--- a/doc/content/modules/user-manual/pages/features/homepage.adoc
+++ b/doc/content/modules/user-manual/pages/features/homepage.adoc
@@ -1,7 +1,7 @@
 :homepage: Projects browser
 = {homepage}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 == What's the {homepage}?
 

--- a/doc/content/modules/user-manual/pages/features/interconnection-view.adoc
+++ b/doc/content/modules/user-manual/pages/features/interconnection-view.adoc
@@ -1,6 +1,6 @@
 = {iv}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {iv} is used to show encapsulated structural contents of _Usage- element: Parts, Properties, Connectors, Ports, and Interfaces.
 

--- a/doc/content/modules/user-manual/pages/features/keyboard-shortcuts.adoc
+++ b/doc/content/modules/user-manual/pages/features/keyboard-shortcuts.adoc
@@ -1,6 +1,6 @@
 = Keyboard shortcuts
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 == General
 

--- a/doc/content/modules/user-manual/pages/features/related-elements.adoc
+++ b/doc/content/modules/user-manual/pages/features/related-elements.adoc
@@ -1,6 +1,6 @@
 = {related-elements}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 For a more focused exploration, delve into the {related-elements} view.
 

--- a/doc/content/modules/user-manual/pages/features/representations-view.adoc
+++ b/doc/content/modules/user-manual/pages/features/representations-view.adoc
@@ -1,6 +1,6 @@
 = {representations-view}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 Explore the {representations-view} view to gain insights into the available representations associated with the  selected element.
 

--- a/doc/content/modules/user-manual/pages/features/state-transition-view.adoc
+++ b/doc/content/modules/user-manual/pages/features/state-transition-view.adoc
@@ -1,6 +1,6 @@
 = State transition view
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {stv} is describes the logical transition of a system through various states of a system and the transitions between those states.
 This view shows the behavior of complex system, for example how it evolves over time in response to specific events/stimuli.

--- a/doc/content/modules/user-manual/pages/features/validation.adoc
+++ b/doc/content/modules/user-manual/pages/features/validation.adoc
@@ -1,6 +1,6 @@
 = {validation}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {validation} view displays diagnostics for the entire project, organized by their kind such as `ERROR`, `WARNING`, or `INFO`.
 Users can conveniently toggle the visibility of diagnostics by using an accordion widget.

--- a/doc/content/modules/user-manual/pages/hands-on/how-tos/explorer.adoc
+++ b/doc/content/modules/user-manual/pages/hands-on/how-tos/explorer.adoc
@@ -3,7 +3,7 @@
 [#sync-editor]
 == Synchronize {explorer} / {editor}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 It's possible to turn-off and turn-on the synchronization between the {explorer} and the current selection in the {editor}.
 
@@ -23,7 +23,7 @@ When synchronization is disabled, tree items that are already expanded in the {e
 [#expand-all]
 == Expand all
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 [WARNING]
 ====
@@ -43,7 +43,7 @@ This action expands the selected element and all its children recursively, offer
 [#explorer-filter]
 == Filter elements in the {explorer}
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 === Filter from name
 

--- a/doc/content/modules/user-manual/pages/hands-on/how-tos/model-management.adoc
+++ b/doc/content/modules/user-manual/pages/hands-on/how-tos/model-management.adoc
@@ -3,7 +3,7 @@
 [#create-model]
 == Create a new model
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 To create a model, follow these steps from the explorer toolbar:
 
@@ -22,7 +22,7 @@ image::hands-on-new-model-result.png[New Model result]
 [#upload-model]
 == Upload a model
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 [NOTE]
 ====
@@ -45,7 +45,7 @@ image::hands-on-upload-model.png[Upload model]
 [#rename-model]
 == Rename a model
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 You can update the model name from the {explorer}:
 
@@ -57,7 +57,7 @@ You can update the model name from the {explorer}:
 [#delete-model]
 == Delete a model
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 [WARNING]
 ====
@@ -93,7 +93,7 @@ You can reset it by deleting the {product} data in cache of your browser.
 [#download-model]
 == Download a model
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 You can download a model from the {explorer}:
 
@@ -111,7 +111,7 @@ The JSON format used by {product} is specific to the tool.
 [#create-element]
 == Create a new element
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The process to create a new element in a model involves the following steps:
 
@@ -126,7 +126,7 @@ Upon completion, the newly created element is automatically selected in the {exp
 
 == Read an element
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 . To navigate through the details of a semantic element, use the {explorer} to navigate through the model and locate the needed element.
 . Select the element in the {explorer}.
@@ -138,7 +138,7 @@ image::hands-on-read-element.png[Read element]
 [#rename-element]
 == Rename an element
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 It's possible to rename an element either from the {explorer}, the {details} view or a representation.
 
@@ -185,7 +185,7 @@ Instead of using the tool in the toolbar, you can press `F2` key or start typing
 [#update-element]
 == Update an element
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 It's possible to update element properties either from the {details} view or a representation.
 
@@ -220,7 +220,7 @@ A powerful syntax exists for editing element properties directly through the dir
 [#delete-element]
 == Delete an element
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 [WARNING]
 ====
@@ -265,7 +265,7 @@ You can reset it by deleting the {product} data in cache of your browser.
 [#direct-edit]
 == Direct edit tool and shortcuts
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The {product} supports a subset of the {sysmlv2} textual syntax, which allows you to update several elements simultaneously.
 This makes it more efficient to edit models.

--- a/doc/content/modules/user-manual/pages/hands-on/how-tos/project-management.adoc
+++ b/doc/content/modules/user-manual/pages/hands-on/how-tos/project-management.adoc
@@ -3,7 +3,7 @@
 [#create-blank-project]
 == Create a blank project
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 To create a new Blank project, user has to click on _Blank project_ card at the top of the homepage.
 
@@ -22,7 +22,7 @@ Refer to the xref:features/editor.adoc[{editor} page] to understand how to use i
 [#create-template-project]
 == Create a project based on a template
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 To create a new project from a `Template`:
 
@@ -57,7 +57,7 @@ Refer to the xref:features/editor.adoc[{editor} page] to understand how to use i
 [#upload-project]
 == Upload a Project
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 [NOTE]
 ====
@@ -84,7 +84,7 @@ Refer to the xref:features/editor.adoc[{editor} page] to understand how to use i
 [#delete-project]
 == Delete a project
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 It's possible to delete a project either from the {homepage} or the {editor}.
 
@@ -121,7 +121,7 @@ image::hands-on-delete-project-editor.png[Delete Project from editor]
 [#rename-project]
 == Rename a project
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 It's possible to rename a project either from the {homepage} or the {editor}.
 
@@ -162,7 +162,7 @@ image::hands-on-rename-project-editor.png[Rename Project from editor]
 [#download-project]
 == Download a project
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 It's possible to download a project either from the {homepage} or the {editor}.
 
@@ -193,7 +193,7 @@ image::hands-on-download-project-editor.png[Download Project from editor]
 [#share-project]
 == Share a project
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 Sharing a project is as straightforward as providing the project URL to someone because everything within {product} is public.
 Once the project URL is shared, the recipient can access and view the project directly.
@@ -202,7 +202,7 @@ This simplicity in sharing allows for seamless collaboration and communication o
 [#project-settings]
 == Manage project settings
 
-include::user-manual:partial$before-you-start-os-experimental-all.adoc[]
+include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 The purpose of this page is to present the various settings manageable by the administrator of a project.
 Currently, capabilities are limited to functions such as uploading images, but additional features for project management will be introduced in future updates.

--- a/doc/content/modules/user-manual/partials/before-you-start-experimental-all.adoc
+++ b/doc/content/modules/user-manual/partials/before-you-start-experimental-all.adoc
@@ -1,0 +1,9 @@
+.Before you Start
+[caption=]
+====
+// Status
+include::user-manual:partial$feature-status-experimental.adoc[]
+
+// Usage
+include::user-manual:partial$feature-usage-all.adoc[]
+====


### PR DESCRIPTION
Contribute a new partial "before you start" which specify features status and usage which is used by all the sections describing a feature. 
Fix a reference in the troubleshooting page.