### PR TITLE
[687] Fix action drop from the diagram to an action flow compartment.

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -78,6 +78,7 @@ These references were still pointing to elements in the standard library resourc
 - https://github.com/eclipse-syson/syson/issues/552[#552] [diagrams] Fix _Add Existing Elements_ tool for start and done actions. 
 - https://github.com/eclipse-syson/syson/issues/685[#685] [services] Fix name resolution in constraint expressions.
 It is now possible to reference an element in any of the containing namespaces of the constraint.
+- https://github.com/eclipse-syson/syson/issues/687[#687] [services] Fix the drop of an action from the diagram to an action flow compartment.
 
 === Improvements
 

--- a/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
@@ -95,6 +95,7 @@ Doing so deleted both the dropped element and its children from the diagram, and
 - Fix an issue that made the _addExistingElements_ not work properly for _start_ and _done_ actions inside actions and parts.
 - Fix an issue on constraint expression name resolution that prevented from referencing elements in other containing namespaces than the direct owner of the constraint.
 It is now possible to reference an element in any of the containing namespaces of the constraint.
+- Fix an issue that deleted the content of an action when it was dropped from the diagram to an action flow compartment.
 
 
 == Improvements


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/687