### PR TITLE
[767] Allow to create dependencies in the explorer

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,6 +46,7 @@ The method `getSuccessionLabel` in `ViewLabelService` has been deleted, successi
 - https://github.com/eclipse-syson/syson/issues/760[#760] [diagrams] Allow to set short name via direct edit.
 - https://github.com/eclipse-syson/syson/issues/761[#761] [details] Make Declared Short Name accessible from the Core tab.
 - https://github.com/eclipse-syson/syson/issues/765[#765] [diagrams] Remove default name of relationships and improve edge labels.
+- https://github.com/eclipse-syson/syson/issues/767[#767] [explorer] Allow to create dependencies from the Explorer view.
 
 === New features
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/GetChildCreationSwitch.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/GetChildCreationSwitch.java
@@ -267,6 +267,7 @@ public class GetChildCreationSwitch extends SysmlEClassSwitch<List<EClass>> {
         childrenCandidates.add(SysmlPackage.eINSTANCE.getOwningMembership());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getDocumentation());
         childrenCandidates.add(SysmlPackage.eINSTANCE.getComment());
+        childrenCandidates.add(SysmlPackage.eINSTANCE.getDependency());
         return childrenCandidates;
     }
 }

--- a/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/GetChildCreationSwitchTest.java
+++ b/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/GetChildCreationSwitchTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.syson.sysml.SysmlFactory;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link GetChildCreationSwitch}.
+ *
+ * @author gdaniel
+ */
+public class GetChildCreationSwitchTest {
+
+    @Test
+    public void testPackageChildren() {
+        List<EClass> children = new GetChildCreationSwitch().doSwitch(SysmlFactory.eINSTANCE.createPackage());
+        List<EClass> expectedChildren = List.of(SysmlPackage.eINSTANCE.getDependency(),
+                SysmlPackage.eINSTANCE.getDocumentation(),
+                SysmlPackage.eINSTANCE.getComment(),
+                SysmlPackage.eINSTANCE.getOwningMembership(),
+                SysmlPackage.eINSTANCE.getPackage());
+        assertThat(children).containsAll(expectedChildren);
+        assertThat(children).noneMatch(eClass -> eClass.isAbstract() || eClass.isInterface());
+        children.removeAll(expectedChildren);
+        // Ensure all the remaining types are subclasses of expected types.
+        assertThat(children).allMatch(eClass -> SysmlPackage.eINSTANCE.getDefinition().isSuperTypeOf(eClass)
+                || SysmlPackage.eINSTANCE.getUsage().isSuperTypeOf(eClass)
+                || SysmlPackage.eINSTANCE.getImport().isSuperTypeOf(eClass)
+                || SysmlPackage.eINSTANCE.getPackage().isSuperTypeOf(eClass));
+    }
+
+    @Test
+    public void testNamespaceChildren() {
+        List<EClass> children = new GetChildCreationSwitch().doSwitch(SysmlFactory.eINSTANCE.createNamespace());
+        List<EClass> expectedChildren = List.of(SysmlPackage.eINSTANCE.getDependency(),
+                SysmlPackage.eINSTANCE.getDocumentation(),
+                SysmlPackage.eINSTANCE.getComment(),
+                SysmlPackage.eINSTANCE.getOwningMembership(),
+                SysmlPackage.eINSTANCE.getPackage());
+        assertThat(children).containsAll(expectedChildren);
+        assertThat(children).noneMatch(eClass -> eClass.isAbstract() || eClass.isInterface());
+        children.removeAll(expectedChildren);
+        // Ensure all the remaining types are subclasses of expected types.
+        assertThat(children).allMatch(eClass -> SysmlPackage.eINSTANCE.getDefinition().isSuperTypeOf(eClass)
+                || SysmlPackage.eINSTANCE.getUsage().isSuperTypeOf(eClass)
+                || SysmlPackage.eINSTANCE.getImport().isSuperTypeOf(eClass)
+                || SysmlPackage.eINSTANCE.getPackage().isSuperTypeOf(eClass));
+    }
+
+}

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -45,6 +45,7 @@ The method `getSuccessionLabel` in `ViewLabelService` has been deleted, successi
 - Allow to set short name via the direct edit.
 - Make Declared Short Name accessible from the Core tab instead of the Advanced tab in the details view.
 - Remove default name of relationships and improve edge labels.
+- Allow to create dependencies from the Explorer view.
 
 == New features
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/767

# Pull request template

PLEASE READ ALL ITEMS AND CHECK RELEVANT CHECKBOXES BELOW.

## Project management

- [x] Has the pull request been added to the relevant project and milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
