### PR TITLE
[740] Fix missing declaredName after exporting an annotating element

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -24,10 +24,11 @@ The following classes have been renamed to reflect their new usage:
 === New features
 
 - https://github.com/eclipse-syson/syson/issues/694[#694] [diagrams] Add a new custom node note among possible node style descriptions.
-- https://github.com/eclipse-syson/syson/issues/695[#695] [diagrams] Add Documentation element as graphical node in all diagrams
-- https://github.com/eclipse-syson/syson/issues/731[#731] [explorer] Allow creation of Comment from the Explorer view
-- https://github.com/eclipse-syson/syson/issues/696[#696] [diagrams] Add Comment element as graphical node in all diagrams
+- https://github.com/eclipse-syson/syson/issues/695[#695] [diagrams] Add Documentation element as graphical node in all diagrams.
+- https://github.com/eclipse-syson/syson/issues/731[#731] [explorer] Allow creation of Comment from the Explorer view.
+- https://github.com/eclipse-syson/syson/issues/696[#696] [diagrams] Add Comment element as graphical node in all diagrams.
 - https://github.com/eclipse-syson/syson/issues/697[#697] [details] Add Comment property to Core tab of the Details view.
+- https://github.com/eclipse-syson/syson/issues/740[#740] [export] Fix missing declaredName after exporting an annotating element.
 
 
 == v2024.9.0

--- a/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/SysMLElementSerializer.java
+++ b/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/SysMLElementSerializer.java
@@ -1630,7 +1630,7 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
         Appender builder = this.newAppender();
         EList<Element> annotatedElements = comment.getAnnotatedElement();
         boolean selfNamespaceDescribingComment = this.isSelfNamespaceDescribingComment(comment);
