### PR TITLE
[doc] Update FAQ, keyboard shortcut and install sections

### DIFF
--- a/doc/content/modules/installation-guide/pages/how-tos/install.adoc
+++ b/doc/content/modules/installation-guide/pages/how-tos/install.adoc
@@ -5,6 +5,16 @@ Detailed explanations walk you through each step.
 
 == Get {product}
 
+[CAUTION]
+.Stable versions
+====
+Only `YEAR.MONTH.0` versions are stable and suitable for production deployments.
+Other versions, such as intermediate releases, are intended solely for testing purposes.
+They're not recommended for production use due to their potential for further changes and instability.
+Always use the stable `.0` releases for any production environments to ensure reliability and support.
+For more details see xref:user-manual:cycle.adoc[].
+====
+
 === Installing {product} with Docker Compose
 
 The easiest and most straightforward method to install {product} using Docker Compose, which automatically installs Java and PostgreSQL.
@@ -51,16 +61,6 @@ Before you proceed with the installation, please ensure you have the following x
 
 {product} is distributed as a single _executable Java Archive_ `JAR` which contains the complete {product} application along with all its dependencies.
 This distribution simplifies the setup process, enabling convenient exploration of {product}'s features.
-
-[CAUTION]
-.Stable versions
-====
-Only `YEAR.MONTH.0` versions are stable and suitable for production deployments.
-Other versions, such as intermediate releases, are intended solely for testing purposes.
-They're not recommended for production use due to their potential for further changes and instability.
-Always use the stable `.0` releases for any production environments to ensure reliability and support.
-For more details see xref:user-manual:cycle.adoc[].
-====
 
 To download the latest pre-built JAR for {product}, follow these steps:
 

--- a/doc/content/modules/user-manual/pages/faq/faq.adoc
+++ b/doc/content/modules/user-manual/pages/faq/faq.adoc
@@ -163,8 +163,7 @@ Read the xref:user-manual:features/collaboration.adoc[] section to learn more ab
 .*How will models developed in your tool, be shared with other vendor {sysmlv2} tools? Are there any limitations we should be aware of?*
 [%collapsible%open]
 ====
-We're fully compatible with the {sysmlv2} standard.
-Models can be shared using the {sysmlv2} textual notation and the {sysmlv2} API.
+The intent is to be fully compatible with the {sysmlv2} standard ensuring that models can be shared using the {sysmlv2} textual notation and the {sysmlv2} API.
 ====
 
 .*How will models in {sysmlv2} and models in {sysmlv1} co-exist?*
@@ -189,7 +188,7 @@ This includes integration capabilities such as:
 
 * Textual Notation Support: {product} supports importing and exporting models using the {sysmlv2} textual notation.
 This facilitates sharing and integration with other {sysmlv2} compatible tools.
-* {sysmlv2} API: {product} is fully compatible with the xref:user-manual:integration/api.adoc[{sysmlv2} API], allowing seamless interaction with other tools and systems that adhere to this standard.
+* {sysmlv2} API:  We're working on making {product} fully compatible with the xref:user-manual:integration/api.adoc[{sysmlv2} API], allowing seamless interaction with other tools and systems that adhere to this standard.
 * Integration with Capella: We're working on establishing xref:user-manual:integration/capella.adoc[integration pathways with Capella], a comprehensive model-based engineering solution.
 
 This will enable users to leverage {product}'s {sysmlv2} capabilities alongside Capella's powerful system architecture modeling tools, ensuring model interoperability.

--- a/doc/content/modules/user-manual/pages/features/keyboard-shortcuts.adoc
+++ b/doc/content/modules/user-manual/pages/features/keyboard-shortcuts.adoc
@@ -6,6 +6,15 @@ include::user-manual:partial$before-you-start-experimental-all.adoc[]
 
 To delete a given element, user can select the element and the press the `Del` key from representation editor.
 
+== Navigation
+
+In a diagram, users can press Alt and drag with the mouse to browse the diagram without moving any elements.
+This is useful for large diagrams where elements might appear in the background when the view is zoomed out.
+
+== Selection
+
+In a diagram, users can press `Alt` and click on an element to select it without displaying the contextual palette on the node.
+
 == Basic editing
 
 User can press `F2` key or start typing the new value directly to efficiently update an element name from representation editor.


### PR DESCRIPTION
Update documentation sections:
* FAQ: to better explain that the API does not yet exist but it is our intent.
* Keyboard Shortcuts: to add the selection without palette and selection without move in a diagram.
* Install: to move the information about using the .0 version to the beginning of the section.