### PR TITLE
[775] Exclude src/test/resources from checkstyle

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -51,6 +51,9 @@ Rename the class `SemanticCheckerFactory` to `SemanticRunnableFactory` to reflec
 - https://github.com/eclipse-syson/syson/issues/765[#765] [diagrams] Remove default name of relationships and improve edge labels.
 - https://github.com/eclipse-syson/syson/issues/767[#767] [explorer] Allow to create dependencies from the Explorer view.
 - https://github.com/eclipse-syson/syson/issues/771[#771] [diagrams] Allow the drop of elements on empty diagram nodes.
+- https://github.com/eclipse-syson/syson/issues/775[#775] [syson] Exclude `src/test/resources` from checkstyle.
+This reduces the time required to build SysON, especially when using Spring Tool Suite.
+
 
 === New features
 

--- a/backend/application/syson-application-configuration/.checkstyle
+++ b/backend/application/syson-application-configuration/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/application/syson-application/.checkstyle
+++ b/backend/application/syson-application/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/application/syson-sysml-export/.checkstyle
+++ b/backend/application/syson-sysml-export/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/application/syson-sysml-import/.checkstyle
+++ b/backend/application/syson-sysml-import/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/metamodel/syson-siriusweb-customnodes-metamodel-edit/.checkstyle
+++ b/backend/metamodel/syson-siriusweb-customnodes-metamodel-edit/.checkstyle
@@ -7,5 +7,6 @@
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/java"/>
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/metamodel/syson-siriusweb-customnodes-metamodel/.checkstyle
+++ b/backend/metamodel/syson-siriusweb-customnodes-metamodel/.checkstyle
@@ -7,5 +7,6 @@
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/java"/>
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/metamodel/syson-sysml-metamodel-edit/.checkstyle
+++ b/backend/metamodel/syson-sysml-metamodel-edit/.checkstyle
@@ -7,5 +7,6 @@
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/java"/>
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/metamodel/syson-sysml-metamodel/.checkstyle
+++ b/backend/metamodel/syson-sysml-metamodel/.checkstyle
@@ -7,5 +7,6 @@
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/java"/>
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/services/syson-services/.checkstyle
+++ b/backend/services/syson-services/.checkstyle
@@ -7,5 +7,6 @@
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
     <filter-data value="src/main/generated"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/tests/syson-tests/.checkstyle
+++ b/backend/tests/syson-tests/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/views/syson-diagram-actionflow-view/.checkstyle
+++ b/backend/views/syson-diagram-actionflow-view/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/views/syson-diagram-common-view/.checkstyle
+++ b/backend/views/syson-diagram-common-view/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/views/syson-diagram-general-view/.checkstyle
+++ b/backend/views/syson-diagram-general-view/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>s
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/views/syson-diagram-interconnection-view/.checkstyle
+++ b/backend/views/syson-diagram-interconnection-view/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/views/syson-diagram-statetransition-view/.checkstyle
+++ b/backend/views/syson-diagram-statetransition-view/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/backend/views/syson-diagram-tests/.checkstyle
+++ b/backend/views/syson-diagram-tests/.checkstyle
@@ -6,5 +6,6 @@
   </fileset>
   <filter name="FilesFromPackage" enabled="true">
     <filter-data value="src/main/resources"/>
+    <filter-data value="src/test/resources"/>
   </filter>
 </fileset-config>

--- a/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2024.11.0.adoc
@@ -52,6 +52,8 @@ Rename the class `SemanticCheckerFactory` to `SemanticRunnableFactory` to reflec
 - Allow the drop of elements on empty diagram nodes.
 It is now possible to drop elements from the explorer on the information box visible on empty diagrams.
 The dropped element is displayed on the diagram, the same way element creation tools on the information box display them on the diagram.
+- Exclude `src/test/resources` from checkstyle.
+This reduces the time required to build SysON, especially when using Spring Tool Suite.
 
 == New features
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/775

# Pull request template

PLEASE READ ALL ITEMS AND CHECK RELEVANT CHECKBOXES BELOW.

## Project management

- [x] Has the pull request been added to the relevant project and milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project and milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [x] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
