### PR TITLE
[619] Fix Inherited members inside compartments don't display palette

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -51,7 +51,9 @@ The following classes & methods have been deleted or modified to simplify the ha
 - [releng] Add a dependency to CycloneDX to compute the backend software bill of materials during the build
 
 === Bug fixes
+
 - https://github.com/eclipse-syson/syson/issues/606[#606] [interconnection-view] Prevent nested part to be rendered as border nodes
+- https://github.com/eclipse-syson/syson/issues/619[#619] [diagrams] Fix an issue where a click on inherited members inside compartments was raising an error instead of displaying the palette.
 
 === Improvements
 

--- a/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
@@ -52,7 +52,9 @@ The changes are:
 - Add a dependency to CycloneDX to compute the backend software bill of materials during the build
 
 == Bug fixes
-- Prevent nested part to be rendered as border nodes in the Interconnection View diagram
+
+- Prevent nested part to be rendered as border nodes in the Interconnection View diagram.
+- Fix an issue where a click on inherited members inside compartments was raising an error instead of displaying the palette.
 
 
 == Improvements


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/619