### PR TITLE
[765] Remove default name of relationships and improve edge labels

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,8 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 * `getCompartmentNodeGraphicalChecker`
 * `getSiblingNodeGraphicalChecker`
 * `checkDiagram`
+- https://github.com/eclipse-syson/syson/issues/765[#765] [diagrams] Remove default name of relationships and improve edge labels.
+The method `getSuccessionLabel` in `ViewLabelService` has been deleted, succession labels are now computed with the generic `getEdgeLabel` method.
 
 === Dependency update
 
@@ -43,6 +45,7 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 - https://github.com/eclipse-syson/syson/issues/756[#756] [diagrams] Add short name in container and compartment item labels.
 - https://github.com/eclipse-syson/syson/issues/760[#760] [diagrams] Allow to set short name via direct edit.
 - https://github.com/eclipse-syson/syson/issues/761[#761] [details] Make Declared Short Name accessible from the Core tab.
+- https://github.com/eclipse-syson/syson/issues/765[#765] [diagrams] Remove default name of relationships and improve edge labels.
 
 === New features
 

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/ElementInitializerSwitch.java
@@ -85,7 +85,6 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
 
     @Override
     public Element caseBindingConnectorAsUsage(BindingConnectorAsUsage object) {
-        object.setDeclaredName("bind");
         return object;
     }
 
@@ -97,7 +96,6 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
 
     @Override
     public Element caseDependency(Dependency object) {
-        object.setDeclaredName("dependency");
         return object;
     }
 
@@ -127,13 +125,11 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
 
     @Override
     public Element caseFeatureTyping(FeatureTyping object) {
-        object.setDeclaredName("typed by");
         return object;
     }
 
     @Override
     public Element caseFlowConnectionUsage(FlowConnectionUsage object) {
-        object.setDeclaredName("flow");
         return object;
     }
 
@@ -176,13 +172,11 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
 
     @Override
     public Element caseRedefinition(Redefinition object) {
-        object.setDeclaredName("redefines");
         return object;
     }
 
     @Override
     public Element caseReferenceSubsetting(ReferenceSubsetting object) {
-        object.setDeclaredName("references");
         return object;
     }
 
