### PR TITLE
[771] Allow the drop of elements on empty diagram nodes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,8 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 * `checkDiagram`
 - https://github.com/eclipse-syson/syson/issues/765[#765] [diagrams] Remove default name of relationships and improve edge labels.
 The method `getSuccessionLabel` in `ViewLabelService` has been deleted, succession labels are now computed with the generic `getEdgeLabel` method.
+- https://github.com/eclipse-syson/syson/issues/771[#771] [diagrams] Allow the drop of elements on empty diagram nodes.
+Rename the class `SemanticCheckerFactory` to `SemanticRunnableFactory` to reflect the new use cases of the class.
 
 === Dependency update
 
@@ -47,6 +49,7 @@ The method `getSuccessionLabel` in `ViewLabelService` has been deleted, successi
 - https://github.com/eclipse-syson/syson/issues/761[#761] [details] Make Declared Short Name accessible from the Core tab.
 - https://github.com/eclipse-syson/syson/issues/765[#765] [diagrams] Remove default name of relationships and improve edge labels.
 - https://github.com/eclipse-syson/syson/issues/767[#767] [explorer] Allow to create dependencies from the Explorer view.
+- https://github.com/eclipse-syson/syson/issues/771[#771] [diagrams] Allow the drop of elements on empty diagram nodes.
 
 === New features
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controller/editingContext/checkers/SemanticCheckerService.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controller/editingContext/checkers/SemanticCheckerService.java
@@ -18,7 +18,7 @@ import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramRefreshed
 import org.eclipse.sirius.components.core.api.IObjectService;
 import org.eclipse.sirius.components.graphql.tests.ExecuteEditingContextFunctionSuccessPayload;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 
 import reactor.test.StepVerifier.Step;
 
