### PR TITLE
[761] Make Declared Short Name accessible from the Core tab

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,6 +42,7 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 - https://github.com/eclipse-syson/syson/issues/717[#717] [import] Handle of aliases and external references have been improved.
 - https://github.com/eclipse-syson/syson/issues/756[#756] [diagrams] Add short name in container and compartment item labels.
 - https://github.com/eclipse-syson/syson/issues/760[#760] [diagrams] Allow to set short name via direct edit.
+- https://github.com/eclipse-syson/syson/issues/761[#761] [details] Make Declared Short Name accessible from the Core tab.
 
 === New features
 

--- a/backend/application/syson-application-configuration/pom.xml
+++ b/backend/application/syson-application-configuration/pom.xml
@@ -92,6 +92,11 @@
 			<version>2024.9.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<version>1.15.3</version>

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/CoreFeaturesSwitch.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/CoreFeaturesSwitch.java
@@ -80,6 +80,7 @@ public class CoreFeaturesSwitch extends SysmlSwitch<List<EStructuralFeature>> {
         var features = new ArrayList<EStructuralFeature>();
         features.add(SysmlPackage.eINSTANCE.getElement_DeclaredName());
         features.add(SysmlPackage.eINSTANCE.getElement_QualifiedName());
+        features.add(SysmlPackage.eINSTANCE.getElement_DeclaredShortName());
         return features;
     }
 

--- a/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/DetailsViewServiceTest.java
+++ b/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/DetailsViewServiceTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
+import org.eclipse.syson.sysml.SysmlFactory;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the {@link DetailsViewService}.
+ *
+ * @author gdaniel
+ */
+public class DetailsViewServiceTest {
+
+    private DetailsViewService detailsViewService;
+
+    @BeforeEach
+    public void setUp() {
+        // Use a dummy CompsedAdapterFactory, we don't test methods that require the one used by SysON for the moment.
+        this.detailsViewService = new DetailsViewService(new ComposedAdapterFactory(), new IFeedbackMessageService.NoOp());
+    }
+
+    @Test
+    public void getCoreFeaturesOfPartUsage() {
+        List<EStructuralFeature> coreStructuralFeatures = this.detailsViewService.getCoreFeatures(SysmlFactory.eINSTANCE.createPartUsage());
+        assertThat(coreStructuralFeatures).containsOnly(SysmlPackage.eINSTANCE.getElement_DeclaredName(),
+                SysmlPackage.eINSTANCE.getElement_QualifiedName(),
+                SysmlPackage.eINSTANCE.getElement_DeclaredShortName(),
+                SysmlPackage.eINSTANCE.getFeature_Direction(),
+                SysmlPackage.eINSTANCE.getOccurrenceUsage_IsIndividual());
+    }
+}

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -41,6 +41,7 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 - Handle of aliases and external references have been improved for textual import.
 - Add support for short name in container and compartment item labels.
 - Allow to set short name via the direct edit.
+- Make Declared Short Name accessible from the Core tab instead of the Advanced tab in the details view.
 
 == New features
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/761

# Pull request template

PLEASE READ ALL ITEMS AND CHECK RELEVANT CHECKBOXES BELOW.

## Project management

- [x] Has the pull request been added to the relevant project and milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
