### PR TITLE
[744] Fix containment of imported Allocation and AllocationDefinition

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ The following classes have been renamed to reflect their new usage:
 === Dependency update
 
 === Bug fixes
+- https://github.com/eclipse-syson/syson/issues/744[#744] [import] Fix containment of imported Allocation and AllocationDefinition
 
 === Improvements
 

--- a/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/parser/AstContainmentReferenceParser.java
+++ b/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/parser/AstContainmentReferenceParser.java
@@ -23,6 +23,7 @@ import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureTyping;
 import org.eclipse.syson.sysml.Featuring;
+import org.eclipse.syson.sysml.Namespace;
 import org.eclipse.syson.sysml.OwningMembership;
 import org.eclipse.syson.sysml.PortDefinition;
 import org.eclipse.syson.sysml.Redefinition;
@@ -104,7 +105,12 @@ public class AstContainmentReferenceParser {
             ownerConjugatedPortTyping.setConjugatedPortDefinition(ownedPortDefinition.getConjugatedPortDefinition());
         }
 
-        if (owner instanceof Element ownerElement && owned instanceof Relationship ownedRelationship) {
+        if (owner instanceof Element ownerElement && owned instanceof Relationship ownedRelationship
+                && !(owned instanceof Namespace)) {
+            // The owned object is a Relationship and isn't a Namespace (e.g. Membership, Specialization). We have to
+            // set its owning related element and source, and add it to the relationships of its owner. This is not the
+            // case if the element is a Relationship and a Namespace: these elements (e.g. Allocation) are handled as
+            // Element and not as Relationships and these references shouldn't be set here.
             LOGGER.trace("ownerElement");
             ownerElement.getOwnedRelationship().add(ownedRelationship);
             ownedRelationship.setOwningRelatedElement(ownerElement);

--- a/backend/application/syson-sysml-import/src/test/resources/ASTTransformerTest/convertAllocationTest/allocation.ast.json
+++ b/backend/application/syson-sysml-import/src/test/resources/ASTTransformerTest/convertAllocationTest/allocation.ast.json
@@ -1,0 +1,50 @@
+{
+  "$type": "Namespace",
+  "children": [
+    {
+      "$type": "OwningMembership",
+      "target": {
+        "$type": "Package",
+        "children": [
+          {
+            "$type": "OwningMembership",
+            "target": {
+              "$type": "AllocationDefinition",
+              "declaredName": "A"
+            }
+          },
+          {
+            "$type": "OwningMembership",
+            "target": {
+              "$type": "AllocationUsage",
+              "children": [
+                {
+                  "$type": "FeatureMembership",
+                  "target": {
+                    "$type": "PartUsage",
+                    "declaredName": "source"
+                  }
+                }
+              ],
+              "heritage": [
+                {
+                  "$type": "FeatureTyping",
+                  "targetRef": {
+                    "$type": "TypeReference",
+                    "text": "A",
+                    "reference": "AllocationTest::A",
+                    "parts": [
+                      "AllocationTest::A"
+                    ]
+                  }
+                }
+              ],
+              "declaredName": "allocation1"
+            }
+          }
+        ],
+        "declaredName": "AllocationTest"
+      }
+    }
+  ]
+}

--- a/backend/application/syson-sysml-import/src/test/resources/ASTTransformerTest/convertAllocationTest/allocation.sysml
+++ b/backend/application/syson-sysml-import/src/test/resources/ASTTransformerTest/convertAllocationTest/allocation.sysml
@@ -1,0 +1,9 @@
+package AllocationTest {
+
+    allocation def A;
+
+    allocation allocation1 : A {
+        part source;
+    }
+
+}

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -19,6 +19,7 @@
 == Dependencies update
 
 == Bug fixes
+- Fix an issue that prevented the import of `Allocation` and `AllocationDefinition`.
 
 == Improvements
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/744

This PR **doesn't** allow to import the `AllocationTest.sysml` file in SysML-v2-Release _Simple Tests_. This file emphasize other issues related to namespace resolution that are out of the scope of this PR.