@@ -208,39 +202,26 @@ public class ElementInitializerSwitch extends SysmlSwitch<Element> {
 
     @Override
     public Element caseSpecialization(Specialization object) {
-        object.setDeclaredName("specializes");
         return object;
     }
 
     @Override
     public Element caseSubclassification(Subclassification object) {
-        object.setDeclaredName("specializes");
         return object;
     }
 
     @Override
     public Element caseSubsetting(Subsetting object) {
-        object.setDeclaredName("subsets");
         return object;
     }
 
     @Override
     public Element caseSuccessionAsUsage(SuccessionAsUsage object) {
-        object.setDeclaredName("succession");
         return object;
     }
 
     @Override
     public Element caseTransitionUsage(TransitionUsage object) {
-        StringBuilder label = new StringBuilder();
-        var source = object.getSource();
-        var target = object.getTarget();
-        if (source != null && target != null) {
-            label = label.append(source.getName()).append("_to_").append(target.getName());
-        } else {
-            label.append("transition");
-        }
-        object.setDeclaredName(label.toString());
         return object;
     }
 

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/LabelService.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/LabelService.java
@@ -213,8 +213,7 @@ public class LabelService {
         if (element instanceof Usage usage) {
             builder.append(this.getBasicNamePrefix(usage));
         }
-        builder.append(this.getShortNameLabel(element));
-        builder.append(element.getDeclaredName());
+        builder.append(this.getIdentificationLabel(element));
         builder.append(this.getMultiplicityLabel(element));
         builder.append(this.getTypingLabel(element));
         builder.append(this.getRedefinitionLabel(element));
@@ -381,6 +380,26 @@ public class LabelService {
             // AttributeUsage are always referential, so no need to add the ref keyword
             label.append(LabelConstants.REF + LabelConstants.SPACE);
         }
+    }
+
+    /**
+     * Returns the identification of the provided {@code element}.
+     * <p>
+     * The identification of an element is the concatenation of its <i>short name</i> and its <i>declared name</i>.
+     * </p>
+     *
+     * @param element
+     *            the element to get the identification from
+     * @return the identification
+     */
+    protected String getIdentificationLabel(Element element) {
+        StringBuilder label = new StringBuilder();
+        label.append(this.getShortNameLabel(element));
+        String declaredName = element.getDeclaredName();
+        if (declaredName != null) {
+            label.append(declaredName);
+        }
+        return label.toString();
     }
 
     /**

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/MultiLineLabelSwitch.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/MultiLineLabelSwitch.java
@@ -83,11 +83,7 @@ public class MultiLineLabelSwitch extends SysmlSwitch<String> {
     @Override
     public String caseElement(Element object) {
         StringBuilder label = new StringBuilder();
-        label.append(this.labelService.getShortNameLabel(object));
-        String declaredName = object.getDeclaredName();
-        if (declaredName != null) {
-            label.append(declaredName);
-        }
+        label.append(this.labelService.getIdentificationLabel(object));
         return label.toString();
     }
 

--- a/backend/views/syson-diagram-actionflow-view/src/test/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-actionflow-view/src/test/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionTests.java
@@ -86,6 +86,7 @@ public class ActionFlowViewDiagramDescriptionTests {
                 .filter(edgeDescription -> edgeDescription.getCenterLabelExpression() != null && !edgeDescription.getCenterLabelExpression().isBlank())
                 // SuccessionAsUsage has a label but the grammar does not support the direct edit tool yet
                 .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getSuccessionAsUsage()).negate())
+                .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getAllocationUsage()).negate())
                 .toList();
         new EdgeDescriptionHasDirectEditToolChecker().checkAll(edgeDescriptionCandidates);
     }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractAllocateEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractAllocateEdgeDescriptionProvider.java
@@ -21,11 +21,11 @@ import org.eclipse.sirius.components.view.diagram.ArrowStyle;
 import org.eclipse.sirius.components.view.diagram.DiagramDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeStyle;
-import org.eclipse.sirius.components.view.diagram.LabelEditTool;
 import org.eclipse.sirius.components.view.diagram.LineStyle;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.sysml.helper.LabelConstants;
 import org.eclipse.syson.util.AQLConstants;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -75,7 +75,7 @@ public abstract class AbstractAllocateEdgeDescriptionProvider extends AbstractEd
         return this.diagramBuilderHelper.newEdgeDescription()
                 .domainType(domainType)
                 .isDomainBasedEdge(true)
-                .centerLabelExpression("allocate")
+                .centerLabelExpression(LabelConstants.OPEN_QUOTE + "allocate" + LabelConstants.CLOSE_QUOTE)
                 .name(this.getName())
                 .semanticCandidatesExpression(AQLConstants.AQL_SELF + ".getAllReachableAllocateEdges()")
                 .sourceNodesExpression(AQLConstants.AQL_SELF + ".getSourceAllocateEdge()")
@@ -119,16 +119,5 @@ public abstract class AbstractAllocateEdgeDescriptionProvider extends AbstractEd
     protected ChangeContextBuilder getTargetReconnectToolBody() {
         return this.viewBuilderHelper.newChangeContext()
                 .expression(AQLUtils.getServiceCallExpression(AQLConstants.EDGE_SEMANTIC_ELEMENT, "reconnectTargetAllocateEdge", AQLConstants.SEMANTIC_RECONNECTION_TARGET));
-    }
-
-    @Override
-    protected LabelEditTool getEdgeEditTool() {
-        var callEditService = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLConstants.AQL_SELF + ".directEditNameOff(newLabel)");
-
-        return this.diagramBuilderHelper.newLabelEditTool()
-                .name("Edit")
-                .initialDirectEditLabelExpression(AQLConstants.AQL_SELF + ".getDefaultInitialDirectEditLabel()")
-                .body(callEditService.build()).build();
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDependencyEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDependencyEdgeDescriptionProvider.java
@@ -21,12 +21,14 @@ import org.eclipse.sirius.components.view.diagram.ArrowStyle;
 import org.eclipse.sirius.components.view.diagram.DiagramDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeStyle;
+import org.eclipse.sirius.components.view.diagram.LabelEditTool;
 import org.eclipse.sirius.components.view.diagram.LineStyle;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.sysml.Dependency;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -74,7 +76,7 @@ public abstract class AbstractDependencyEdgeDescriptionProvider extends Abstract
         return this.diagramBuilderHelper.newEdgeDescription()
                 .domainType(domainType)
                 .isDomainBasedEdge(true)
-                .centerLabelExpression("")
+                .centerLabelExpression(AQLUtils.getSelfServiceCallExpression("getDependencyLabel"))
                 .name(this.getName())
                 .semanticCandidatesExpression("aql:self.getAllReachable(" + domainType + ")")
                 .sourceNodesExpression(AQLConstants.AQL_SELF + "." + SysmlPackage.eINSTANCE.getDependency_Client().getName())
@@ -104,6 +106,18 @@ public abstract class AbstractDependencyEdgeDescriptionProvider extends Abstract
                 .lineStyle(LineStyle.DASH)
                 .sourceArrowStyle(ArrowStyle.NONE)
                 .targetArrowStyle(ArrowStyle.INPUT_ARROW)
+                .build();
+    }
+
+    @Override
+    protected LabelEditTool getEdgeEditTool() {
+        var changeContext = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLUtils.getSelfServiceCallExpression("directEdit", "newLabel"))
+                .build();
+
+        return this.diagramBuilderHelper.newLabelEditTool()
+                .name("Edit Dependency Label")
+                .body(changeContext)
                 .build();
     }
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSuccessionEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSuccessionEdgeDescriptionProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.components.view.diagram.ArrowStyle;
 import org.eclipse.sirius.components.view.diagram.DiagramDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeStyle;
+import org.eclipse.sirius.components.view.diagram.LabelEditTool;
 import org.eclipse.sirius.components.view.diagram.LineStyle;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
@@ -71,7 +72,7 @@ public abstract class AbstractSuccessionEdgeDescriptionProvider extends Abstract
         return this.diagramBuilderHelper.newEdgeDescription()
                 .domainType(domainType)
                 .isDomainBasedEdge(true)
-                .centerLabelExpression(AQLUtils.getSelfServiceCallExpression("getSuccessionLabel"))
+                .centerLabelExpression(AQLUtils.getSelfServiceCallExpression("getEdgeLabel"))
                 .name(this.descriptionNameGenerator.getEdgeName(SysmlPackage.eINSTANCE.getSuccession()))
                 .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
                 .style(this.createEdgeStyle())
@@ -103,6 +104,18 @@ public abstract class AbstractSuccessionEdgeDescriptionProvider extends Abstract
         var params = List.of(AQLConstants.SEMANTIC_RECONNECTION_SOURCE, AQLConstants.SEMANTIC_RECONNECTION_TARGET);
         return this.viewBuilderHelper.newChangeContext()
                 .expression(AQLUtils.getServiceCallExpression(AQLConstants.EDGE_SEMANTIC_ELEMENT, "reconnectTargetSuccessionEdge", params));
+    }
+
+    @Override
+    protected LabelEditTool getEdgeEditTool() {
+        var changeContext = this.viewBuilderHelper.newChangeContext()
+                .expression(AQLUtils.getSelfServiceCallExpression("directEdit", "newLabel"))
+                .build();
+
+        return this.diagramBuilderHelper.newLabelEditTool()
+                .name("Edit Succession Label")
+                .body(changeContext)
+                .build();
     }
 
     private EdgeStyle createEdgeStyle() {

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewCreateService.java
@@ -428,7 +428,6 @@ public class ViewCreateService {
         var ownerMembership = SysmlFactory.eINSTANCE.createOwningMembership();
         owner.getOwnedRelationship().add(ownerMembership);
         var allocation = SysmlFactory.eINSTANCE.createAllocationUsage();
-        allocation.setDeclaredName("allocate");
         ownerMembership.getOwnedRelatedElement().add(allocation);
         // create both ends ReferenceSubsetting
         this.addEndToAllocateEdge(allocation, source);

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewLabelService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewLabelService.java
@@ -30,12 +30,12 @@ import org.eclipse.syson.sysml.AcceptActionUsage;
 import org.eclipse.syson.sysml.ActionUsage;
 import org.eclipse.syson.sysml.Comment;
 import org.eclipse.syson.sysml.ConstraintUsage;
+import org.eclipse.syson.sysml.Dependency;
 import org.eclipse.syson.sysml.Documentation;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.Expression;
 import org.eclipse.syson.sysml.RequirementConstraintMembership;
 import org.eclipse.syson.sysml.StateSubactionMembership;
-import org.eclipse.syson.sysml.Succession;
 import org.eclipse.syson.sysml.TransitionFeatureKind;
 import org.eclipse.syson.sysml.TransitionUsage;
 import org.eclipse.syson.sysml.Usage;
@@ -99,11 +99,7 @@ public class ViewLabelService extends LabelService {
             label.append(this.getCompartmentItemLabel(constraintUsage));
         } else {
             label.append(this.getUsageListItemPrefix(usage));
-            label.append(this.getShortNameLabel(usage));
-            String declaredName = usage.getDeclaredName();
-            if (declaredName != null) {
-                label.append(declaredName);
-            }
+            label.append(this.getIdentificationLabel(usage));
             label.append(this.getMultiplicityLabel(usage));
             label.append(this.getTypingLabel(usage));
             label.append(this.getRedefinitionLabel(usage));
@@ -111,6 +107,31 @@ public class ViewLabelService extends LabelService {
             label.append(this.getValueLabel(usage));
         }
         return label.toString();
+    }
+
+    /**
+     * The default label for edges.
+     *
+     * @param element
+     *            the element to get the edge label from
+     * @return the edge label
+     */
+    public String getEdgeLabel(Element element) {
+        StringBuilder label = new StringBuilder();
+        label.append(this.getIdentificationLabel(element));
+        label.append(this.getTypingLabel(element));
+        return label.toString();
+    }
+
+    /**
+     * Returns the label for the given {@code dependency}.
+     *
+     * @param dependency
+     *            the dependency to get the edge label from
+     * @return the edge label
+     */
+    public String getDependencyLabel(Dependency dependency) {
+        return this.getIdentificationLabel(dependency);
     }
 
     /**
@@ -126,8 +147,7 @@ public class ViewLabelService extends LabelService {
             label.append(this.getValue(expression));
         } else {
             // The constraint doesn't have an expression, we use its name as default label.
-            label.append(this.getShortNameLabel(constraintUsage));
-            label.append(constraintUsage.getDeclaredName());
+            label.append(this.getIdentificationLabel(constraintUsage));
         }
         return label.toString();
     }
@@ -257,27 +277,6 @@ public class ViewLabelService extends LabelService {
                 .forEach(val -> this.utilService.removeTransitionFeaturesOfSpecificKind(element, val));
 
         return element;
-    }
-
-    /**
-     * Succession edge label getter service.
-     *
-     * @param succession
-     *            The succession edge
-     * @return the label of the given {@link Succession}
-     */
-    public String getSuccessionLabel(Succession succession) {
-        StringBuilder resultLabel = new StringBuilder();
-        var guardExpressions = succession.getGuardExpression();
-        if (!guardExpressions.isEmpty()) {
-            String guardLabel = this.getGuardExpressionsDefaultDirectEditLabel(guardExpressions);
-            if (!guardLabel.isBlank()) {
-                resultLabel.append(LabelConstants.OPEN_BRACKET)
-                        .append(guardLabel)
-                        .append(LabelConstants.CLOSE_BRACKET);
-            }
-        }
-        return resultLabel.toString();
     }
 
     /**

--- a/backend/views/syson-diagram-common-view/src/test/java/org/eclipse/syson/diagram/common/view/services/ViewLabelServiceTest.java
+++ b/backend/views/syson-diagram-common-view/src/test/java/org/eclipse/syson/diagram/common/view/services/ViewLabelServiceTest.java
@@ -20,12 +20,14 @@ import java.util.List;
 import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.syson.sysml.AttributeUsage;
 import org.eclipse.syson.sysml.ConstraintUsage;
+import org.eclipse.syson.sysml.Dependency;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureChainExpression;
 import org.eclipse.syson.sysml.FeatureChaining;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
 import org.eclipse.syson.sysml.FeatureReferenceExpression;
 import org.eclipse.syson.sysml.FeatureValue;
+import org.eclipse.syson.sysml.InterfaceUsage;
 import org.eclipse.syson.sysml.LiteralInteger;
 import org.eclipse.syson.sysml.Membership;
 import org.eclipse.syson.sysml.OperatorExpression;
@@ -53,6 +55,10 @@ public class ViewLabelServiceTest {
     private static final String ATTRIBUTE_USAGE_SHORT_NAME = "shortName";
 
     private static final String CONSTRAINT_USAGE_NAME = "myConstraint";
+
+    private static final String SHORT_NAME = "1.1";
+
+    private static final String SHORT_NAME_LABEL = LabelConstants.LESSER_THAN + SHORT_NAME + LabelConstants.GREATER_THAN;
 
     private ViewLabelService viewLabelService;
 
@@ -251,6 +257,26 @@ public class ViewLabelServiceTest {
         feature.getOwnedRelationship().addAll(List.of(featureChaining1, featureChaining2));
 
         assertThat(this.viewLabelService.getCompartmentItemLabel(constraintUsage)).isEqualTo("1 >= x.y.z");
+    }
+
+    @DisplayName("Given a Dependency with a name and short name, when its edge label is computed, then the label contains the name and short name")
+    @Test
+    public void testGetDependencyLabelOfDependencyWithNameAndShortName() {
+        Dependency dependency = SysmlFactory.eINSTANCE.createDependency();
+        dependency.setDeclaredShortName(SHORT_NAME);
+        dependency.setDeclaredName("dependency");
+
+        assertThat(this.viewLabelService.getDependencyLabel(dependency)).isEqualTo(SHORT_NAME_LABEL + " dependency");
+    }
+
+    @DisplayName("Given an Interface with a name and short name, when its edge label is computed, then the label contains the name and short name")
+    @Test
+    public void testGetEdgeLabelOfInterfaceWithNameAndShortName() {
+        InterfaceUsage interfaceUsage = SysmlFactory.eINSTANCE.createInterfaceUsage();
+        interfaceUsage.setDeclaredShortName(SHORT_NAME);
+        interfaceUsage.setDeclaredName("interface");
+
+        assertThat(this.viewLabelService.getEdgeLabel(interfaceUsage)).isEqualTo(SHORT_NAME_LABEL + " interface");
     }
 
     /**

--- a/backend/views/syson-diagram-general-view/src/test/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-general-view/src/test/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionTests.java
@@ -86,6 +86,7 @@ public class GeneralViewDiagramDescriptionTests {
                 .filter(edgeDescription -> edgeDescription.getCenterLabelExpression() != null && !edgeDescription.getCenterLabelExpression().isBlank())
                 // SuccessionAsUsage has a label but the grammar does not support the direct edit tool yet
                 .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getSuccessionAsUsage()).negate())
+                .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getAllocationUsage()).negate())
                 .toList();
         new EdgeDescriptionHasDirectEditToolChecker().checkAll(edgeDescriptionCandidates);
     }

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/edges/BindingConnectorAsUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/edges/BindingConnectorAsUsageEdgeDescriptionProvider.java
@@ -67,7 +67,7 @@ public class BindingConnectorAsUsageEdgeDescriptionProvider implements IEdgeDesc
         return this.diagramBuilderHelper.newEdgeDescription()
                 .domainType(domainType)
                 .isDomainBasedEdge(true)
-                .centerLabelExpression("")
+                .centerLabelExpression("=")
                 .name(this.getName())
                 .semanticCandidatesExpression("aql:self.getAllReachable(" + domainType + ")")
                 .sourceNodesExpression("aql:self.getSourcePort()")

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewCreateService.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewCreateService.java
@@ -94,7 +94,9 @@ public class InterconnectionViewCreateService extends ViewCreateService {
 
         InterfaceUsage interfaceUsage = SysmlFactory.eINSTANCE.createInterfaceUsage();
         this.elementInitializer(interfaceUsage);
-        interfaceUsage.setDeclaredName("connect");
+        // Edges should have an empty default name. This is not the case when using the initializer, because
+        // InterfaceUsage can be a node, which requires a default name.
+        interfaceUsage.setDeclaredName("");
         featureMembership.getOwnedRelatedElement().add(interfaceUsage);
 
         EndFeatureMembership sourceEndFeatureMembership = SysmlFactory.eINSTANCE.createEndFeatureMembership();

--- a/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewLabelService.java
+++ b/backend/views/syson-diagram-interconnection-view/src/main/java/org/eclipse/syson/diagram/interconnection/view/services/InterconnectionViewLabelService.java
@@ -16,8 +16,6 @@ import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
 import org.eclipse.syson.diagram.common.view.services.ShowDiagramsIconsService;
 import org.eclipse.syson.diagram.common.view.services.ViewLabelService;
 import org.eclipse.syson.diagram.interconnection.view.InterconnectionViewDiagramDescriptionProvider;
-import org.eclipse.syson.sysml.ConnectorAsUsage;
-import org.eclipse.syson.sysml.PortUsage;
 import org.eclipse.syson.sysml.Usage;
 
 /**
@@ -45,21 +43,6 @@ public class InterconnectionViewLabelService extends ViewLabelService {
                 .append(this.getTypingLabel(usage))
                 .append(this.getRedefinitionLabel(usage))
                 .append(this.getSubsettingLabel(usage));
-        return label.toString();
-    }
-
-    /**
-     * Get the label for the given {@link ConnectorAsUsage}. The label is used a edge label only.
-     *
-     * @param connector
-     *            the given {@link ConnectorAsUsage}.
-     * @return the label for the given {@link PortUsage}.
-     */
-    public String getEdgeLabel(ConnectorAsUsage connector) {
-        StringBuilder label = new StringBuilder();
-        label
-                .append(connector.getDeclaredName())
-                .append(this.getTypingLabel(connector));
         return label.toString();
     }
 }

