### PR TITLE
[468] Rename creation tools for Start and Done actions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -80,6 +80,7 @@ But, if you encounter execution rights problem, you can still copy _syside-cli.j
 - https://github.com/eclipse-syson/syson/issues/445[#445] [diagrams] Improve the way node descriptions are retrieved for a given semantic element
 - https://github.com/eclipse-syson/syson/issues/439[#439] [diagrams] Handle Perform action concept in diagrams
 - https://github.com/eclipse-syson/syson/issues/460[#460] [details] Extra property "Typed by" is now always visible in the details view for _Feature_ elements, even if the _Feature_ doesn't have a type yet.
+- https://github.com/eclipse-syson/syson/issues/468[#468] [diagrams] Rename creation tools for Start and Done actions
 
 === New features
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/DoneActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/DoneActionNodeToolProvider.java
@@ -41,7 +41,7 @@ public class DoneActionNodeToolProvider extends AbstractFreeFormCompartmentNodeT
 
     @Override
     protected String getLabel() {
-        return "Add Done Action";
+        return "New Done Action";
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StartActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StartActionNodeToolProvider.java
@@ -41,7 +41,7 @@ public class StartActionNodeToolProvider extends AbstractFreeFormCompartmentNode
 
     @Override
     protected String getLabel() {
-        return "Add Start Action";
+        return "New Start Action";
     }
 
     @Override


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/468