### PR TITLE
[606] Prevent nested part to be rendered as border nodes

### DIFF
--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ChildUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ChildUsageNodeDescriptionProvider.java
@@ -110,8 +110,12 @@ public class ChildUsageNodeDescriptionProvider extends AbstractNodeDescriptionPr
         var optItemUsageBorderNodeDescription = cache.getNodeDescription(this.descriptionNameGenerator.getBorderNodeName(SysmlPackage.eINSTANCE.getItemUsage()));
         NodeDescription nodeDescription = optChildUsageNodeDescription.get();
         nodeDescription.getReusedChildNodeDescriptions().addAll(reusedChildren);
-        nodeDescription.getReusedBorderNodeDescriptions().add(optPortUsageBorderNodeDescription.get());
-        nodeDescription.getReusedBorderNodeDescriptions().add(optItemUsageBorderNodeDescription.get());
+        if (SysmlPackage.eINSTANCE.getPartUsage().equals(this.eClass)) {
+            nodeDescription.getReusedBorderNodeDescriptions().add(optPortUsageBorderNodeDescription.get());
+        }
+        if (SysmlPackage.eINSTANCE.getActionUsage().equals(this.eClass)) {
+            nodeDescription.getReusedBorderNodeDescriptions().add(optItemUsageBorderNodeDescription.get());
+        }
         nodeDescription.setPalette(this.createNodePalette(nodeDescription, cache));
 
         List<NodeDescription> growableNodes = new ArrayList<>();

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/FirstLevelChildUsageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/FirstLevelChildUsageNodeDescriptionProvider.java
@@ -109,8 +109,12 @@ public class FirstLevelChildUsageNodeDescriptionProvider extends AbstractNodeDes
 
         NodeDescription nodeDescription = optChildUsageNodeDescription.get();
         nodeDescription.getReusedChildNodeDescriptions().addAll(reusedChildren);
-        nodeDescription.getReusedBorderNodeDescriptions().add(optPortUsageBorderNodeDescription.get());
-        nodeDescription.getReusedBorderNodeDescriptions().add(optItemUsageBorderNodeDescription.get());
+        if (SysmlPackage.eINSTANCE.getPartUsage().equals(this.eClass)) {
+            nodeDescription.getReusedBorderNodeDescriptions().add(optPortUsageBorderNodeDescription.get());
+        }
+        if (SysmlPackage.eINSTANCE.getActionUsage().equals(this.eClass)) {
+            nodeDescription.getReusedBorderNodeDescriptions().add(optItemUsageBorderNodeDescription.get());
+        }
         nodeDescription.setPalette(this.createNodePalette(cache));
 
         List<NodeDescription> growableNodes = new ArrayList<>();

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ItemUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ItemUsageBorderNodeDescriptionProvider.java
@@ -43,11 +43,11 @@ import org.eclipse.syson.util.ViewConstants;
  */
 public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescriptionProvider {
 
-    private final IDescriptionNameGenerator nameGenerator;
+    private final IDescriptionNameGenerator descriptionNameGenerator;
 
-    public ItemUsageBorderNodeDescriptionProvider(IColorProvider colorProvider, IDescriptionNameGenerator nameGenerator) {
+    public ItemUsageBorderNodeDescriptionProvider(IColorProvider colorProvider, IDescriptionNameGenerator descriptionNameGenerator) {
         super(colorProvider);
-        this.nameGenerator = Objects.requireNonNull(nameGenerator);
+        this.descriptionNameGenerator = Objects.requireNonNull(descriptionNameGenerator);
     }
 
     @Override
@@ -59,7 +59,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .domainType(domainType)
                 .outsideLabels(this.createOutsideLabelDescription())
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getParameters"))
+                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getBorderNodesItems"))
                 .style(this.createItemUnsetNodeStyle())
                 .conditionalStyles(this.createItemUsageConditionalNodeStyles().toArray(ConditionalNodeStyle[]::new))
                 .userResizable(UserResizableDirection.NONE)
@@ -76,7 +76,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
     }
 
     public String getName() {
-        return this.nameGenerator.getBorderNodeName(SysmlPackage.eINSTANCE.getItemUsage());
+        return this.descriptionNameGenerator.getBorderNodeName(SysmlPackage.eINSTANCE.getItemUsage());
     }
 
     private NodeStyleDescription createItemUnsetNodeStyle() {
@@ -142,7 +142,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .initialDirectEditLabelExpression(AQLUtils.getSelfServiceCallExpression("getDefaultInitialDirectEditLabel"))
                 .body(callEditService.build());
 
-        NodeDescription portBorderNodeDescription = cache.getNodeDescription(this.nameGenerator.getBorderNodeName(SysmlPackage.eINSTANCE.getPortUsage())).get();
+        NodeDescription portBorderNodeDescription = cache.getNodeDescription(this.descriptionNameGenerator.getBorderNodeName(SysmlPackage.eINSTANCE.getPortUsage())).get();
         NodeDescription rootPortBorderNode = cache.getNodeDescription(RootPortUsageBorderNodeDescriptionProvider.NAME).get();
 
         return this.diagramBuilderHelper.newNodePalette()
@@ -162,7 +162,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createBindingConnectorAsUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()))
+                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()))
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getBindingConnectorAsUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -176,7 +176,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createFlowConnectionUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()))
+                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()))
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getFlowConnectionUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ItemUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/ItemUsageBorderNodeDescriptionProvider.java
@@ -162,7 +162,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createBindingConnectorAsUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()))
+                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()) + " (bind)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getBindingConnectorAsUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -176,7 +176,7 @@ public class ItemUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createFlowConnectionUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()))
+                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()) + " (flow)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getFlowConnectionUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/PortUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/PortUsageBorderNodeDescriptionProvider.java
@@ -164,7 +164,7 @@ public class PortUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createBindingConnectorAsUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()))
+                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()) + " (bind)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getBindingConnectorAsUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -178,7 +178,7 @@ public class PortUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createInterfaceUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getInterfaceUsage()))
+                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getInterfaceUsage()) + " (connect)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getInterfaceUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -192,7 +192,7 @@ public class PortUsageBorderNodeDescriptionProvider extends AbstractNodeDescript
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createFlowConnectionUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()))
+                .name(this.nameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()) + " (flow)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getFlowConnectionUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootPortUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/nodes/RootPortUsageBorderNodeDescriptionProvider.java
@@ -163,7 +163,7 @@ public class RootPortUsageBorderNodeDescriptionProvider extends AbstractNodeDesc
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createBindingConnectorAsUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()))
+                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()) + " (bind)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getBindingConnectorAsUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -177,7 +177,7 @@ public class RootPortUsageBorderNodeDescriptionProvider extends AbstractNodeDesc
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createInterfaceUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getInterfaceUsage()))
+                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getInterfaceUsage()) + " (connect)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getInterfaceUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -191,7 +191,7 @@ public class RootPortUsageBorderNodeDescriptionProvider extends AbstractNodeDesc
                 .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, "createFlowConnectionUsage", EdgeDescription.SEMANTIC_EDGE_TARGET));
 
         return builder
