### PR TITLE
[731] Allow Comment creation from Explorer

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@
 
 - https://github.com/eclipse-syson/syson/issues/694[#694] [diagrams] Add a new custom node note among possible node style descriptions.
 - https://github.com/eclipse-syson/syson/issues/695[#695] [diagrams] Add Documentation element as graphical node
+- https://github.com/eclipse-syson/syson/issues/731[#731] [explorer] Allow creation of Comment from the Explorer view
 
 
 == v2024.9.0

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/GetChildCreationSwitch.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/GetChildCreationSwitch.java
@@ -68,6 +68,7 @@ public class GetChildCreationSwitch extends SysmlEClassSwitch<List<EClass>> {
         childrenCandidates.add(SysmlPackage.eINSTANCE.getSubclassification());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getFeatureMembership());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getDocumentation());
+        childrenCandidates.add(SysmlPackage.eINSTANCE.getComment());
         return childrenCandidates;
     }
 
@@ -102,6 +103,7 @@ public class GetChildCreationSwitch extends SysmlEClassSwitch<List<EClass>> {
                 });
         childrenCandidates.add(SysmlPackage.eINSTANCE.getSubclassification());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getDocumentation());
+        childrenCandidates.add(SysmlPackage.eINSTANCE.getComment());
         return childrenCandidates;
     }
 
@@ -192,6 +194,7 @@ public class GetChildCreationSwitch extends SysmlEClassSwitch<List<EClass>> {
         childrenCandidates.add(SysmlPackage.eINSTANCE.getSubclassification());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getFeatureMembership());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getDocumentation());
+        childrenCandidates.add(SysmlPackage.eINSTANCE.getComment());
         return childrenCandidates;
     }
 
@@ -242,6 +245,7 @@ public class GetChildCreationSwitch extends SysmlEClassSwitch<List<EClass>> {
         childrenCandidates.add(SysmlPackage.eINSTANCE.getLiteralString());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getFeatureMembership());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getDocumentation());
+        childrenCandidates.add(SysmlPackage.eINSTANCE.getComment());
         return childrenCandidates;
     }
 
@@ -262,6 +266,7 @@ public class GetChildCreationSwitch extends SysmlEClassSwitch<List<EClass>> {
                 });
         childrenCandidates.add(SysmlPackage.eINSTANCE.getOwningMembership());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getDocumentation());
+        childrenCandidates.add(SysmlPackage.eINSTANCE.getComment());
         return childrenCandidates;
     }
 }

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/GetIntermediateContainerCreationSwitch.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/GetIntermediateContainerCreationSwitch.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.syson.sysml.Comment;
 import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Documentation;
 import org.eclipse.syson.sysml.Element;
@@ -45,6 +46,11 @@ public class GetIntermediateContainerCreationSwitch extends SysmlEClassSwitch<Op
     @Override
     public Optional<EClass> defaultCase(EObject object) {
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<EClass> caseComment(Comment object) {
+        return Optional.of(SysmlPackage.eINSTANCE.getOwningMembership());
     }
 
     @Override

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
@@ -17,6 +17,7 @@ import org.eclipse.syson.sysml.AcceptActionUsage;
 import org.eclipse.syson.sysml.ActorMembership;
 import org.eclipse.syson.sysml.AttributeUsage;
 import org.eclipse.syson.sysml.BindingConnectorAsUsage;
+import org.eclipse.syson.sysml.Comment;
 import org.eclipse.syson.sysml.ConjugatedPortDefinition;
 import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Dependency;
@@ -85,6 +86,12 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
     @Override
     public Element caseBindingConnectorAsUsage(BindingConnectorAsUsage object) {
         object.setDeclaredName("bind");
+        return object;
+    }
+
+    @Override
+    public Element caseComment(Comment object) {
+        object.setBody("add comment here");
         return object;
     }
 

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -20,3 +20,5 @@ The `Documentation` graphical node is linked to its documented element by an edg
 - Display prefix keywords in labels of `Documentation` graphical nodes.
 
 image::release-notes-documentation-note.png[Documentation note node]
+
+- Allow creation of Comment from the Explorer view.


### PR DESCRIPTION
User can now create a new Comment element from the explorer view.

Bug: https://github.com/eclipse-syson/syson/issues/731
Signed-off-by: Jessy Mallet <jessy.mallet@obeo.fr>

Be careful, before merging this PR, PR https://github.com/eclipse-syson/syson/pull/728 should be merged.