--- a/backend/views/syson-diagram-interconnection-view/src/test/java/org/eclipse/syson/diagram/interconnection/view/InterconnectionViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-interconnection-view/src/test/java/org/eclipse/syson/diagram/interconnection/view/InterconnectionViewDiagramDescriptionTests.java
@@ -88,6 +88,9 @@ public class InterconnectionViewDiagramDescriptionTests {
         List<EdgeDescription> edgeDescriptionCandidates = this.diagramDescription.getEdgeDescriptions().stream()
                 // SuccessionAsUsage has a label but the grammar does not support the direct edit tool yet
                 .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getSuccessionAsUsage()).negate())
+                .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getAllocationUsage()).negate())
+                // BindingConnectorAsUsage has a fixed label ("=") which cannot be edited.
+                .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getBindingConnectorAsUsage()).negate())
                 .filter(edgeDescription -> edgeDescription.getCenterLabelExpression() != null && !edgeDescription.getCenterLabelExpression().isBlank())
                 .toList();
         new EdgeDescriptionHasDirectEditToolChecker().checkAll(edgeDescriptionCandidates);

--- a/backend/views/syson-diagram-statetransition-view/src/test/java/org/eclipse/syson/diagram/statetransition/view/StateTransitionViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-statetransition-view/src/test/java/org/eclipse/syson/diagram/statetransition/view/StateTransitionViewDiagramDescriptionTests.java
@@ -41,6 +41,7 @@ import org.eclipse.syson.diagram.tests.checkers.NodeDescriptionIsReusedByChecker
 import org.eclipse.syson.diagram.tests.checkers.NodeDescriptionReusesChecker;
 import org.eclipse.syson.diagram.tests.predicates.DiagramPredicates;
 import org.eclipse.syson.services.ColorProvider;
