### PR TITLE
[606] Prevent nested part to be rendered as border nodes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -41,6 +41,7 @@ The changes are:
 - [releng] Add a dependency to CycloneDX to compute the backend software bill of materials during the build
 
 === Bug fixes
+- https://github.com/eclipse-syson/syson/issues/606[#606] [interconnection-view] Prevent nested part to be rendered as border nodes
 
 === Improvements
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/description/ToolDescriptionService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/description/ToolDescriptionService.java
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
+import org.eclipse.syson.sysml.FeatureMembership;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
@@ -252,6 +253,11 @@ public class ToolDescriptionService {
     /**
      * Returns the creation node tool description for the given Node Description to build a new node for the given
      * EClass.
+     * <p>
+     * This method creates a {@link FeatureMembership}, use
+     * {@link #createNodeTool(NodeDescription, EClass, EClass, NodeContainmentKind)} to specify the membership type to
+     * create.
+     * </p>
      *
      * @param nodeDescription
      *            the Node Description where the returned tool is added
@@ -259,6 +265,7 @@ public class ToolDescriptionService {
      *            the EClass that the returned tool is in charge of
      * @param nodeKind
      *            the kind of the node associated to the EClass that is built by the returned tool
+     * @return the created node tool
      */
     public NodeTool createNodeTool(NodeDescription nodeDescription, EClass eClass, NodeContainmentKind nodeKind) {
         return this.createNodeToolWithDirection(nodeDescription, eClass, nodeKind, null);
@@ -266,18 +273,62 @@ public class ToolDescriptionService {
 
     /**
      * Returns the creation node tool description for the given Node Description to build a new node for the given
-     * EClass (which must be a {@link Feature}.
+     * EClass.
+     *
+     * @param nodeDescription
+     *            the Node Description where the returned tool is added
+     * @param eClass
+     *            the EClass that the returned tool is in charge of
+     * @param membershipEClass
+     *            the EClass of the membership to create
+     * @param nodeKind
+     *            the kind of the node associated to the EClass that is built by the returned tool
+     * @return the created node tool
+     */
+    public NodeTool createNodeTool(NodeDescription nodeDescription, EClass eClass, EClass membershipEClass, NodeContainmentKind nodeKind) {
+        return this.createNodeToolWithDirection(nodeDescription, eClass, membershipEClass, nodeKind, null);
+    }
+
+    /**
+     * Returns the creation node tool description for the given Node Description to build a new node for the given
+     * EClass (which must be a {@link Feature}).
+     * <p>
+     * This method creates a {@link FeatureMembership}, use
+     * {@link #createNodeToolWithDirection(NodeDescription, EClass, EClass, NodeContainmentKind, FeatureDirectionKind)}
+     * to specify the membership type to create.
+     * </p>
      *
      * @param nodeDescription
      *            the Node Description where the returned tool is added
      * @param eClass
      *            the EClass that the returned tool is in charge of
      * @param nodeKind
+     *            the kind of the node associated to the EClass that is build by the returned tool
+     * @param direction
+     *            the feature direction
+     * @return the created node tool
+     */
+    public NodeTool createNodeToolWithDirection(NodeDescription nodeDescription, EClass eClass, NodeContainmentKind nodeKind, FeatureDirectionKind direction) {
+        return this.createNodeToolWithDirection(nodeDescription, eClass, SysmlPackage.eINSTANCE.getFeatureMembership(), nodeKind, direction);
+    }
+
+    /**
+     * Returns the creation node tool description for the given Node Description to build a new node for the given
+     * EClass (which must be a {@link Feature}).
+     *
+     * @param nodeDescription
+     *            the Node Description where the returned tool is added
+     * @param eClass
+     *            the EClass that the returned tool is in charge of
+     * @param membershipEClass
+     *            the EClass of the membership to create
+     * @param nodeKind
      *            the kind of the node associated to the EClass that is built by the returned tool
      * @param direction
      *            the feature direction
+     * @return the created node tool
      */
-    public NodeTool createNodeToolWithDirection(NodeDescription nodeDescription, EClass eClass, NodeContainmentKind nodeKind, FeatureDirectionKind direction) {
+    public NodeTool createNodeToolWithDirection(NodeDescription nodeDescription, EClass eClass, EClass membershipEClass, NodeContainmentKind nodeKind, FeatureDirectionKind direction) {
         // make sure that the given element is a feature to avoid error at runtime.
         if (!SysmlPackage.eINSTANCE.getFeature().isSuperTypeOf(eClass) && direction != null) {
             return this.createNodeTool(nodeDescription, eClass, nodeKind);
@@ -322,7 +373,7 @@ public class ToolDescriptionService {
                 .children(createEClassInstance.build(), createView.build());
 
         var createMembership = this.viewBuilderHelper.newCreateInstance()
-                .typeName(SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getFeatureMembership()))
+                .typeName(SysMLMetamodelHelper.buildQualifiedName(membershipEClass))
                 .referenceName(SysmlPackage.eINSTANCE.getElement_OwnedRelationship().getName())
                 .variableName("newFeatureMembership")
                 .children(changeContexMembership.build());

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ItemUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ItemUsageBorderNodeDescriptionProvider.java
@@ -31,7 +31,6 @@ import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.sirius.components.view.diagram.UserResizableDirection;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractNodeDescriptionProvider;
 import org.eclipse.syson.sysml.SysmlPackage;
-import org.eclipse.syson.util.AQLConstants;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -60,7 +59,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .domainType(domainType)
                 .outsideLabels(this.createOutsideLabelDescription())
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLConstants.AQL_SELF + "." + SysmlPackage.eINSTANCE.getUsage_NestedItem().getName())
+                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getParameters"))
                 .style(this.createItemUnsetNodeStyle())
                 .conditionalStyles(this.createItemUsageConditionalNodeStyles().toArray(ConditionalNodeStyle[]::new))
                 .userResizable(UserResizableDirection.NONE)

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeService.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeService.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.interconnection.view.services;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.sirius.components.core.api.IObjectService;
@@ -96,6 +97,21 @@ public class InterconnectionViewNodeService extends ViewNodeService {
             this.logger.warn("Cannot get {} from the provided element {}", ActionUsage.class.getSimpleName(), element);
         }
         return actionUsages;
+    }
+
+    /**
+     * Returns the parameters of the provided element.
+     *
+     * @param element
+     *            the element
+     * @return the features that are parameters of the provided {@code element}
+     */
+    public List<Feature> getParameters(Element element) {
+        List<Feature> parameters = new ArrayList<>();
+        if (element instanceof ActionUsage actionUsage) {
+            parameters = actionUsage.getParameter();
+        }
+        return parameters;
     }
 
     public boolean isInFeature(Feature feature) {

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeToolSectionSwitch.java
@@ -97,10 +97,14 @@ public class InterconnectionViewNodeToolSectionSwitch extends AbstractViewNodeTo
 
         NodeDescription itemNodeDescription = this.cache.getNodeDescription(this.descriptionNameGenerator.getBorderNodeName(SysmlPackage.eINSTANCE.getItemUsage())).get();
         createSection.getNodeTools().addAll(List.of(
-                this.toolDescriptionService.createNodeTool(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), NodeContainmentKind.BORDER_NODE),
-                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.IN),
-                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.INOUT),
-                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.OUT)));
+                this.toolDescriptionService.createNodeTool(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                        NodeContainmentKind.BORDER_NODE),
+                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                        NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.IN),
+                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                        NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.INOUT),
+                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                        NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.OUT)));
 
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
         createSection.getNodeTools().add(new ActionFlowCompartmentNodeToolProvider().create(null));

--- a/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
@@ -43,6 +43,8 @@ The changes are:
 - Add a dependency to CycloneDX to compute the backend software bill of materials during the build
 
 == Bug fixes
+- Prevent nested part to be rendered as border nodes in the Interconnection View diagram
+
 
 == Improvements
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/606