@@ -29,12 +29,12 @@ import reactor.test.StepVerifier.Step;
  */
 public class SemanticCheckerService {
 
-    private final SemanticCheckerFactory semanticCheckerFactory;
+    private final SemanticRunnableFactory semanticRunnableFactory;
 
     private final IObjectService objectService;
 
-    public SemanticCheckerService(SemanticCheckerFactory semanticCheckerFactory, IObjectService objectService) {
-        this.semanticCheckerFactory = semanticCheckerFactory;
+    public SemanticCheckerService(SemanticRunnableFactory semanticRunnableFactory, IObjectService objectService) {
+        this.semanticRunnableFactory = semanticRunnableFactory;
         this.objectService = objectService;
     }
 
@@ -46,7 +46,7 @@ public class SemanticCheckerService {
     }
 
     public void checkEditingContext(ISemanticChecker semanticChecker, Step<DiagramRefreshedEventPayload> verifier) {
-        Runnable runnableChecker = this.semanticCheckerFactory.createRunnableChecker(SysMLv2Identifiers.GENERAL_VIEW_WITH_TOP_NODES_PROJECT,
+        Runnable runnableChecker = this.semanticRunnableFactory.createRunnable(SysMLv2Identifiers.GENERAL_VIEW_WITH_TOP_NODES_PROJECT,
                 (editingContext, executeEditingContextFunctionInput) -> {
                     semanticChecker.check(editingContext);
                     return new ExecuteEditingContextFunctionSuccessPayload(executeEditingContextFunctionInput.id(), true);

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/checkers/CheckNodeOnDiagram.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/checkers/CheckNodeOnDiagram.java
@@ -38,6 +38,8 @@ public class CheckNodeOnDiagram implements IDiagramChecker {
 
     private int compartmentCount;
 
+    private String targetObjectLabel;
+
     public CheckNodeOnDiagram(DiagramDescriptionIdProvider diagramDescriptionIdProvider, DiagramComparator diagramComparator) {
         this.diagramDescriptionIdProvider = diagramDescriptionIdProvider;
         this.diagramComparator = diagramComparator;
@@ -53,12 +55,20 @@ public class CheckNodeOnDiagram implements IDiagramChecker {
         return this;
     }
 
+    public CheckNodeOnDiagram hasTargetObjectLabel(String expectedTargetObjectLabel) {
+        this.targetObjectLabel = Objects.requireNonNull(expectedTargetObjectLabel);
+        return this;
+    }
+
     @Override
     public void check(Diagram previousDiagram, Diagram newDiagram) {
         List<Node> newNodes = this.diagramComparator.newNodes(previousDiagram, newDiagram);
         assertThat(newDiagram.getNodes()).anySatisfy(childNode -> {
             assertThat(childNode).hasDescriptionId(this.diagramDescriptionIdProvider.getNodeDescriptionId(this.nodeDescriptionName));
             assertThat(childNode.getChildNodes()).hasSize(this.compartmentCount);
+            if (this.targetObjectLabel != null) {
+                assertThat(childNode).hasTargetObjectLabel(this.targetObjectLabel);
+            }
             assertThat(newNodes).contains(childNode);
         });
     }

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVDropFromExplorerTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVDropFromExplorerTests.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.controllers.diagrams.general.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.components.diagrams.tests.assertions.DiagramAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramEventInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramRefreshedEventPayload;
+import org.eclipse.sirius.components.core.api.IEditingContext;
+import org.eclipse.sirius.components.core.api.IObjectService;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.Node;
+import org.eclipse.sirius.components.graphql.tests.ExecuteEditingContextFunctionSuccessPayload;
+import org.eclipse.sirius.components.view.diagram.DiagramDescription;
+import org.eclipse.sirius.components.view.emf.diagram.IDiagramIdProvider;
+import org.eclipse.sirius.web.tests.services.api.IGivenInitialServerState;
+import org.eclipse.syson.AbstractIntegrationTests;
+import org.eclipse.syson.application.controllers.diagrams.checkers.CheckDiagramElementCount;
+import org.eclipse.syson.application.controllers.diagrams.checkers.CheckNodeOnDiagram;
+import org.eclipse.syson.application.controllers.diagrams.testers.DropFromExplorerTester;
+import org.eclipse.syson.application.data.SysMLv2Identifiers;
+import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
+import org.eclipse.syson.diagram.general.view.nodes.GeneralViewEmptyDiagramNodeDescriptionProvider;
+import org.eclipse.syson.services.SemanticRunnableFactory;
+import org.eclipse.syson.services.diagrams.DiagramComparator;
+import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
+import org.eclipse.syson.services.diagrams.api.IGivenDiagramDescription;
+import org.eclipse.syson.services.diagrams.api.IGivenDiagramReference;
+import org.eclipse.syson.services.diagrams.api.IGivenDiagramSubscription;
+import org.eclipse.syson.sysml.Element;
+import org.eclipse.syson.sysml.Package;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.transaction.annotation.Transactional;
+
+import reactor.test.StepVerifier;
+import reactor.test.StepVerifier.Step;
+
+/**
+ * Tests the drop of elements from the explorer on the General View diagram.
+ *
+ * @author gdaniel
+ */
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GVDropFromExplorerTests extends AbstractIntegrationTests {
+
+    @Autowired
+    private IGivenInitialServerState givenInitialServerState;
+
+    @Autowired
+    private IGivenDiagramReference givenDiagram;
+
+    @Autowired
+    private IGivenDiagramDescription givenDiagramDescription;
+
+    @Autowired
+    private IGivenDiagramSubscription givenDiagramSubscription;
+
+    @Autowired
+    private IDiagramIdProvider diagramIdProvider;
+
+    @Autowired
+    private IObjectService objectService;
+
+    @Autowired
+    private DropFromExplorerTester dropFromExplorerTester;
+
+    @Autowired
+    private SemanticRunnableFactory semanticRunnableFactory;
+
+    @Autowired
+    private DiagramComparator diagramComparator;
+
+    private DiagramDescriptionIdProvider diagramDescriptionIdProvider;
+
+    private Step<DiagramRefreshedEventPayload> verifier;
+
+    private AtomicReference<Diagram> diagram;
+
+    private DiagramDescription diagramDescription;
+
+    private final IDescriptionNameGenerator descriptionNameGenerator = new GVDescriptionNameGenerator();
+
+    @BeforeEach
+    public void setUp() {
+        this.givenInitialServerState.initialize();
+        var diagramEventInput = new DiagramEventInput(UUID.randomUUID(),
+                SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_PROJECT,
+                SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_DIAGRAM);
+        var flux = this.givenDiagramSubscription.subscribe(diagramEventInput);
+        this.verifier = StepVerifier.create(flux);
+        this.diagram = this.givenDiagram.getDiagram(this.verifier);
+        this.diagramDescription = this.givenDiagramDescription.getDiagramDescription(SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_PROJECT,
+                SysMLv2Identifiers.GENERAL_VIEW_DIAGRAM_DESCRIPTION_ID);
+        this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (this.verifier != null) {
+            this.verifier.thenCancel()
+                    .verify(Duration.ofSeconds(10));
+        }
+    }
+
+    @Sql(scripts = { "/scripts/syson-test-database.sql" }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    @Test
+    public void dropFromExplorerOnEmptyDiagram() {
+        AtomicReference<String> semanticElementId = new AtomicReference<>();
+        Runnable semanticChecker = this.semanticRunnableFactory.createRunnable(SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_PROJECT,
+                (editingContext, executeEditingContextFunctionInput) -> {
+                    String partUsageId = this.getSemanticElementWithTargetObjectLabel(editingContext, "part1");
+                    semanticElementId.set(partUsageId);
+                    return new ExecuteEditingContextFunctionSuccessPayload(executeEditingContextFunctionInput.id(), true);
+                });
+
+        this.verifier.then(semanticChecker);
+
+        this.verifier.then(() -> {
+            assertThat(this.diagram.get().getNodes()).hasSize(1);
+            Node emptyDiagramNode = this.diagram.get().getNodes().get(0);
+            String emptyDiagramNodeDescriptionId = this.diagramDescriptionIdProvider.getNodeDescriptionId(GeneralViewEmptyDiagramNodeDescriptionProvider.NAME);
+            // Ensure the existing node is the "empty diagram" one.
+            assertThat(emptyDiagramNode).hasDescriptionId(emptyDiagramNodeDescriptionId);
+            this.dropFromExplorerTester.dropFromExplorerOnDiagram(SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_PROJECT,
+                    this.diagram,
+                    semanticElementId.get());
+        });
+
+        Consumer<DiagramRefreshedEventPayload> updatedDiagramConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(newDiagram -> {
+                    new CheckDiagramElementCount(this.diagramComparator)
+                            .hasNewEdgeCount(0)
+                            // 1 node for the PartUsage and 7 for its compartments
+                            .hasNewNodeCount(8)
+                            .check(this.diagram.get(), newDiagram);
+                    new CheckNodeOnDiagram(this.diagramDescriptionIdProvider, this.diagramComparator)
+                            .hasNodeDescriptionName(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getPartUsage()))
+                            .hasTargetObjectLabel("part1")
+                            .hasCompartmentCount(7)
+                            .check(this.diagram.get(), newDiagram);
+                }, () -> fail("Missing diagram"));
+
+        this.verifier.consumeNextWith(updatedDiagramConsumer);
+    }
+
+    @Sql(scripts = { "/scripts/syson-test-database.sql" }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    @Test
+    public void dropFromExplorerOnEmptyDiagramNode() {
+        AtomicReference<String> semanticElementId = new AtomicReference<>();
+        Runnable semanticChecker = this.semanticRunnableFactory.createRunnable(SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_PROJECT,
+                (editingContext, executeEditingContextFunctionInput) -> {
+                    String partUsageId = this.getSemanticElementWithTargetObjectLabel(editingContext, "part1");
+                    semanticElementId.set(partUsageId);
+                    return new ExecuteEditingContextFunctionSuccessPayload(executeEditingContextFunctionInput.id(), true);
+                });
+
+        this.verifier.then(semanticChecker);
+
+        this.verifier.then(() -> {
+            assertThat(this.diagram.get().getNodes()).hasSize(1);
+            Node emptyDiagramNode = this.diagram.get().getNodes().get(0);
+            String emptyDiagramNodeDescriptionId = this.diagramDescriptionIdProvider.getNodeDescriptionId(GeneralViewEmptyDiagramNodeDescriptionProvider.NAME);
+            // Ensure the existing node is the "empty diagram" one.
+            assertThat(emptyDiagramNode).hasDescriptionId(emptyDiagramNodeDescriptionId);
+            this.dropFromExplorerTester.dropFromExplorer(SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_PROJECT,
+                    this.diagram,
+                    emptyDiagramNode.getId(),
+                    semanticElementId.get());
+        });
+
+        Consumer<DiagramRefreshedEventPayload> updatedDiagramConsumer = payload -> Optional.of(payload)
+                .map(DiagramRefreshedEventPayload::diagram)
+                .ifPresentOrElse(newDiagram -> {
+                    new CheckDiagramElementCount(this.diagramComparator)
+                            .hasNewEdgeCount(0)
+                            // 1 node for the PartUsage and 7 for its compartments
+                            .hasNewNodeCount(8)
+                            .check(this.diagram.get(), newDiagram);
+                    new CheckNodeOnDiagram(this.diagramDescriptionIdProvider, this.diagramComparator)
+                            .hasNodeDescriptionName(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getPartUsage()))
+                            .hasTargetObjectLabel("part1")
+                            .hasCompartmentCount(7)
+                            .check(this.diagram.get(), newDiagram);
+                }, () -> fail("Missing diagram"));
+
+        this.verifier.consumeNextWith(updatedDiagramConsumer);
+    }
+
+    private String getSemanticElementWithTargetObjectLabel(IEditingContext editingContext, String targetObjectLabel) {
+        Object semanticRootObject = this.objectService.getObject(editingContext,
+                SysMLv2Identifiers.GENERAL_VIEW_ADD_EXISTING_ELEMENTS_DIAGRAM_OBJECT).orElse(null);
+        assertThat(semanticRootObject).isInstanceOf(Package.class);
+        Package rootPackage = (Package) semanticRootObject;
+        Optional<Element> optPartUsage = rootPackage.getOwnedMember().stream().filter(m -> Objects.equals(m.getName(), targetObjectLabel)).findFirst();
+        assertThat(optPartUsage).isPresent();
+        String partUsageId = this.objectService.getId(optPartUsage.get());
+        assertThat(partUsageId).isNotNull();
+        return partUsageId;
+    }
+}

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVEdgeCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVEdgeCreationTests.java
@@ -37,7 +37,7 @@ import org.eclipse.syson.application.controllers.diagrams.checkers.IDiagramCheck
 import org.eclipse.syson.application.controllers.diagrams.testers.EdgeCreationTester;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.api.IGivenDiagramDescription;
@@ -88,7 +88,7 @@ public class GVEdgeCreationTests extends AbstractIntegrationTests {
     private EdgeCreationTester edgeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -120,7 +120,7 @@ public class GVEdgeCreationTests extends AbstractIntegrationTests {
                 SysMLv2Identifiers.GENERAL_VIEW_DIAGRAM_DESCRIPTION_ID);
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeActionFlowCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeActionFlowCreationTests.java
@@ -54,7 +54,7 @@ import org.eclipse.syson.diagram.common.view.nodes.JoinActionNodeDescriptionProv
 import org.eclipse.syson.diagram.common.view.nodes.MergeActionNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.services.description.ReferencingPerformActionUsageNodeDescriptionService;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -117,7 +117,7 @@ public class GVSubNodeActionFlowCreationTests extends AbstractIntegrationTests {
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -201,7 +201,7 @@ public class GVSubNodeActionFlowCreationTests extends AbstractIntegrationTests {
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeAnalysisCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeAnalysisCreationTests.java
@@ -47,7 +47,7 @@ import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTe
 import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -108,7 +108,7 @@ public class GVSubNodeAnalysisCreationTests extends AbstractIntegrationTests {
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -185,7 +185,7 @@ public class GVSubNodeAnalysisCreationTests extends AbstractIntegrationTests {
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeExtensionCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeExtensionCreationTests.java
@@ -33,7 +33,7 @@ import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTe
 import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -91,7 +91,7 @@ public class GVSubNodeExtensionCreationTests extends AbstractIntegrationTests {
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -140,7 +140,7 @@ public class GVSubNodeExtensionCreationTests extends AbstractIntegrationTests {
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeInterconnectionCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeInterconnectionCreationTests.java
@@ -33,7 +33,7 @@ import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTe
 import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -91,7 +91,7 @@ public class GVSubNodeInterconnectionCreationTests extends AbstractIntegrationTe
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -209,7 +209,7 @@ public class GVSubNodeInterconnectionCreationTests extends AbstractIntegrationTe
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeRequirementCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeRequirementCreationTests.java
@@ -33,7 +33,7 @@ import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTe
 import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -91,7 +91,7 @@ public class GVSubNodeRequirementCreationTests extends AbstractIntegrationTests 
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -178,7 +178,7 @@ public class GVSubNodeRequirementCreationTests extends AbstractIntegrationTests 
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeStateTransitionCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeStateTransitionCreationTests.java
@@ -37,7 +37,7 @@ import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.common.view.nodes.StatesCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -97,7 +97,7 @@ public class GVSubNodeStateTransitionCreationTests extends AbstractIntegrationTe
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -168,7 +168,7 @@ public class GVSubNodeStateTransitionCreationTests extends AbstractIntegrationTe
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeStructureCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeStructureCreationTests.java
@@ -33,7 +33,7 @@ import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTe
 import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -91,7 +91,7 @@ public class GVSubNodeStructureCreationTests extends AbstractIntegrationTests {
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -244,7 +244,7 @@ public class GVSubNodeStructureCreationTests extends AbstractIntegrationTests {
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeTemporalCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVSubNodeTemporalCreationTests.java
@@ -37,7 +37,7 @@ import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTe
 import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
@@ -95,7 +95,7 @@ public class GVSubNodeTemporalCreationTests extends AbstractIntegrationTests {
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -151,7 +151,7 @@ public class GVSubNodeTemporalCreationTests extends AbstractIntegrationTests {
         this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(this.diagramDescription, this.diagramIdProvider);
         this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
         this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVTopNodeCreationTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVTopNodeCreationTests.java
@@ -38,7 +38,7 @@ import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTe
 import org.eclipse.syson.application.controllers.utils.TestNameGenerator;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
 import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.api.IGivenDiagramDescription;
@@ -92,7 +92,7 @@ public class GVTopNodeCreationTests extends AbstractIntegrationTests {
     private NodeCreationTester nodeCreationTester;
 
     @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     @Autowired
     private DiagramComparator diagramComparator;
@@ -194,7 +194,7 @@ public class GVTopNodeCreationTests extends AbstractIntegrationTests {
 
         this.verifier.consumeNextWith(updatedDiagramConsumer);
 
-        Runnable semanticChecker = this.semanticCheckerFactory.createRunnableChecker(SysMLv2Identifiers.GENERAL_VIEW_EMPTY_PROJECT,
+        Runnable semanticChecker = this.semanticRunnableFactory.createRunnable(SysMLv2Identifiers.GENERAL_VIEW_EMPTY_PROJECT,
                 (editingContext, executeEditingContextFunctionInput) -> {
                     Object semanticRootObject = this.objectService.getObject(editingContext, SysMLv2Identifiers.GENERAL_VIEW_EMPTY_DIAGRAM_OBJECT).orElse(null);
                     assertThat(semanticRootObject).isInstanceOf(Element.class);

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/testers/DropFromExplorerTester.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/testers/DropFromExplorerTester.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.controllers.diagrams.testers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jayway.jsonpath.JsonPath;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.sirius.components.collaborative.diagrams.dto.DropOnDiagramInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.DropOnDiagramSuccessPayload;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.tests.graphql.DropOnDiagramMutationRunner;
+import org.eclipse.sirius.components.diagrams.tests.navigation.DiagramNavigator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import reactor.test.StepVerifier;
+
+/**
+ * Drops an element from the explorer on a diagram.
+ * <p>
+ * This class should be used as part of a subscription verification (see
+ * {@link StepVerifier#create(org.reactivestreams.Publisher)}).
+ * </p>
+ *
+ * @author gdaniel
+ */
+@Service
+public class DropFromExplorerTester {
+
+    @Autowired
+    private DropOnDiagramMutationRunner dropOnDiagramMutationRunner;
+
+    public void dropFromExplorerOnDiagram(String projectId, AtomicReference<Diagram> diagram, String semanticElementId) {
+        this.dropFromExplorer(projectId, diagram, null, semanticElementId);
+    }
+
+    public void dropFromExplorer(String projectId, AtomicReference<Diagram> diagram, String targetNodeId, String semanticElementId) {
+        DiagramNavigator diagramNavigator = new DiagramNavigator(diagram.get());
+        final String targetId;
+        if (targetNodeId == null) {
+            targetId = diagram.get().getId();
+        } else {
+            targetId = diagramNavigator.nodeWithId(targetNodeId).getNode().getId();
+        }
+        var dropOnDiagramInput = new DropOnDiagramInput(
+                UUID.randomUUID(),
+                projectId,
+                diagram.get().getId(),
+                targetId,
+                List.of(semanticElementId),
+                0,
+                0);
+        var dropOnDiagramResult = this.dropOnDiagramMutationRunner.run(dropOnDiagramInput);
+        String typename = JsonPath.read(dropOnDiagramResult, "$.data.dropOnDiagram.__typename");
+        assertThat(typename).isEqualTo(DropOnDiagramSuccessPayload.class.getSimpleName());
+    }
+}

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/metamodel/helper/ImplicitSpecializationsTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/metamodel/helper/ImplicitSpecializationsTests.java
@@ -27,12 +27,8 @@ import org.eclipse.sirius.web.tests.services.api.IGivenInitialServerState;
 import org.eclipse.syson.AbstractIntegrationTests;
 import org.eclipse.syson.application.controller.editingContext.checkers.ISemanticChecker;
 import org.eclipse.syson.application.controller.editingContext.checkers.SemanticCheckerService;
-import org.eclipse.syson.application.controllers.diagrams.testers.NodeCreationTester;
 import org.eclipse.syson.application.data.SysMLv2Identifiers;
-import org.eclipse.syson.diagram.general.view.GVDescriptionNameGenerator;
-import org.eclipse.syson.services.SemanticCheckerFactory;
-import org.eclipse.syson.services.diagrams.DiagramComparator;
-import org.eclipse.syson.services.diagrams.NodeCreationTestsService;
+import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.api.IGivenDiagramSubscription;
 import org.eclipse.syson.sysml.AcceptActionUsage;
 import org.eclipse.syson.sysml.Element;
@@ -40,7 +36,6 @@ import org.eclipse.syson.sysml.PartDefinition;
 import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.SysmlFactory;
 import org.eclipse.syson.sysml.helper.EMFUtils;
-import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -74,19 +69,9 @@ public class ImplicitSpecializationsTests extends AbstractIntegrationTests {
     private IObjectService objectService;
 
     @Autowired
-    private NodeCreationTester nodeCreationTester;
-
-    @Autowired
-    private SemanticCheckerFactory semanticCheckerFactory;
-
-    @Autowired
-    private DiagramComparator diagramComparator;
+    private SemanticRunnableFactory semanticRunnableFactory;
 
     private Step<DiagramRefreshedEventPayload> verifier;
-
-    private NodeCreationTestsService creationTestsService;
-
-    private final IDescriptionNameGenerator descriptionNameGenerator = new GVDescriptionNameGenerator();
 
     private SemanticCheckerService semanticCheckerService;
 
@@ -98,8 +83,7 @@ public class ImplicitSpecializationsTests extends AbstractIntegrationTests {
                 SysMLv2Identifiers.GENERAL_VIEW_WITH_TOP_NODES_DIAGRAM);
         var flux = this.givenDiagramSubscription.subscribe(diagramEventInput);
         this.verifier = StepVerifier.create(flux);
-        this.creationTestsService = new NodeCreationTestsService(this.nodeCreationTester, this.descriptionNameGenerator);
-        this.semanticCheckerService = new SemanticCheckerService(this.semanticCheckerFactory, this.objectService);
+        this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectService);
     }
 
     @AfterEach

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/services/SemanticRunnableFactory.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/services/SemanticRunnableFactory.java
@@ -27,19 +27,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.test.StepVerifier.Step;
 
 /**
- * Provides methods to run semantic checks as part of a subscription verification.
+ * Provides methods to run semantic functions as part of a subscription verification.
+ * <p>
+ * This class is typically used in conjunction with a {@link StepVerifier} to produce a {@link Runnable} that can be
+ * consumed by {@link Step#then(Runnable)}. The code executed inside the {@link Runnable} has access to the editing
+ * context, which can be used to update the semantic model, or perform verifications.
+ * </p>
  *
  * @author gdaniel
  */
 @Service
-public class SemanticCheckerFactory {
+public class SemanticRunnableFactory {
 
     @Autowired
     private IExecuteEditingContextFunctionRunner executeEditingContextFunctionRunner;
 
-    public Runnable createRunnableChecker(String projectId, BiFunction<IEditingContext, IInput, IPayload> function) {
+    public Runnable createRunnable(String projectId, BiFunction<IEditingContext, IInput, IPayload> function) {
         return () -> {
             var input = new ExecuteEditingContextFunctionInput(UUID.randomUUID(), projectId, function);
 

--- a/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/nodes/ActionFlowViewEmptyDiagramNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-actionflow-view/src/main/java/org/eclipse/syson/diagram/actionflow/view/nodes/ActionFlowViewEmptyDiagramNodeDescriptionProvider.java
@@ -27,7 +27,7 @@ import org.eclipse.syson.diagram.common.view.tools.ToolSectionDescription;
  */
 public class ActionFlowViewEmptyDiagramNodeDescriptionProvider extends AbstractEmptyDiagramNodeDescriptionProvider {
 
-    public static final String NAME = "AFV Node EmptyDiagram";
+    public static final String NAME = "AFV Node " + EMPTY_DIAGRAM_NAME_SUFFIX;
 
     public ActionFlowViewEmptyDiagramNodeDescriptionProvider(IColorProvider colorProvider) {
         super(colorProvider, new AFVDescriptionNameGenerator());

--- a/backend/views/syson-diagram-actionflow-view/src/test/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-actionflow-view/src/test/java/org/eclipse/syson/diagram/actionflow/view/ActionFlowViewDiagramDescriptionTests.java
@@ -30,6 +30,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.emf.IJavaServiceProvider;
 import org.eclipse.syson.diagram.tests.checkers.AQLExpressionCallsExistingServicesChecker;
 import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasDropToolChecker;
+import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasOneEmptyDiagramNodeChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasDirectEditToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasReconnectToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.NodeDescriptionHasChildrenChecker;
@@ -177,5 +178,11 @@ public class ActionFlowViewDiagramDescriptionTests {
                 .filter(expression -> expression != null && !expression.isBlank())
                 .collect(Collectors.toSet());
         new AQLExpressionCallsExistingServicesChecker(this.diagramServices).checkAll(aqlExpressions);
+    }
+
+    @Test
+    @DisplayName("Diagram contains an empty diagram node")
+    public void diagramHasOnEmptyDiagramNode() {
+        new DiagramDescriptionHasOneEmptyDiagramNodeChecker().check(this.diagramDescription);
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractEmptyDiagramNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractEmptyDiagramNodeDescriptionProvider.java
@@ -47,6 +47,15 @@ import org.eclipse.syson.util.ViewConstants;
  */
 public abstract class AbstractEmptyDiagramNodeDescriptionProvider extends AbstractNodeDescriptionProvider {
 
+    /**
+     * The suffix used to identify empty diagram nodes.
+     * <p>
+     * This suffix has to be used to define the name of the {@link NodeDescription} created by subclasses. It is used to
+     * differentiate empty diagram nodes from other nodes, e.g. when dropping element on them.
+     * </p>
+     */
+    public static final String EMPTY_DIAGRAM_NAME_SUFFIX = "EmptyDiagram";
+
     private final ToolDescriptionService toolDescriptionService;
 
     private final IDescriptionNameGenerator nameGenerator;

--- a/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/GeneralViewEmptyDiagramNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-general-view/src/main/java/org/eclipse/syson/diagram/general/view/nodes/GeneralViewEmptyDiagramNodeDescriptionProvider.java
@@ -28,7 +28,7 @@ import org.eclipse.syson.diagram.general.view.GeneralViewDiagramDescriptionProvi
  */
 public class GeneralViewEmptyDiagramNodeDescriptionProvider extends AbstractEmptyDiagramNodeDescriptionProvider {
 
-    public static final String NAME = "GV Node EmptyDiagram";
+    public static final String NAME = "GV Node " + EMPTY_DIAGRAM_NAME_SUFFIX;
 
     public GeneralViewEmptyDiagramNodeDescriptionProvider(IColorProvider colorProvider) {
         super(colorProvider, new GVDescriptionNameGenerator());

--- a/backend/views/syson-diagram-general-view/src/test/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-general-view/src/test/java/org/eclipse/syson/diagram/general/view/GeneralViewDiagramDescriptionTests.java
@@ -30,6 +30,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.emf.IJavaServiceProvider;
 import org.eclipse.syson.diagram.tests.checkers.AQLExpressionCallsExistingServicesChecker;
 import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasDropToolChecker;
+import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasOneEmptyDiagramNodeChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasDirectEditToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasReconnectToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.NodeDescriptionHasChildrenChecker;
@@ -178,5 +179,11 @@ public class GeneralViewDiagramDescriptionTests {
                 .filter(expression -> expression != null && !expression.isBlank())
                 .collect(Collectors.toSet());
         new AQLExpressionCallsExistingServicesChecker(this.diagramServices).checkAll(aqlExpressions);
+    }
+
+    @Test
+    @DisplayName("Diagram contains an empty diagram node")
+    public void diagramHasOnEmptyDiagramNode() {
+        new DiagramDescriptionHasOneEmptyDiagramNodeChecker().check(this.diagramDescription);
     }
 }

--- a/backend/views/syson-diagram-interconnection-view/src/test/java/org/eclipse/syson/diagram/interconnection/view/InterconnectionViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-interconnection-view/src/test/java/org/eclipse/syson/diagram/interconnection/view/InterconnectionViewDiagramDescriptionTests.java
@@ -30,6 +30,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.emf.IJavaServiceProvider;
 import org.eclipse.syson.diagram.tests.checkers.AQLExpressionCallsExistingServicesChecker;
 import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasDropToolChecker;
+import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasNoEmptyDiagramNodeChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasDirectEditToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasReconnectToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.NodeDescriptionHasChildrenChecker;
@@ -184,5 +185,11 @@ public class InterconnectionViewDiagramDescriptionTests {
                 .filter(expression -> expression != null && !expression.isBlank())
                 .collect(Collectors.toSet());
         new AQLExpressionCallsExistingServicesChecker(this.diagramServices).checkAll(aqlExpressions);
+    }
+
+    @Test
+    @DisplayName("Diagram does not contain an empty diagram node")
+    public void diagramHasNoEmptyDiagramNode() {
+        new DiagramDescriptionHasNoEmptyDiagramNodeChecker().check(this.diagramDescription);
     }
 }

--- a/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/StateTransitionViewEmptyDiagramNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-statetransition-view/src/main/java/org/eclipse/syson/diagram/statetransition/view/nodes/StateTransitionViewEmptyDiagramNodeDescriptionProvider.java
@@ -27,7 +27,7 @@ import org.eclipse.syson.util.IDescriptionNameGenerator;
  */
 public class StateTransitionViewEmptyDiagramNodeDescriptionProvider extends AbstractEmptyDiagramNodeDescriptionProvider {
 
-    public static final String NAME = "STV Node EmptyDiagram";
+    public static final String NAME = "STV Node " + EMPTY_DIAGRAM_NAME_SUFFIX;
 
     public StateTransitionViewEmptyDiagramNodeDescriptionProvider(IColorProvider colorProvider, IDescriptionNameGenerator descriptionNameGenerator) {
         super(colorProvider, descriptionNameGenerator);

--- a/backend/views/syson-diagram-statetransition-view/src/test/java/org/eclipse/syson/diagram/statetransition/view/StateTransitionViewDiagramDescriptionTests.java
+++ b/backend/views/syson-diagram-statetransition-view/src/test/java/org/eclipse/syson/diagram/statetransition/view/StateTransitionViewDiagramDescriptionTests.java
@@ -30,6 +30,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.emf.IJavaServiceProvider;
 import org.eclipse.syson.diagram.tests.checkers.AQLExpressionCallsExistingServicesChecker;
 import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasDropToolChecker;
+import org.eclipse.syson.diagram.tests.checkers.DiagramDescriptionHasOneEmptyDiagramNodeChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasDirectEditToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.EdgeDescriptionHasReconnectToolChecker;
 import org.eclipse.syson.diagram.tests.checkers.NodeDescriptionHasChildrenChecker;
@@ -178,5 +179,11 @@ public class StateTransitionViewDiagramDescriptionTests {
                 .filter(expression -> expression != null && !expression.isBlank())
                 .collect(Collectors.toSet());
         new AQLExpressionCallsExistingServicesChecker(this.diagramServices).checkAll(aqlExpressions);
+    }
+
+    @Test
+    @DisplayName("Diagram contains an empty diagram node")
+    public void diagramHasOnEmptyDiagramNode() {
+        new DiagramDescriptionHasOneEmptyDiagramNodeChecker().check(this.diagramDescription);
     }
 }

--- a/backend/views/syson-diagram-tests/pom.xml
+++ b/backend/views/syson-diagram-tests/pom.xml
@@ -101,6 +101,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.syson</groupId>
+			<artifactId>syson-diagram-common-view</artifactId>
+			<version>2024.9.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.syson</groupId>
 			<artifactId>syson-sysml-metamodel</artifactId>
 			<version>2024.9.1</version>
 		</dependency>

--- a/backend/views/syson-diagram-tests/src/main/java/org/eclipse/syson/diagram/tests/checkers/DiagramDescriptionHasNoEmptyDiagramNodeChecker.java
+++ b/backend/views/syson-diagram-tests/src/main/java/org/eclipse/syson/diagram/tests/checkers/DiagramDescriptionHasNoEmptyDiagramNodeChecker.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.tests.checkers;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.view.diagram.DiagramDescription;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.syson.diagram.common.view.nodes.AbstractEmptyDiagramNodeDescriptionProvider;
+import org.eclipse.syson.sysml.helper.EMFUtils;
+
+/**
+ * Checks that the provided {@link DiagramDescription} does not have an empty diagram node.
+ * <p>
+ * Empty diagram nodes are information boxes displayed on empty diagrams to indicate the end user how to get started
+ * with the diagram. A diagram may not need such node if it is never empty.
+ * </p>
+ *
+ * @author gdaniel
+ */
+public class DiagramDescriptionHasNoEmptyDiagramNodeChecker extends AbstractChecker<DiagramDescription> {
+
+    @Override
+    public void check(DiagramDescription diagramDescription) {
+        List<NodeDescription> emptyDiagramNodeDescriptions = EMFUtils.allContainedObjectOfType(diagramDescription, NodeDescription.class)
+                .filter(nodeDescription -> nodeDescription.getName() != null && nodeDescription.getName().contains(AbstractEmptyDiagramNodeDescriptionProvider.EMPTY_DIAGRAM_NAME_SUFFIX))
+                .toList();
+        assertThat(emptyDiagramNodeDescriptions).as("DiagramDescription should not have an empty diagram node").isEmpty();
+    }
+}

--- a/backend/views/syson-diagram-tests/src/main/java/org/eclipse/syson/diagram/tests/checkers/DiagramDescriptionHasOneEmptyDiagramNodeChecker.java
+++ b/backend/views/syson-diagram-tests/src/main/java/org/eclipse/syson/diagram/tests/checkers/DiagramDescriptionHasOneEmptyDiagramNodeChecker.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.diagram.tests.checkers;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.sirius.components.view.diagram.DiagramDescription;
+import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.syson.diagram.common.view.nodes.AbstractEmptyDiagramNodeDescriptionProvider;
+import org.eclipse.syson.sysml.helper.EMFUtils;
+
+/**
+ * Checks that the provided {@link DiagramDescription} has an empty diagram node.
+ * <p>
+ * Empty diagram nodes are information boxes displayed on empty diagrams to indicate the end user how to get started
+ * with the diagram.
+ * </p>
+ *
+ * @author gdaniel
+ */
+public class DiagramDescriptionHasOneEmptyDiagramNodeChecker extends AbstractChecker<DiagramDescription> {
+
+    @Override
+    public void check(DiagramDescription diagramDescription) {
+        List<NodeDescription> emptyDiagramNodeDescriptions = EMFUtils.allContainedObjectOfType(diagramDescription, NodeDescription.class)
+                .filter(nodeDescription -> nodeDescription.getName() != null && nodeDescription.getName().contains(AbstractEmptyDiagramNodeDescriptionProvider.EMPTY_DIAGRAM_NAME_SUFFIX))
+                .toList();
+        assertThat(emptyDiagramNodeDescriptions).as("DiagramDescription should have a single empty diagram node").hasSize(1);
+    }
+}

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -26,6 +26,8 @@ The following methods have been moved from `NodeCreationTestsService` to `Diagra
 * `checkDiagram`
 - Remove default name of relationships and improve edge labels.
 The method `getSuccessionLabel` in `ViewLabelService` has been deleted, succession labels are now computed with the generic `getEdgeLabel` method.
+- Allow the drop of elements on empty diagram nodes.
+Rename the class `SemanticCheckerFactory` to `SemanticRunnableFactory` to reflect the new use cases of the class.
 
 == Dependencies update
 
@@ -46,6 +48,9 @@ The method `getSuccessionLabel` in `ViewLabelService` has been deleted, successi
 - Make Declared Short Name accessible from the Core tab instead of the Advanced tab in the details view.
 - Remove default name of relationships and improve edge labels.
 - Allow to create dependencies from the Explorer view.
+- Allow the drop of elements on empty diagram nodes.
+It is now possible to drop elements from the explorer on the information box visible on empty diagrams.
+The dropped element is displayed on the diagram, the same way element creation tools on the information box display them on the diagram.
 
 == New features
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/771

# Pull request template

PLEASE READ ALL ITEMS AND CHECK RELEVANT CHECKBOXES BELOW.

## Project management

- [x] Has the pull request been added to the relevant project and milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