+import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.helper.EMFUtils;
 import org.eclipse.syson.util.DescriptionNameGenerator;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,6 +87,7 @@ public class StateTransitionViewDiagramDescriptionTests {
     public void eachEdgeWithCenterLabelHasDirectEditTool() {
         List<EdgeDescription> edgeDescriptionCandidates = this.diagramDescription.getEdgeDescriptions().stream()
                 .filter(edgeDescription -> edgeDescription.getCenterLabelExpression() != null && !edgeDescription.getCenterLabelExpression().isBlank())
+                .filter(this.diagramPredicates.hasDomainType(SysmlPackage.eINSTANCE.getAllocationUsage()).negate())
                 .toList();
         new EdgeDescriptionHasDirectEditToolChecker().checkAll(edgeDescriptionCandidates);
     }

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -24,6 +24,8 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 * `getCompartmentNodeGraphicalChecker`
 * `getSiblingNodeGraphicalChecker`
 * `checkDiagram`
+- Remove default name of relationships and improve edge labels.
+The method `getSuccessionLabel` in `ViewLabelService` has been deleted, succession labels are now computed with the generic `getEdgeLabel` method.
 
 == Dependencies update
 
@@ -42,6 +44,7 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 - Add support for short name in container and compartment item labels.
 - Allow to set short name via the direct edit.
 - Make Declared Short Name accessible from the Core tab instead of the Advanced tab in the details view.
+- Remove default name of relationships and improve edge labels.
 
 == New features
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/765

Rational for the changes in the PR:
- The name of transition is never visible (8.2.3.17). The transition label contains only the trigger expression and the action usage
- The name of a succession is visible (8.2.3.9) via the rule _UsageDeclaration_
- The name of a dependency is visible (8.2.3.3) via the rule _Identification_
- The name of a flow is visible (8.2.3.13) via the rule _UsageDeclaration_
- The name of a message is visible (8.2.3.13) via the rule _UsageDeclaration_
- The name of an interface is visible (8.2.3.14) via the rule _UsageDeclaration_
- The name of a binding connection is always "=" (8.2.3.13)
- The name of an allocation is always `<<allocate>>` (8.2.3.15)

The rule _Identification_ is a wrapper for short name + name.
The rule _UsageDeclaration_ is a wrapper for _Identification_ and typing/subsetting, etc. For the moment only **typing** relationships are displayed in the labels.

# Pull request template

PLEASE READ ALL ITEMS AND CHECK RELEVANT CHECKBOXES BELOW.

## Project management

- [x] Has the pull request been added to the relevant project and milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
