### PR TITLE
[470] Reduce the default height of the Package node in diagrams

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -81,6 +81,7 @@ But, if you encounter execution rights problem, you can still copy _syside-cli.j
 - https://github.com/eclipse-syson/syson/issues/439[#439] [diagrams] Handle Perform action concept in diagrams
 - https://github.com/eclipse-syson/syson/issues/460[#460] [details] Extra property "Typed by" is now always visible in the details view for _Feature_ elements, even if the _Feature_ doesn't have a type yet.
 - https://github.com/eclipse-syson/syson/issues/468[#468] [diagrams] Rename creation tools for Start and Done actions
+- https://github.com/eclipse-syson/syson/issues/470[#470] [diagrams] Reduce the default height of the Package node in diagrams 
 
 === New features
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPackageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPackageNodeDescriptionProvider.java
@@ -105,7 +105,7 @@ public abstract class AbstractPackageNodeDescriptionProvider extends AbstractNod
         return this.diagramBuilderHelper.newNodeDescription()
                 .collapsible(true)
                 .childrenLayoutStrategy(new FreeFormLayoutStrategyDescriptionBuilder().build())
-                .defaultHeightExpression("300")
+                .defaultHeightExpression("101")
                 .defaultWidthExpression("300")
                 .domainType(domainType)
                 .insideLabel(this.createInsideLabelDescription())


### PR DESCRIPTION
bug: https://github.com/eclipse-syson/syson/issues/470