### PR TITLE
[477] Add Direct Edit tool in control nodes palette

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -84,6 +84,7 @@ But, if you encounter execution rights problem, you can still copy _syside-cli.j
 - https://github.com/eclipse-syson/syson/issues/470[#470] [diagrams] Reduce the default height of the Package node in diagrams 
 - https://github.com/eclipse-syson/syson/issues/472[#472] [properties] Move Feature#direction in Core tab of the Details view
 - https://github.com/eclipse-syson/syson/issues/475[#475] [explorer] Sort New Object menu entries
+- https://github.com/eclipse-syson/syson/issues/477[#477] [diagrams] Add Direct Edit tool in control nodes palette
 
 === New features
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractControlNodeActionNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractControlNodeActionNodeDescriptionProvider.java
@@ -140,11 +140,20 @@ public abstract class AbstractControlNodeActionNodeDescriptionProvider extends A
                 .name(this.getRemoveToolLabel())
                 .body(changeContext.build());
 
+        var callEditService = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLUtils.getSelfServiceCallExpression("directEdit", "newLabel"));
+
+        var editTool = this.diagramBuilderHelper.newLabelEditTool()
+                .name("Edit")
+                .initialDirectEditLabelExpression(AQLUtils.getSelfServiceCallExpression("getDefaultInitialDirectEditLabel"))
+                .body(callEditService.build());
+
         var edgeTools = new ArrayList<EdgeTool>();
         edgeTools.addAll(this.getEdgeTools(cache));
 
         return this.diagramBuilderHelper.newNodePalette()
                 .deleteTool(deleteTool.build())
+                .labelEditTool(editTool.build())
                 .edgeTools(edgeTools.toArray(EdgeTool[]::new))
                 .toolSections(this.defaultToolsFactory.createDefaultHideRevealNodeToolSection())
                 .build();


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/477