### PR TITLE
Add visibility decorators

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -108,6 +108,7 @@ The tool now works correctly on packages, and doesn't render sibling elements wh
 - https://github.com/eclipse-syson/syson/issues/494[#494] [diagrams] Change the default name of the transition element
 - [syson] Provide new icons for State, Conjugation, Port (in,in/out,out) and Item (in,in/out,out).
 - https://github.com/eclipse-syson/syson/issues/519[#519] [diagrams] Add tools for creating _Items_ on _ActionDefinition_ in GeneralView and ActionFlowView.
+- https://github.com/eclipse-syson/syson/issues/504[#504] [syson] Add private and protected visibility decorators on all elements
 
 === New features
 

--- a/backend/metamodel/syson-sysml-metamodel-edit/src/main/java/org/eclipse/syson/sysml/provider/NamespaceItemProvider.java
+++ b/backend/metamodel/syson-sysml-metamodel-edit/src/main/java/org/eclipse/syson/sysml/provider/NamespaceItemProvider.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.syson.sysml.provider;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.edit.provider.ComposeableAdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedImage;
 import org.eclipse.emf.edit.provider.IItemPropertyDescriptor;
 import org.eclipse.syson.sysml.Namespace;
 import org.eclipse.syson.sysml.SysmlPackage;
@@ -181,6 +183,37 @@ public class NamespaceItemProvider extends ElementItemProvider {
     @Override
     public Object getImage(Object object) {
         return this.overlayImage(object, this.getResourceLocator().getImage("full/obj16/Namespace.svg"));
+    }
+
+    /**
+     * {@inheritDoc}.
+     *
+     * @generated NOT
+     */
+    @Override
+    protected Object overlayImage(Object object, Object image) {
+        Object superResult = super.overlayImage(object, image);
+        if (object instanceof Namespace namespace && namespace.getOwningMembership() != null) {
+            List<Object> images = new ArrayList<>(2);
+            images.add(image);
+            if (superResult != null) {
+                images.add(superResult);
+            }
+            switch (namespace.getOwningMembership().getVisibility()) {
+                case PRIVATE:
+                    images.add(this.getResourceLocator().getImage("full/ovr16/VisibilityKind_private.svg"));
+                    break;
+                case PROTECTED:
+                    images.add(this.getResourceLocator().getImage("full/ovr16/VisibilityKind_protected.svg"));
+                    break;
+                case PUBLIC:
+                    return image;
+                default:
+                    return image;
+            }
+            image = new ComposedImage(images);
+        }
+        return image;
     }
 
     /**

--- a/backend/metamodel/syson-sysml-metamodel-edit/src/main/resources/icons/full/ovr16/VisibilityKind_private.svg
+++ b/backend/metamodel/syson-sysml-metamodel-edit/src/main/resources/icons/full/ovr16/VisibilityKind_private.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+    <g style="opacity:1">
+        <path d="M9.125 11.315h6.124v2.201H9.125z" style="opacity:1;fill:#ec6a6d;fill-opacity:1;stroke:#ca2230;stroke-width:.831794;stroke-linecap:square;stroke-opacity:1"/>
+    </g>
+</svg>

--- a/backend/metamodel/syson-sysml-metamodel-edit/src/main/resources/icons/full/ovr16/VisibilityKind_protected.svg
+++ b/backend/metamodel/syson-sysml-metamodel-edit/src/main/resources/icons/full/ovr16/VisibilityKind_protected.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="VisibilityKind_protected.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
+  <g
+     id="g954"
+     transform="translate(6.7912959,7.3319201)"
+     style="stroke:#664f19;stroke-opacity:1">
+    <path
+       d="M 2.236492,8.0918306 4.3042983,0.4277534 m 0.947166,7.6640772 2.074745,-7.6640772"
+       style="fill:none;stroke:#664f19;stroke-width:1.338;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2-3" />
+    <path
+       d="M 0.70386341,5.9074512 H 7.9876409 M 1.4783214,2.9606385 h 7.2837775"
+       style="fill:none;stroke:#664f19;stroke-width:1.299;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4-6" />
+  </g>
+  <g
+     id="g839"
+     style="stroke:#d1a746;stroke-opacity:1"
+     transform="translate(-0.33211272,-0.32239974)">
+    <path
+       d="M 9.3680477,15.746221 11.435854,8.0821438 m 0.947166,7.6640772 2.074745,-7.6640772"
+       style="fill:none;stroke:#d1a746;stroke-width:1.0384px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path2" />
+    <path
+       d="M 2.659,3.564 H 4.54 M 2.859,2.803 H 4.74"
+       style="fill:none;stroke:#d1a746;stroke-width:0.258112px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="matrix(3.87229,0,0,3.87229,-2.461,-0.239)"
+       id="path4" />
+  </g>
+</svg>


### PR DESCRIPTION
This commits add two overlay decorators for both private and protected visibility, and includes the supporting code so that any SysMLv2 element which has such visibility will have an overlayed decorator.

We decided to not add the "public" decorator considering that currently everything is created "public" by default and that would clutter and add noise on the UI.