### PR TITLE
[674] Ensure that dropped nodes are always collapsed

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -47,6 +47,10 @@ The following methods have been deleted or modified:
 * Deleted `ViewCreateService#createPartUsageAsSubject`
 * Add new `EClass`, 'EReference' and `IDescriptionNameGenerator` parameters to `SubjectCompartmentNodeToolProvider`
 - [core] Migrate frontend to MUI 5, if you contributed React components that use MUI, you should upgrade them to use MUI 5.
+- https://github.com/eclipse-syson/syson/issues/674[#674] [diagrams] Ensure that dropped nodes are always collapsed.
+Moved `ToolService#dropElementFromExplorer` and `ToolService#dropElementFromDiagram` into `ViewToolService`.
+* The method `dropElementFromExplorer` now requires view-related imports that motivated this refactoring.
+* The method `dropElementFromDiagram` has been moved for the sake of consistency.
 
 === Dependency update
 
@@ -107,6 +111,7 @@ For example, `myAttribute : ISQ::MassValue` now correctly types the attribute wi
   * A new filter is available to hide root Namespaces and is enabled by default.
   * It is no longer possible to create Namespace from the explorer.
   * It is no longer possible to create a representation on a root Namespace.
+- https://github.com/eclipse-syson/syson/issues/674[#674] [diagrams] Ensure that dropped nodes are always collapsed.
 
 === New features
 

--- a/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
@@ -61,6 +61,10 @@ The changes are:
 * Deleted `ViewNodeService#isHiddenByDefaultNonExhibitStates`
 * Add new `IViewDiagramElementFinder` parameter to `StateTransitionViewNodeToolSectionSwitch`
 - Migrate frontend to MUI 5, if you contributed React components that use MUI, you should upgrade them to use MUI 5.
+- Ensure that dropped nodes are always collapsed, the following methods have been moved to support this feature
+* The method `ToolService#dropElementFromExplorer` has been moved to `ViewToolService` since it now requires view-related imports that motivated this refactoring.
+* The method `ToolService#dropElementFromDiagram` has been moved to `ViewToolService` for the sake of consistency.
+
 
 == Dependencies update
 
@@ -144,6 +148,7 @@ For example, `myAttribute : ISQ::MassValue` now correctly types the attribute wi
 * A new filter is available to hide root Namespaces and is enabled by default.
 * It is no longer possible to create Namespace from the explorer.
 * It is no longer possible to create a representation on a root Namespace.
+- Improve the drop from the explorer to ensure that dropped nodes are always collapsed.
 
 == New features
 

--- a/integration-tests/cypress/e2e/project/diagrams/general-view/dropFromExplorer.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/general-view/dropFromExplorer.cy.ts
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { Project } from '../../../../pages/Project';
+import { SysMLv2 } from '../../../../usecases/SysMLv2';
+import { Diagram } from '../../../../workbench/Diagram';
+import { Explorer } from '../../../../workbench/Explorer';
+
+describe('Drop From Explorer Tests', () => {
+  const sysmlv2 = new SysMLv2();
+  const diagramLabel = 'General View';
+
+  context('Given a SysMLv2 project with a General View diagram', () => {
+    const diagram = new Diagram();
+    const explorer = new Explorer();
+    let projectId: string = '';
+    beforeEach(() =>
+      sysmlv2.createSysMLv2Project().then((createdProjectData) => {
+        projectId = createdProjectData.projectId;
+        new Project().visit(projectId);
+        explorer.getExplorerView().contains(sysmlv2.getProjectLabel());
+        explorer.expand(sysmlv2.getProjectLabel());
+        explorer.getExplorerView().contains(sysmlv2.getRootElementLabel());
+        explorer.expand(sysmlv2.getRootElementLabel());
+        explorer.select(diagramLabel);
+        diagram.getDiagram(diagramLabel).should('exist');
+        // Wait for the arrange all action to complete
+        /* eslint-disable-next-line cypress/no-unnecessary-waiting */
+        cy.wait(400);
+      })
+    );
+
+    afterEach(() => cy.deleteProject(projectId));
+
+    context('When we create a PartUsage with an AttributeUsage in the root Package in the explorer', () => {
+      beforeEach(() => {
+        explorer.createObject(sysmlv2.getRootElementLabel(), 'SysMLv2EditService-PartUsage');
+        explorer.createObject('part', 'SysMLv2EditService-AttributeUsage');
+        explorer.getTreeItemByLabel('part').should('exist');
+        explorer
+          .getTreeItemByLabel('attribute')
+          .should('exist')
+          .parents('ul')
+          .first()
+          .siblings()
+          .contains('part')
+          .should('exist');
+      });
+
+      it('Then we can drop the PartUsage on the diagram, and its compartment are not visible', () => {
+        const dataTransfer = new DataTransfer();
+        explorer.dragTreeItem('part', dataTransfer);
+        diagram.dropOnDiagram(diagramLabel, dataTransfer);
+
+        diagram.getNodes(diagramLabel, 'part').should('exist');
+        // Check that the compartments of the node aren't visible
+        diagram.getNodes(diagramLabel, 'attributes').should('not.exist');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/674

To rebase/merge after #672 