### PR TITLE
[doc] Change default start page to have the latest tag version

### DIFF
--- a/doc/docs-site/antora-playbook.yml
+++ b/doc/docs-site/antora-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: SysON Docs
-  start_page: syson::index.adoc
+  start_page: v2024.9.0@syson::index.adoc
 
 output:
   clean: true


### PR DESCRIPTION
Change default start page to have the latest tag version as default page of documentation.