-                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()))
+                .name(this.descriptionNameGenerator.getCreationToolName(SysmlPackage.eINSTANCE.getFlowConnectionUsage()) + " (flow)")
                 .iconURLsExpression("/icons/full/obj16/" + SysmlPackage.eINSTANCE.getFlowConnectionUsage().getName() + ".svg")
                 .body(body.build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeService.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeService.java
@@ -23,8 +23,10 @@ import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
+import org.eclipse.syson.sysml.ItemUsage;
 import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.PortUsage;
+import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.Usage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,18 +102,18 @@ public class InterconnectionViewNodeService extends ViewNodeService {
     }
 
     /**
-     * Returns the parameters of the provided element.
+     * Returns the items of the provided element. Only intended to be used by ItemUsageBorderNodeDescriptionProvider.
      *
      * @param element
      *            the element
-     * @return the features that are parameters of the provided {@code element}
+     * @return the the items of the provided element.
      */
-    public List<Feature> getParameters(Element element) {
-        List<Feature> parameters = new ArrayList<>();
+    public List<ItemUsage> getBorderNodesItems(Element element) {
+        List<ItemUsage> items = new ArrayList<>();
         if (element instanceof ActionUsage actionUsage) {
-            parameters = actionUsage.getParameter();
+            items = actionUsage.getNestedItem().stream().filter(ni -> SysmlPackage.eINSTANCE.getItemUsage().equals(ni.eClass())).toList();
         }
-        return parameters;
+        return items;
     }
 
     public boolean isInFeature(Feature feature) {

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewNodeToolSectionSwitch.java
@@ -97,13 +97,13 @@ public class InterconnectionViewNodeToolSectionSwitch extends AbstractViewNodeTo
 
         NodeDescription itemNodeDescription = this.cache.getNodeDescription(this.descriptionNameGenerator.getBorderNodeName(SysmlPackage.eINSTANCE.getItemUsage())).get();
         createSection.getNodeTools().addAll(List.of(
-                this.toolDescriptionService.createNodeTool(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                this.toolDescriptionService.createNodeTool(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getFeatureMembership(),
                         NodeContainmentKind.BORDER_NODE),
-                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getFeatureMembership(),
                         NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.IN),
-                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getFeatureMembership(),
                         NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.INOUT),
-                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getParameterMembership(),
+                this.toolDescriptionService.createNodeToolWithDirection(itemNodeDescription, SysmlPackage.eINSTANCE.getItemUsage(), SysmlPackage.eINSTANCE.getFeatureMembership(),
                         NodeContainmentKind.BORDER_NODE, FeatureDirectionKind.OUT)));
 
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/606