-        if (isNullOrEmpty(comment.getLocale()) && selfNamespaceDescribingComment) {
+        if (isNullOrEmpty(comment.getLocale()) && selfNamespaceDescribingComment && comment.getDeclaredName() == null) {
             builder.append(this.getCommentBody(comment.getBody()));
         } else {
             builder.append("comment");
@@ -1656,6 +1656,7 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
         Appender builder = this.newAppender();
 
         builder.appendSpaceIfNeeded().append("doc");
+        this.appendNameWithShortName(builder, doc);
         boolean selfNamespaceDescribingComment = this.isSelfNamespaceDescribingComment(doc);
         if (isNullOrEmpty(doc.getLocale()) && selfNamespaceDescribingComment) {
             builder.appendWithSpaceIfNeeded(this.getCommentBody(doc.getBody()));

--- a/backend/application/syson-sysml-export/src/test/java/org/eclipse/syson/sysml/export/SysMLElementSerializerTest.java
+++ b/backend/application/syson-sysml-export/src/test/java/org/eclipse/syson/sysml/export/SysMLElementSerializerTest.java
@@ -119,6 +119,10 @@ public class SysMLElementSerializerTest {
 
     private static final String SUBSETTING2 = "sub2";
 
+    private static final String ANNOTATING1 = "Annotating1";
+
+    private static final String BODY = "A body";
+
     private ModelBuilder builder;
 
     private List<Status> status;
@@ -217,10 +221,10 @@ public class SysMLElementSerializerTest {
 
         this.builder.setType(partUsage, partDef);
 
-        this.builder.createIn(Comment.class, partUsage).setBody("A comment");
+        this.builder.createIn(Comment.class, partUsage).setBody(BODY);
         this.assertTextualFormEquals("""
                 ref part PartUsage1 : 'Part Def1' {
-                    /* A comment */
+                    /* A body */
                 }""", partUsage);
     }
 
@@ -453,7 +457,7 @@ public class SysMLElementSerializerTest {
         Package pack1 = this.fact.createPackage();
         pack1.setDeclaredName(PACKAGE1);
         Comment comment = this.fact.createComment();
-        comment.setBody("A body");
+        comment.setBody(BODY);
         this.addOwnedMembership(pack1, comment);
         this.assertTextualFormEquals("""
                 package Package1 {
@@ -462,14 +466,32 @@ public class SysMLElementSerializerTest {
     }
 
     /**
-     * Comment in Namespace can use a simple serialization format only only if no other information are provided.
+     * Comment in Namespace can use a simple serialization format only if no other declaredName is specified.
+     */
+    @Test
+    public void commentInNamespaceWithDeclaredName() {
+        Package pack1 = this.fact.createPackage();
+        pack1.setDeclaredName(PACKAGE1);
+        Comment comment = this.fact.createComment();
+        comment.setDeclaredName(ANNOTATING1);
+        comment.setBody(BODY);
+        this.addOwnedMembership(pack1, comment);
+        this.assertTextualFormEquals("""
+                package Package1 {
+                    comment Annotating1
+                        /* A body */
+                }""", pack1);
+    }
+
+    /**
+     * Comment in Namespace can use a simple serialization format only if no other information are provided.
      */
     @Test
     public void commentInNamespaceWithLocal() {
         Package pack1 = this.fact.createPackage();
         pack1.setDeclaredName(PACKAGE1);
         Comment comment = this.fact.createComment();
-        comment.setBody("A body");
+        comment.setBody(BODY);
         comment.setLocale("fr_FR");
         this.addOwnedMembership(pack1, comment);
         this.assertTextualFormEquals("""
@@ -489,7 +511,7 @@ public class SysMLElementSerializerTest {
         this.addOwnedMembership(pack1, attr);
 
         Comment comment = this.fact.createComment();
-        comment.setBody("A body");
+        comment.setBody(BODY);
         comment.setDeclaredName("XXX");
         comment.setDeclaredShortName("X");
         comment.setLocale("fr_FR");
@@ -617,7 +639,7 @@ public class SysMLElementSerializerTest {
         partDef.setDeclaredName("PartDef1");
 
         Comment comment = this.fact.createComment();
-        comment.setBody("A body");
+        comment.setBody(BODY);
         this.addOwnedMembership(partDef, comment);
 
         this.assertTextualFormEquals("""
@@ -662,7 +684,7 @@ public class SysMLElementSerializerTest {
         this.addOwnedMembership(greyLiteral, m1u);
         EnumerationUsage redLiteral = this.builder.createInWithName(EnumerationUsage.class, enumDef, "red");
 
-        this.builder.createIn(Comment.class, redLiteral).setBody("A body");
+        this.builder.createIn(Comment.class, redLiteral).setBody(BODY);
 
         this.assertTextualFormEquals("""
                 enum def Colors {
@@ -1163,11 +1185,11 @@ public class SysMLElementSerializerTest {
         RequirementUsage req = this.builder.createWithName(RequirementUsage.class, "requs");
 
         SubjectMembership subject = this.builder.createIn(SubjectMembership.class, req);
-        
+
         ReferenceUsage referenceUsage = this.builder.createWithName(ReferenceUsage.class, "subject_1");
         subject.getOwnedRelatedElement().add(referenceUsage);
         referenceUsage.setDirection(FeatureDirectionKind.IN);
-        
+
 
         PartDefinition partDefinition = this.builder.createWithName(PartDefinition.class, "partD_1");
         this.builder.setType(referenceUsage, partDefinition);
@@ -1496,7 +1518,7 @@ public class SysMLElementSerializerTest {
                 }""", root);
 
     }
-    
+
     @Test
     public void documentation() {
 
@@ -1512,11 +1534,29 @@ public class SysMLElementSerializerTest {
                     doc /* A comment */
                 }""", partUsage);
     }
-     
+
+    @Test
+    public void documentationWithDeclaredName() {
+
+        PartDefinition partDef = this.builder.createWithName(PartDefinition.class, "Part Def1");
+
+        PartUsage partUsage = this.builder.createWithName(PartUsage.class, "PartUsage1");
+
+        this.builder.setType(partUsage, partDef);
+
+        this.builder.createIn(Documentation.class, partUsage).setBody(BODY);
+        partUsage.getDocumentation().get(0).setDeclaredName(ANNOTATING1);
+
+        this.assertTextualFormEquals("""
+                ref part PartUsage1 : 'Part Def1' {
+                    doc Annotating1 /* A body */
+                }""", partUsage);
+    }
+
     @Test
     public void itemUsage() {
-        var model = new ItemTest(builder);
-        
+        var model = new ItemTest(this.builder);
+
         this.assertTextualFormEquals("""
             package ItemTest {
                 item f : A;

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -42,3 +42,4 @@ image::release-notes-comment-note.png[Comment note node]
 - Add `Comment` property to Core tab of the Details view, allowing to add/edit a `Comment` for the selected element.
 This property widget will only handle the first `Comment` associated to the selected element.
 If no `Comment` is associated to the selected element, then a new value in this widget will also create a `Comment` element and will associate it to the selected element.
+- Add declaredName attribute in annotating export file result if the annotatingElement contains a declaredName.


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/740