### PR TITLE
[709] Allow to drop Definition from the explorer on an Usage to type it

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -133,6 +133,7 @@ For example, `myAttribute : ISQ::MassValue` now correctly types the attribute wi
   * A warning message is now displayed when attempting to drop an element which is already displayed and visible in the target container.
 - https://github.com/eclipse-syson/syson/issues/670[#670] [diagrams] Ignore keywords order during direct edit of prefixes label of `Definitions` and `Usages` graphical elements.
 - https://github.com/eclipse-syson/syson/issues/689[#689] [diagrams] Ensure coherence between Direct Edit capabilities and the displayed label
+- https://github.com/eclipse-syson/syson/issues/709[#709] [diagrams] Allow to drop a Definition from the explorer on an Usage on a diagram or in a list compartment to type it.
 
 === New features
 

--- a/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.9.0.adoc
@@ -173,6 +173,7 @@ For example, `myAttribute : ISQ::MassValue` now correctly types the attribute wi
 A warning message is now displayed when attempting to drop an element which is already displayed and visible in the target container.
 - Ignore keywords order during direct edit of prefixes labels of `Definitions` and `Usages` graphical elements.
 - DirectEdit on graphical node or list item authorized only to modify keywords which can be displayed in each label.
+- Allow to drop a Definition from the explorer on an Usage on a diagram or in a list compartment to type it.
 
 == New features
 

--- a/integration-tests/cypress/e2e/project/diagrams/general-view/dropFromExplorer.cy.ts
+++ b/integration-tests/cypress/e2e/project/diagrams/general-view/dropFromExplorer.cy.ts
@@ -92,5 +92,42 @@ describe('Drop From Explorer Tests', () => {
         diagram.getNodes(diagramLabel, 'attributes').should('not.exist');
       });
     });
+    context('When we create a PartUsage and a PartDefinition in the root Package in the explorer', () => {
+      beforeEach(() => {
+        explorer.createObject(sysmlv2.getRootElementLabel(), 'SysMLv2EditService-PartUsage');
+        explorer.createObject(sysmlv2.getRootElementLabel(), 'SysMLv2EditService-PartDefinition');
+        explorer.getTreeItemByLabel('part').should('exist');
+        explorer.getTreeItemByLabel('PartDefinition').should('exist');
+      });
+
+      it('Then when we drop the PartUsage on the diagram, and drop the PartDefinition on the PartUsage, the PartUsage is typed with the PartDefinition', () => {
+        const dataTransfer = new DataTransfer();
+        explorer.dragTreeItem('part', dataTransfer);
+        diagram.dropOnDiagram(diagramLabel, dataTransfer);
+        diagram.getNodes(diagramLabel, 'part').should('exist').should('have.length', 1);
+        explorer.dragTreeItem('PartDefinition', dataTransfer);
+        diagram.getNodes(diagramLabel, 'part').should('exist').trigger('drop', { dataTransfer });
+        diagram.getNodes(diagramLabel, 'part : PartDefinition').should('exist').should('have.length', 1);
+      });
+
+      it('Then when we drop the PartUsage and PartDefinition on the diagram, and drop the PartDefinition on the PartUsage, the PartUsage is typed with the PartDefinition and an edge is visible between the PartUsage and PartDefinition', () => {
+        const dataTransfer = new DataTransfer();
+        explorer.dragTreeItem('part', dataTransfer);
+        diagram.dropOnDiagram(diagramLabel, dataTransfer);
+        diagram.getNodes(diagramLabel, 'part').should('exist').should('have.length', 1);
+        explorer.dragTreeItem('PartDefinition', dataTransfer);
+        diagram.dropOnDiagram(diagramLabel, dataTransfer, 'center');
+        diagram.getNodes(diagramLabel, 'PartDefinition').should('exist').should('have.length', 1);
+        explorer.dragTreeItem('PartDefinition', dataTransfer);
+        diagram.getNodes(diagramLabel, 'part').should('exist').trigger('drop', { dataTransfer });
+        diagram.getNodes(diagramLabel, 'part : PartDefinition').should('exist').should('have.length', 1);
+        // Check that an edge has been created and that its end is a closed arrow with dots (i.e. a feature typing).
+        diagram
+          .getEdgePaths(diagramLabel)
+          .should('have.length', 1)
+          .invoke('attr', 'marker-end')
+          .should('contain', '#ClosedArrowWithDots');
+      });
+    });
   });
 });

--- a/integration-tests/cypress/workbench/Diagram.ts
+++ b/integration-tests/cypress/workbench/Diagram.ts
@@ -137,8 +137,9 @@ export class Diagram {
     cy.getByTestId('share').click();
   }
 
-  public dropOnDiagram(diagramLabel: string, dataTransfer: DataTransfer): void {
-    this.getDiagram(diagramLabel).getByTestId('rf__wrapper').trigger('drop', 'bottomRight', { dataTransfer });
+  public dropOnDiagram(diagramLabel: string, dataTransfer: DataTransfer, position?: Cypress.PositionType): void {
+    const dropPosition = position ? position : 'bottomRight';
+    this.getDiagram(diagramLabel).getByTestId('rf__wrapper').trigger('drop', dropPosition, { dataTransfer });
   }
 
   public roundSvgPathData(pathData: string): string {


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/709