### PR TITLE
[651] Remove owning Usage memberships from inherited memberships

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -62,6 +62,7 @@ The following methods have been deleted or modified:
 - https://github.com/eclipse-syson/syson/issues/619[#619] [diagrams] Fix an issue where a click on inherited members inside compartments was raising an error instead of displaying the palette.
 - https://github.com/eclipse-syson/syson/issues/621[#621] [syson] Fix non-containment reference issue on standard library copy.
 These references were still pointing to elements in the standard library resources, while they should point to elements in the copied resources.
+- https://github.com/eclipse-syson/syson/issues/651[#651] [metamodel] Remove owning Usage memberships from inherited memberships of Usages.
 
 === Improvements
 

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/helper/MembershipComputer.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/helper/MembershipComputer.java
@@ -33,7 +33,6 @@ import org.eclipse.syson.sysml.NamespaceImport;
 import org.eclipse.syson.sysml.Specialization;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.Type;
-import org.eclipse.syson.sysml.Usage;
 import org.eclipse.syson.sysml.VisibilityKind;
 
 /**
@@ -141,15 +140,6 @@ public class MembershipComputer<T extends Element> {
             if (general != null && !this.visited.contains(general)) {
                 this.visibleMemberships(general, false, true, true).stream()
                         .filter(namefilter)
-                        .forEach(generalMemberships::add);
-            }
-        }
-        if (self instanceof Usage usage) {
-            Usage owningUsage = usage.getOwningUsage();
-            if (owningUsage != null) {
-                generalMemberships.addAll(this.inheritedMemberships(owningUsage));
-                owningUsage.getOwnedFeatureMembership().stream()
-                        .filter(m -> m.getVisibility() != VisibilityKind.PRIVATE)
                         .forEach(generalMemberships::add);
             }
         }

--- a/backend/metamodel/syson-sysml-metamodel/src/test/java/org/eclipse/syson/sysml/impl/PartUsageImplTest.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/test/java/org/eclipse/syson/sysml/impl/PartUsageImplTest.java
@@ -15,6 +15,7 @@ package org.eclipse.syson.sysml.impl;
 import static org.eclipse.syson.sysml.util.TestUtils.testInheritedFeature;
 
 import org.eclipse.syson.sysml.AttributeUsage;
+import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.PartDefinition;
 import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.VisibilityKind;
@@ -119,14 +120,8 @@ public class PartUsageImplTest {
 
         testInheritedFeature(testModel.typeDef);
         testInheritedFeature(testModel.superPart, testModel.publicTypeDefAttribute, testModel.protectedTypeDefAttribute);
-        testInheritedFeature(testModel.containedPart,
-                // Visible from typeDef
-                testModel.publicTypeDefAttribute, testModel.protectedTypeDefAttribute,
-                // Visible from owning part
-                testModel.publicSuperPartAttribute, testModel.protectedSuperPartAttribute,
-                // Itself since it's a feature of its parent
-                testModel.containedPart);
-
+        // Composite parts do not inherit memberships from their container.
+        testInheritedFeature(testModel.containedPart, new Feature[] {});
         testInheritedFeature(testModel.subPart,
                 // Visible from typeDef
                 testModel.publicTypeDefAttribute, testModel.protectedTypeDefAttribute,

--- a/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
@@ -66,6 +66,8 @@ The changes are:
 - Prevent nested part to be rendered as border nodes in the Interconnection View diagram.
 - Fix an issue where a click on inherited members inside compartments was raising an error instead of displaying the palette.
 - Fix an issue where non-containment references in standard libraries weren't correctly imported into the project's editing context.
+- Remove owning Usage memberships from inherited memberships of Usages.
+Memberships of a Type are inherited via _Specialization_ or _Conjugation_, not by composition.
 
 
 == Improvements


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/651