### PR TITLE
[494] Change the default name of the transition element

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -94,6 +94,7 @@ The tool now works correctly on packages, and doesn't render sibling elements wh
 - https://github.com/eclipse-syson/syson/issues/483[#483] [diagrams] The empty/null values for subsetting/redefinition/subclassification/featureTyping are not displayed anymore in diagram node labels.
 - https://github.com/eclipse-syson/syson/issues/482[#482] [diagrams] Add tools for creating Ports with direction
 - https://github.com/eclipse-syson/syson/issues/492[#492] [diagrams] Add tools for creation Items with direction
+- https://github.com/eclipse-syson/syson/issues/494[#494] [diagrams] Change the default name of the transition element
 
 === New features
 

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
@@ -33,6 +33,7 @@ import org.eclipse.syson.sysml.Subclassification;
 import org.eclipse.syson.sysml.Subsetting;
 import org.eclipse.syson.sysml.SuccessionAsUsage;
 import org.eclipse.syson.sysml.SysmlFactory;
+import org.eclipse.syson.sysml.TransitionUsage;
 import org.eclipse.syson.sysml.Usage;
 import org.eclipse.syson.sysml.util.SysmlSwitch;
 
@@ -145,6 +146,20 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
     @Override
     public Element caseSuccessionAsUsage(SuccessionAsUsage object) {
         object.setDeclaredName("succession");
+        return object;
+    }
+
+    @Override
+    public Element caseTransitionUsage(TransitionUsage object) {
+        StringBuilder label = new StringBuilder();
+        var source = object.getSource();
+        var target = object.getTarget();
+        if (source != null && target != null) {
+            label = label.append(source.getName()).append("_to_").append(target.getName());
+        } else {
+            label.append("transition");
+        }
+        object.setDeclaredName(label.toString());
         return object;
     }
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewToolService.java
@@ -694,7 +694,6 @@ public class ViewToolService extends ToolService {
         // Create transition usage and add it to the parent element
         // sourceParentElement <>-> FeatureMembership -> RelatedElement = TransitionUsage
         TransitionUsage newTransitionUsage = SysmlFactory.eINSTANCE.createTransitionUsage();
-        this.elementInitializerSwitch.doSwitch(newTransitionUsage);
         var featureMembership = SysmlFactory.eINSTANCE.createFeatureMembership();
         featureMembership.getOwnedRelatedElement().add(newTransitionUsage);
         sourceParentElement.getOwnedRelationship().add(featureMembership);
@@ -716,6 +715,7 @@ public class ViewToolService extends ToolService {
         // Set Succession Source and Target Features
         succession.getOwnedRelationship().add(this.createConnectorEndFeatureMembership(sourceUsage));
         succession.getOwnedRelationship().add(this.createConnectorEndFeatureMembership(targetUsage));
+        this.elementInitializerSwitch.doSwitch(newTransitionUsage);
 
         return sourceUsage;
     }


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/494