### PR TITLE
[660] Allow to select existing Requirements in objective tool

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -96,6 +96,7 @@ The supported properties are `in`, `out`, `inout`, `abstract`, `variation`, `rea
 - https://github.com/eclipse-syson/syson/issues/648[#648] [general-view] Add support for edges between actors and their containing UseCase/Requirement.
 The source of the edge (the UseCase or Requirement) can be reconnected to another UseCase or Requirement, but the target (Actor) cannot be reconnected.
 - https://github.com/eclipse-syson/syson/issues/656[#656] [services] Improve the drag and drop of containers elements to move their content
+- https://github.com/eclipse-syson/syson/issues/660[#660] [general-view] Allow to select existing _RequirementUsage_ and _RequirementDefinition_ on Objective tool. 
 
 === New features
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/JavaServiceIsCalledChecker.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/JavaServiceIsCalledChecker.java
@@ -41,7 +41,9 @@ import org.eclipse.sirius.components.view.diagram.InsideLabelDescription;
 import org.eclipse.sirius.components.view.diagram.InsideLabelStyle;
 import org.eclipse.sirius.components.view.diagram.LabelEditTool;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.OutsideLabelDescription;
+import org.eclipse.sirius.components.view.diagram.SelectionDialogDescription;
 import org.eclipse.sirius.components.view.diagram.Tool;
 import org.eclipse.syson.sysml.helper.EMFUtils;
 import org.eclipse.syson.util.AQLConstants;
@@ -162,6 +164,11 @@ public class JavaServiceIsCalledChecker {
             expressions.add(nodeTool.getPreconditionExpression());
             if (nodeTool instanceof LabelEditTool labelEditTool) {
                 expressions.add(labelEditTool.getInitialDirectEditLabelExpression());
+            }
+            if (nodeTool instanceof NodeTool createNodeTool) {
+                if (createNodeTool.getDialogDescription() instanceof SelectionDialogDescription selectionDialogDescription) {
+                    expressions.add(selectionDialogDescription.getSelectionCandidatesExpression());
+                }
             }
             for (Operation bodyOperation : nodeTool.getBody()) {
                 EMFUtils.allContainedObjectOfType(bodyOperation, ChangeContext.class)

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/DiagramDirectEditListener.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/DiagramDirectEditListener.java
@@ -364,7 +364,7 @@ public class DiagramDirectEditListener extends DirectEditBaseListener {
                 if (type instanceof ConjugatedPortDefinition conjugatedPortDef) {
                     this.handleConjugatedPortTyping(usage, conjugatedPortDef);
                 } else if (type != null) {
-                    this.handleFeatureTyping(usage, type);
+                    this.utilService.setFeatureTyping(usage, type);
                 }
             }
         }
@@ -597,34 +597,6 @@ public class DiagramDirectEditListener extends DirectEditBaseListener {
         }
     }
 
-    private void handleFeatureTyping(Usage usage, Type type) {
-        var optConjugatedPortTyping = this.element.getOwnedRelationship().stream()
-                .filter(ConjugatedPortTyping.class::isInstance)
-                .map(ConjugatedPortTyping.class::cast)
-                .findFirst();
-        if (optConjugatedPortTyping.isPresent()) {
-            EcoreUtil.remove(optConjugatedPortTyping.get());
-        }
-        var optFeatureTyping = this.element.getOwnedRelationship().stream()
-                .filter(FeatureTyping.class::isInstance)
-                .map(FeatureTyping.class::cast)
-                .findFirst();
-        if (optFeatureTyping.isPresent()) {
-            FeatureTyping featureTyping = optFeatureTyping.get();
-            if (!type.equals(featureTyping.getType())) {
-                featureTyping.setType(type);
-                featureTyping.setIsImplied(false);
-            }
-            featureTyping.setTypedFeature(usage);
-        } else {
-            var newFeatureTyping = SysmlFactory.eINSTANCE.createFeatureTyping();
-            this.element.getOwnedRelationship().add(newFeatureTyping);
-            newFeatureTyping.setType(type);
-            newFeatureTyping.setTypedFeature(usage);
-            this.elementInitializer.doSwitch(newFeatureTyping);
-        }
-    }
-
     @Override
     public void exitSubsettingExpression(SubsettingExpressionContext ctx) {
         if (this.options.contains(LabelService.SUBSETTING_OFF)) {
@@ -660,24 +632,7 @@ public class DiagramDirectEditListener extends DirectEditBaseListener {
             }
 
             if (definition != null) {
-                var optSubclassification = subclassificationDef.getOwnedRelationship().stream()
-                        .filter(Subclassification.class::isInstance)
-                        .map(Subclassification.class::cast)
-                        .findFirst();
-                if (optSubclassification.isPresent()) {
-                    Subclassification subclassification = optSubclassification.get();
-                    if (!definition.equals(subclassification.getSuperclassifier())) {
-                        subclassification.setSuperclassifier(definition);
-                        subclassification.setIsImplied(false);
-                    }
-                    subclassification.setSubclassifier(subclassificationDef);
-                } else {
-                    var newSubclassification = SysmlFactory.eINSTANCE.createSubclassification();
-                    subclassificationDef.getOwnedRelationship().add(newSubclassification);
-                    newSubclassification.setSuperclassifier(definition);
-                    newSubclassification.setSubclassifier(subclassificationDef);
-                    this.elementInitializer.caseSubclassification(newSubclassification);
-                }
+                this.utilService.setSubclassification(subclassificationDef, definition);
             }
         }
     }
@@ -705,24 +660,7 @@ public class DiagramDirectEditListener extends DirectEditBaseListener {
             }
 
             if (usage != null) {
-                var optSubsetting = subsettingUsage.getOwnedRelationship().stream()
-                        .filter(elt -> elt instanceof Subsetting && !(elt instanceof Redefinition))
-                        .map(Subsetting.class::cast)
-                        .findFirst();
-                if (optSubsetting.isPresent()) {
-                    Subsetting subsetting = optSubsetting.get();
-                    if (!usage.equals(subsetting.getSubsettedFeature())) {
-                        subsetting.setSubsettedFeature(usage);
-                        subsetting.setIsImplied(false);
-                    }
-                    subsetting.setSubsettingFeature(subsettingUsage);
-                } else {
-                    var newSubsetting = SysmlFactory.eINSTANCE.createSubsetting();
-                    subsettingUsage.getOwnedRelationship().add(newSubsetting);
-                    newSubsetting.setSubsettedFeature(usage);
-                    newSubsetting.setSubsettingFeature(subsettingUsage);
-                    this.elementInitializer.caseSubsetting(newSubsetting);
-                }
+                this.utilService.setSubsetting(subsettingUsage, usage);
             }
         }
     }
@@ -760,24 +698,7 @@ public class DiagramDirectEditListener extends DirectEditBaseListener {
             }
 
             if (usage != null) {
-                var optRedefinition = redefining.getOwnedRelationship().stream()
-                        .filter(Redefinition.class::isInstance)
-                        .map(Redefinition.class::cast)
-                        .findFirst();
-                if (optRedefinition.isPresent()) {
-                    Redefinition redefinition = optRedefinition.get();
-                    if (!usage.equals(redefinition.getRedefinedFeature())) {
-                        redefinition.setRedefinedFeature(usage);
-                        redefinition.setIsImplied(false);
-                    }
-                    redefinition.setRedefiningFeature(redefining);
-                } else {
-                    var newRedefinition = SysmlFactory.eINSTANCE.createRedefinition();
-                    redefining.getOwnedRelationship().add(newRedefinition);
-                    newRedefinition.setRedefinedFeature(usage);
-                    newRedefinition.setRedefiningFeature(redefining);
-                    this.elementInitializer.caseRedefinition(newRedefinition);
-                }
+                this.utilService.setRedefinition(redefining, usage);
             }
         }
     }

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
@@ -14,6 +14,7 @@ package org.eclipse.syson.services;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.syson.sysml.AcceptActionUsage;
+import org.eclipse.syson.sysml.ActorMembership;
 import org.eclipse.syson.sysml.AttributeUsage;
 import org.eclipse.syson.sysml.BindingConnectorAsUsage;
 import org.eclipse.syson.sysml.ConjugatedPortDefinition;
@@ -25,21 +26,28 @@ import org.eclipse.syson.sysml.EnumerationDefinition;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
 import org.eclipse.syson.sysml.FeatureTyping;
 import org.eclipse.syson.sysml.FlowConnectionUsage;
+import org.eclipse.syson.sysml.ObjectiveMembership;
 import org.eclipse.syson.sysml.OwningMembership;
 import org.eclipse.syson.sysml.Package;
 import org.eclipse.syson.sysml.ParameterMembership;
+import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.PerformActionUsage;
 import org.eclipse.syson.sysml.PortConjugation;
 import org.eclipse.syson.sysml.PortDefinition;
 import org.eclipse.syson.sysml.Redefinition;
 import org.eclipse.syson.sysml.ReferenceSubsetting;
+import org.eclipse.syson.sysml.ReferenceUsage;
+import org.eclipse.syson.sysml.RequirementUsage;
 import org.eclipse.syson.sysml.Specialization;
 import org.eclipse.syson.sysml.Subclassification;
+import org.eclipse.syson.sysml.SubjectMembership;
 import org.eclipse.syson.sysml.Subsetting;
 import org.eclipse.syson.sysml.SuccessionAsUsage;
 import org.eclipse.syson.sysml.SysmlFactory;
 import org.eclipse.syson.sysml.TransitionUsage;
 import org.eclipse.syson.sysml.Usage;
+import org.eclipse.syson.sysml.UseCaseDefinition;
+import org.eclipse.syson.sysml.UseCaseUsage;
 import org.eclipse.syson.sysml.util.SysmlSwitch;
 
 /**
@@ -129,6 +137,15 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
     }
 
     @Override
+    public Element casePartUsage(PartUsage object) {
+        this.caseUsage(object);
+        if (object.getOwningMembership() instanceof ActorMembership) {
+            object.setDeclaredName("actor");
+        }
+        return object;
+    }
+
+    @Override
     public Element casePerformActionUsage(PerformActionUsage object) {
         // no name for new perform action
         return object;
@@ -159,6 +176,26 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
     @Override
     public Element caseReferenceSubsetting(ReferenceSubsetting object) {
         object.setDeclaredName("references");
+        return object;
+    }
+
+    @Override
+    public Element caseReferenceUsage(ReferenceUsage object) {
+        this.caseUsage(object);
+        if (object.getOwningMembership() instanceof SubjectMembership) {
+            object.setDeclaredName("subject");
+        }
+        return object;
+    }
+
+    @Override
+    public Element caseRequirementUsage(RequirementUsage object) {
+        this.caseUsage(object);
+        if (object.getOwningMembership() instanceof ObjectiveMembership) {
+            if (object.getOwner() instanceof UseCaseUsage || object.getOwner() instanceof UseCaseDefinition) {
+                object.setDeclaredName(object.getOwner().getName() + "'s objective");
+            }
+        }
         return object;
     }
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
@@ -37,18 +37,22 @@ import org.eclipse.syson.sysml.ActionDefinition;
 import org.eclipse.syson.sysml.ActionUsage;
 import org.eclipse.syson.sysml.AllocationDefinition;
 import org.eclipse.syson.sysml.AllocationUsage;
+import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.EndFeatureMembership;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
 import org.eclipse.syson.sysml.FeatureMembership;
 import org.eclipse.syson.sysml.FeatureTyping;
+import org.eclipse.syson.sysml.ItemDefinition;
+import org.eclipse.syson.sysml.ItemUsage;
 import org.eclipse.syson.sysml.Membership;
 import org.eclipse.syson.sysml.ObjectiveMembership;
 import org.eclipse.syson.sysml.Package;
 import org.eclipse.syson.sysml.ParameterMembership;
 import org.eclipse.syson.sysml.PartDefinition;
 import org.eclipse.syson.sysml.PartUsage;
+import org.eclipse.syson.sysml.ReferenceUsage;
 import org.eclipse.syson.sysml.RequirementConstraintKind;
 import org.eclipse.syson.sysml.RequirementConstraintMembership;
 import org.eclipse.syson.sysml.RequirementDefinition;
@@ -247,16 +251,60 @@ public class ViewCreateService {
      *            the element usage to set the objective for
      * @return the created RequirementUsage
      */
-    public Element createRequirementUsageAsObjectiveRequirement(Element self) {
+    public Element createRequirementUsageAsObjectiveRequirement(Element self, Element selectedObject) {
         Element result = self;
         if (self instanceof UseCaseUsage
                 || self instanceof UseCaseDefinition) {
             RequirementUsage newRequirementUsage = SysmlFactory.eINSTANCE.createRequirementUsage();
             result = newRequirementUsage;
-            newRequirementUsage.setDeclaredName(self.getDeclaredName() + "'s objective");
-            var objectiveMembership = SysmlFactory.eINSTANCE.createObjectiveMembership();
+            var objectiveMembership = this.createMembership(self, SysmlPackage.eINSTANCE.getObjectiveMembership());
             objectiveMembership.getOwnedRelatedElement().add(newRequirementUsage);
-            self.getOwnedRelationship().add(objectiveMembership);
+            this.elementInitializerSwitch.doSwitch(newRequirementUsage);
+            if (selectedObject instanceof RequirementUsage requirementUsage) {
+                this.utilService.setSubsetting(newRequirementUsage, requirementUsage);
+            } else if (selectedObject instanceof RequirementDefinition requirementDefinition) {
+                this.utilService.setFeatureTyping(newRequirementUsage, requirementDefinition);
+            }
+        }
+        return result;
+    }
+
+    public Element createReferenceUsageAsSubject(Element self, Element selectedObject) {
+        Element result = self;
+        if (self instanceof UseCaseUsage
+                || self instanceof UseCaseDefinition
+                || self instanceof RequirementUsage
+                || self instanceof RequirementDefinition) {
+            ReferenceUsage newReferenceUsage = SysmlFactory.eINSTANCE.createReferenceUsage();
+            result = newReferenceUsage;
+            var subjectMembership = this.createMembership(self, SysmlPackage.eINSTANCE.getSubjectMembership());
+            subjectMembership.getOwnedRelatedElement().add(newReferenceUsage);
+            this.elementInitializerSwitch.doSwitch(newReferenceUsage);
+            if (selectedObject instanceof Usage usage) {
+                this.utilService.setSubsetting(newReferenceUsage, usage);
+            } else if (selectedObject instanceof Definition definition) {
+                this.utilService.setFeatureTyping(newReferenceUsage, definition);
+            }
+        }
+        return result;
+    }
+
+    public Element createPartUsageAsActor(Element self, Element selectedObject) {
+        Element result = self;
+        if (self instanceof UseCaseUsage
+                || self instanceof UseCaseDefinition
+                || self instanceof RequirementUsage
+                || self instanceof RequirementDefinition) {
+            PartUsage newPartUsage = SysmlFactory.eINSTANCE.createPartUsage();
+            result = newPartUsage;
+            var actorMembership = this.createMembership(self, SysmlPackage.eINSTANCE.getActorMembership());
+            actorMembership.getOwnedRelatedElement().add(newPartUsage);
+            this.elementInitializerSwitch.doSwitch(newPartUsage);
+            if (selectedObject instanceof ItemUsage usage) {
+                this.utilService.setSubsetting(newPartUsage, usage);
+            } else if (selectedObject instanceof ItemDefinition definition) {
+                this.utilService.setFeatureTyping(newPartUsage, definition);
+            }
         }
         return result;
     }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
@@ -263,6 +263,24 @@ public class ViewNodeService {
                 .toList();
     }
 
+    public List<Element> getAllReachableRequirements(EObject eObject) {
+        List<EObject> allRequirementUsages = this.utilService.getAllReachable(eObject, SysmlPackage.eINSTANCE.getRequirementUsage(), false);
+        List<EObject> allRequirementDefinitions = this.utilService.getAllReachable(eObject, SysmlPackage.eINSTANCE.getRequirementDefinition(), false);
+        return Stream.concat(allRequirementUsages.stream(), allRequirementDefinitions.stream())
+                .filter(Element.class::isInstance)
+                .map(Element.class::cast)
+                .toList();
+    }
+
+    public List<Element> getAllReachableItems(EObject eObject) {
+        List<EObject> allItemUsage = this.utilService.getAllReachable(eObject, SysmlPackage.eINSTANCE.getItemUsage(), false);
+        List<EObject> allItemDefinition = this.utilService.getAllReachable(eObject, SysmlPackage.eINSTANCE.getItemDefinition(), false);
+        return Stream.concat(allItemUsage.stream(), allItemDefinition.stream())
+                .filter(Element.class::isInstance)
+                .map(Element.class::cast)
+                .toList();
+    }
+
     /**
      * Returns {@code true} if the provided {@code element} is an actor, {@code false} otherwise.
      * <p>

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/AbstractCompartmentNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/AbstractCompartmentNodeToolProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.components.view.builder.generated.DiagramBuilders;
 import org.eclipse.sirius.components.view.builder.generated.ViewBuilders;
 import org.eclipse.sirius.components.view.builder.providers.INodeToolProvider;
 import org.eclipse.sirius.components.view.diagram.NodeTool;
+import org.eclipse.sirius.components.view.diagram.SelectionDialogDescription;
 import org.eclipse.syson.util.AQLConstants;
 
 /**
@@ -43,6 +44,19 @@ public abstract class AbstractCompartmentNodeToolProvider implements INodeToolPr
      * @return the AQL expression associated to this node tool.
      */
     protected abstract String getServiceCallExpression();
+
+    /**
+     * Returns the selection dialog to display as part of the tool's execution.
+     * <p>
+     * No selection dialog will be displayed if this method returns {@code null}.
+     * </p>
+     *
+     * @return the selection dialog to display as part of the tool's execution
+     */
+    protected SelectionDialogDescription getSelectionDialogDescription() {
+        // No selection dialog by default.
+        return null;
+    }
 
     /**
      * Return the node tool label visible in the compartment palette.
@@ -79,6 +93,7 @@ public abstract class AbstractCompartmentNodeToolProvider implements INodeToolPr
     @Override
     public NodeTool create(IViewDiagramElementFinder cache) {
         var builder = this.diagramBuilderHelper.newNodeTool();
+        builder.dialogDescription(this.getSelectionDialogDescription());
 
         List<Operation> allOperations = new ArrayList<>();
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ActorCompartmentNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ActorCompartmentNodeToolProvider.java
@@ -12,18 +12,8 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.common.view.tools;
 
-import java.util.List;
-import java.util.Objects;
-
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EReference;
-import org.eclipse.sirius.components.view.builder.IViewDiagramElementFinder;
-import org.eclipse.sirius.components.view.diagram.NodeContainmentKind;
-import org.eclipse.sirius.components.view.diagram.NodeTool;
-import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.sirius.components.view.diagram.SelectionDialogDescription;
 import org.eclipse.syson.util.AQLUtils;
-import org.eclipse.syson.util.IDescriptionNameGenerator;
-import org.eclipse.syson.util.SysMLMetamodelHelper;
 
 /**
  * Node tool provider for Actor compartment in the element that need such compartment.
@@ -32,22 +22,17 @@ import org.eclipse.syson.util.SysMLMetamodelHelper;
  */
 public class ActorCompartmentNodeToolProvider extends AbstractCompartmentNodeToolProvider {
 
-    private final EClass parentEClass;
-
-    private final EReference eReference;
-
-    private final IDescriptionNameGenerator descriptionNameGenerator;
-
-    public ActorCompartmentNodeToolProvider(EClass parentEClass, EReference eReference, IDescriptionNameGenerator descriptionNameGenerator) {
-        super();
-        this.parentEClass = Objects.requireNonNull(parentEClass);
-        this.eReference = Objects.requireNonNull(eReference);
-        this.descriptionNameGenerator = Objects.requireNonNull(descriptionNameGenerator);
+    @Override
+    protected String getServiceCallExpression() {
+        return "aql:self.createPartUsageAsActor(selectedObject)";
     }
 
     @Override
-    protected String getServiceCallExpression() {
-        return "";
+    protected SelectionDialogDescription getSelectionDialogDescription() {
+        return this.diagramBuilderHelper.newSelectionDialogDescription()
+                .selectionCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachableItems"))
+                .selectionMessage("Select an existing Item as actor:")
+                .build();
     }
 
     @Override
@@ -63,74 +48,5 @@ public class ActorCompartmentNodeToolProvider extends AbstractCompartmentNodeToo
     @Override
     protected boolean revealOnCreate() {
         return true;
-    }
-
-    @Override
-    public NodeTool create(IViewDiagramElementFinder cache) {
-        var builder = this.diagramBuilderHelper.newNodeTool();
-
-        var setType = this.viewBuilderHelper.newSetValue()
-                .featureName("type")
-                .valueExpression("aql:selectedObject");
-
-        var changeContextFeatureTyping = this.viewBuilderHelper.newChangeContext()
-                .expression("aql:newFeatureTyping")
-                .children(setType.build());
-
-        var initializeFeatureTyping = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getServiceCallExpression("newFeatureTyping", "elementInitializer"));
-
-        var createFeatureTypingInstance = this.viewBuilderHelper.newCreateInstance()
-                .typeName(SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getFeatureTyping()))
-                .referenceName(SysmlPackage.eINSTANCE.getElement_OwnedRelationship().getName())
-                .variableName("newFeatureTyping")
-                .children(initializeFeatureTyping.build(), changeContextFeatureTyping.build());
-
-        var setName = this.viewBuilderHelper.newSetValue()
-                .featureName("declaredName")
-                .valueExpression("actor");
-
-        var changeContextInitializeNewInstance = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getServiceCallExpression("newInstance", "elementInitializer"));
-
-        var changeContextNewInstance = this.viewBuilderHelper.newChangeContext()
-                .expression("aql:newInstance");
-
-        var createEClassInstance = this.viewBuilderHelper.newCreateInstance()
-                .typeName(SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getPartUsage()))
-                .referenceName(SysmlPackage.eINSTANCE.getRelationship_OwnedRelatedElement().getName())
-                .variableName("newInstance")
-                .children(changeContextInitializeNewInstance.build(), setName.build(), createFeatureTypingInstance.build(), changeContextNewInstance.build());
-
-        var nodeDescription = cache.getNodeDescription(this.descriptionNameGenerator.getCompartmentItemName(this.parentEClass, this.eReference))
-                .orElse(null);
-
-        var createView = this.diagramBuilderHelper.newCreateView()
-                .containmentKind(NodeContainmentKind.CHILD_NODE)
-                .elementDescription(nodeDescription)
-                .parentViewExpression(AQLUtils.getSelfServiceCallExpression("getParentViewExpression", "selectedNode"))
-                .semanticElementExpression("aql:newInstance")
-                .variableName("newInstanceView");
-
-        var reveal = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getServiceCallExpression("selectedNode", "revealCompartment", List.of("self", "diagramContext", "editingContext", "convertedNodes")));
-
-        var domainType = SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getPartUsage());
-
-        var selectExistingUsage = this.diagramBuilderHelper.newSelectionDialogDescription()
-                .selectionCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", List.of(domainType, "false")))
-                .selectionMessage("Select an existing PartUsage as actor:");
-
-        var changeContexMembership = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getSelfServiceCallExpression("createMembership", SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getActorMembership())))
-                .children(createEClassInstance.build(), createView.build(), reveal.build());
-
-        return builder
-                .name(this.getNodeToolName())
-                .iconURLsExpression(this.getNodeToolIconURLsExpression())
-                .body(changeContexMembership.build())
-                .dialogDescription(selectExistingUsage.build())
-                .preconditionExpression(this.getPreconditionExpression())
-                .build();
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ObjectiveRequirementCompartmentNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ObjectiveRequirementCompartmentNodeToolProvider.java
@@ -12,20 +12,21 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.common.view.tools;
 
+import org.eclipse.syson.sysml.RequirementUsage;
+
 /**
- * Node tool provider for Objective Requirement compartment in the element that need such compartment.
+ * Node tool provider for objective compartment in the element that need such compartment.
+ * <p>
+ * This tool creates a new {@link RequirementUsage} and sets it as the objective of the containing element.
+ * </p>
  *
  * @author Jerome Gout
  */
 public class ObjectiveRequirementCompartmentNodeToolProvider extends AbstractCompartmentNodeToolProvider {
 
-    public ObjectiveRequirementCompartmentNodeToolProvider() {
-        super();
-    }
-
     @Override
     protected String getServiceCallExpression() {
-        return "aql:self.createRequirementUsageAsObjectiveRequirement()";
+        return "aql:self.createRequirementUsageAsObjectiveRequirement(null)";
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider.java
@@ -12,47 +12,52 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.common.view.tools;
 
-import java.util.List;
-
 import org.eclipse.sirius.components.view.diagram.SelectionDialogDescription;
-import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.sysml.RequirementUsage;
 import org.eclipse.syson.util.AQLUtils;
-import org.eclipse.syson.util.SysMLMetamodelHelper;
 
 /**
- * Node tool provider for Subject compartment in the element that need such compartment.
+ * Node tool provider for objective compartment in the element that need such compartment.
+ * <p>
+ * This tool opens a selection dialog to select the existing requirement to use as the objective. The selected
+ * requirement isn't used as is, but is set as the type/subsetted feature of a new {@link RequirementUsage} representing
+ * the objective.
+ * </p>
  *
- * @author Jerome Gout
+ * @author gdaniel
  */
-public class SubjectCompartmentNodeToolProvider extends AbstractCompartmentNodeToolProvider {
+public class ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider extends AbstractCompartmentNodeToolProvider {
+
+    public ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider() {
+        super();
+    }
 
     @Override
     protected String getServiceCallExpression() {
-        return "aql:self.createReferenceUsageAsSubject(selectedObject)";
+        return "aql:self.createRequirementUsageAsObjectiveRequirement(selectedObject)";
     }
 
     @Override
     protected SelectionDialogDescription getSelectionDialogDescription() {
-        String domainType = SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getType());
         return this.diagramBuilderHelper.newSelectionDialogDescription()
-                .selectionCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", List.of(domainType, "false")))
-                .selectionMessage("Select an existing Type as subject:")
+                .selectionCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachableRequirements"))
+                .selectionMessage("Select an existing Requirement as objective:")
                 .build();
     }
 
     @Override
     protected String getNodeToolName() {
-        return "New Subject";
+        return "New Objective from existing Requirement";
     }
 
     @Override
     protected String getNodeToolIconURLsExpression() {
-        return "/icons/full/obj16/Subject.svg";
+        return "/icons/full/obj16/Objective.svg";
     }
 
     @Override
     protected String getPreconditionExpression() {
-        return "aql:self.isEmptySubjectCompartment()";
+        return "aql:self.isEmptyObjectiveRequirementCompartment()";
     }
 
     @Override

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementDefinitionActorsCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementDefinitionActorsCompartmentNodeDescriptionProvider.java
@@ -65,7 +65,7 @@ public class RequirementDefinitionActorsCompartmentNodeDescriptionProvider exten
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new ActorCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new ActorCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementDefinitionSubjectCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementDefinitionSubjectCompartmentNodeDescriptionProvider.java
@@ -64,7 +64,7 @@ public class RequirementDefinitionSubjectCompartmentNodeDescriptionProvider exte
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new SubjectCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new SubjectCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementUsageActorsCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementUsageActorsCompartmentNodeDescriptionProvider.java
@@ -65,7 +65,7 @@ public class RequirementUsageActorsCompartmentNodeDescriptionProvider extends Ab
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new ActorCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new ActorCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementUsageSubjectCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/RequirementUsageSubjectCompartmentNodeDescriptionProvider.java
@@ -64,7 +64,7 @@ public class RequirementUsageSubjectCompartmentNodeDescriptionProvider extends A
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new SubjectCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new SubjectCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseDefinitionActorsCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseDefinitionActorsCompartmentNodeDescriptionProvider.java
@@ -65,7 +65,7 @@ public class UseCaseDefinitionActorsCompartmentNodeDescriptionProvider extends A
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new ActorCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new ActorCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseDefinitionObjectiveRequirementCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseDefinitionObjectiveRequirementCompartmentNodeDescriptionProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
 import org.eclipse.sirius.components.view.builder.providers.INodeToolProvider;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractCompartmentNodeDescriptionProvider;
+import org.eclipse.syson.diagram.common.view.tools.ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.ObjectiveRequirementCompartmentNodeToolProvider;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLUtils;
@@ -61,6 +62,7 @@ public class UseCaseDefinitionObjectiveRequirementCompartmentNodeDescriptionProv
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
         creationToolProviders.add(new ObjectiveRequirementCompartmentNodeToolProvider());
+        creationToolProviders.add(new ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseDefinitionSubjectCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseDefinitionSubjectCompartmentNodeDescriptionProvider.java
@@ -64,7 +64,7 @@ public class UseCaseDefinitionSubjectCompartmentNodeDescriptionProvider extends 
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new SubjectCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new SubjectCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseUsageActorsCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseUsageActorsCompartmentNodeDescriptionProvider.java
@@ -65,7 +65,7 @@ public class UseCaseUsageActorsCompartmentNodeDescriptionProvider extends Abstra
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new ActorCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new ActorCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseUsageObjectiveRequirementCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseUsageObjectiveRequirementCompartmentNodeDescriptionProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
 import org.eclipse.sirius.components.view.builder.providers.INodeToolProvider;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractCompartmentNodeDescriptionProvider;
+import org.eclipse.syson.diagram.common.view.tools.ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.ObjectiveRequirementCompartmentNodeToolProvider;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLUtils;
@@ -61,6 +62,7 @@ public class UseCaseUsageObjectiveRequirementCompartmentNodeDescriptionProvider 
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
         creationToolProviders.add(new ObjectiveRequirementCompartmentNodeToolProvider());
+        creationToolProviders.add(new ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseUsageSubjectCompartmentNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/UseCaseUsageSubjectCompartmentNodeDescriptionProvider.java
@@ -64,7 +64,7 @@ public class UseCaseUsageSubjectCompartmentNodeDescriptionProvider extends Abstr
     @Override
     protected List<INodeToolProvider> getItemCreationToolProviders() {
         List<INodeToolProvider> creationToolProviders = new ArrayList<>();
-        creationToolProviders.add(new SubjectCompartmentNodeToolProvider(this.eClass, this.eReference, this.getDescriptionNameGenerator()));
+        creationToolProviders.add(new SubjectCompartmentNodeToolProvider());
         return creationToolProviders;
     }
 }

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/services/GeneralViewNodeToolSectionSwitch.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/services/GeneralViewNodeToolSectionSwitch.java
@@ -38,6 +38,7 @@ import org.eclipse.syson.diagram.common.view.tools.ForkActionNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.JoinActionNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.MergeActionNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.ObjectiveRequirementCompartmentNodeToolProvider;
+import org.eclipse.syson.diagram.common.view.tools.ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.PerformActionNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.ReferencingPerformActionNodeToolProvider;
 import org.eclipse.syson.diagram.common.view.tools.SetAsCompositeToolProvider;
@@ -445,7 +446,8 @@ public class GeneralViewNodeToolSectionSwitch extends AbstractViewNodeToolSectio
         var createSection = this.toolDescriptionService.buildCreateSection(
                 this.createNewSubjectNodeTool(SysmlPackage.eINSTANCE.getUseCaseDefinition(), SysmlPackage.eINSTANCE.getCaseDefinition_SubjectParameter()),
                 this.createNewActorNodeTool(SysmlPackage.eINSTANCE.getUseCaseDefinition(), SysmlPackage.eINSTANCE.getCaseDefinition_ActorParameter()),
-                this.createRequirementUsageAsObjectiveRequirementNodeTool());
+                this.createRequirementUsageAsObjectiveRequirementNodeTool(),
+                this.creatRequirementUsageAsObjectiveWithBaseRequirementNodeTool());
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
         return List.of(createSection, this.toolDescriptionService.addElementsNodeToolSection(true));
     }
@@ -471,7 +473,8 @@ public class GeneralViewNodeToolSectionSwitch extends AbstractViewNodeToolSectio
                         null, FeatureDirectionKind.OUT),
                 this.createNewSubjectNodeTool(SysmlPackage.eINSTANCE.getUseCaseUsage(), SysmlPackage.eINSTANCE.getCaseUsage_SubjectParameter()),
                 this.createNewActorNodeTool(SysmlPackage.eINSTANCE.getUseCaseUsage(), SysmlPackage.eINSTANCE.getCaseUsage_ActorParameter()),
-                this.createRequirementUsageAsObjectiveRequirementNodeTool());
+                this.createRequirementUsageAsObjectiveRequirementNodeTool(),
+                this.creatRequirementUsageAsObjectiveWithBaseRequirementNodeTool());
         createSection.getNodeTools().addAll(this.createToolsForCompartmentItems(object));
         var editSection = this.toolDescriptionService.buildEditSection(
                 new SetAsCompositeToolProvider().create(this.cache),
@@ -509,18 +512,23 @@ public class GeneralViewNodeToolSectionSwitch extends AbstractViewNodeToolSectio
     }
 
     private NodeTool createNewSubjectNodeTool(EClass eClass, EReference eRefrence) {
-        var subjectCompartmentNodeToolProvider = new SubjectCompartmentNodeToolProvider(eClass, eRefrence, this.descriptionNameGenerator);
+        var subjectCompartmentNodeToolProvider = new SubjectCompartmentNodeToolProvider();
         return subjectCompartmentNodeToolProvider.create(this.cache);
     }
 
     private NodeTool createNewActorNodeTool(EClass eClass, EReference eReference) {
-        var actorsCompartmentNodeToolProvider = new ActorCompartmentNodeToolProvider(eClass, eReference, this.descriptionNameGenerator);
+        var actorsCompartmentNodeToolProvider = new ActorCompartmentNodeToolProvider();
         return actorsCompartmentNodeToolProvider.create(this.cache);
     }
 
     private NodeTool createRequirementUsageAsObjectiveRequirementNodeTool() {
         var objectiveRequirementCompartmentNodeToolProvider = new ObjectiveRequirementCompartmentNodeToolProvider();
         return objectiveRequirementCompartmentNodeToolProvider.create(this.cache);
+    }
+
+    private NodeTool creatRequirementUsageAsObjectiveWithBaseRequirementNodeTool() {
+        var objectiveRequirementWithBaseRequirementCompartmentNodeToolProvider = new ObjectiveRequirementWithBaseRequirementCompartmentNodeToolProvider();
+        return objectiveRequirementWithBaseRequirementCompartmentNodeToolProvider.create(this.cache);
     }
 
     private NodeToolSection createPartDefinitionElementsToolSection() {

--- a/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
@@ -124,6 +124,7 @@ image::release-notes-actor-representation.png[Actor node on the General View dia
 
 - Add support for edges between actors and their containing UseCase/Requirement in the General View diagram.
 The source of the edge (the UseCase or Requirement) can be reconnected to another UseCase or Requirement, but the target (Actor) cannot be reconnected.
+- Allow to select existing _RequirementUsage_ and _RequirementDefinition_ on Objective tool. 
 
 == New features
 


### PR DESCRIPTION
This PR also contains the following refactorings:
- Update `AbstractCompartmentNodeToolProvider` to support selection dialog
- Remove selection dialog related code in existing subclasses of `AbstractCompartmentNodeToolProvider`
- Extract common methods from `DiagramDirectEditListener` in `UtilService` to make them reusable in other services (`setFeatureTyping`, `setSubsetting`, etc)
- Uniformize the use of `ElementInitializerSwitch` in tools using selection dialog

Bug: https://github.com/eclipse-syson/syson/issues/660

To merge after #659 