### PR TITLE
[releng] Remove Libraries Menu

### DIFF
--- a/frontend/syson/src/extensions/SysONExtensionRegistryMergeStrategy.ts
+++ b/frontend/syson/src/extensions/SysONExtensionRegistryMergeStrategy.ts
@@ -13,11 +13,14 @@
 
 import {
   ComponentExtension,
-  ExtensionRegistryMergeStrategy,
   DataExtension,
+  ExtensionRegistryMergeStrategy,
 } from '@eclipse-sirius/sirius-components-core';
-import { DefaultExtensionRegistryMergeStrategy } from '@eclipse-sirius/sirius-web-application';
 import { treeItemContextMenuEntryExtensionPoint } from '@eclipse-sirius/sirius-components-trees';
+import {
+  DefaultExtensionRegistryMergeStrategy,
+  navigationBarMenuEntryExtensionPoint,
+} from '@eclipse-sirius/sirius-web-application';
 
 export class SysONExtensionRegistryMergeStrategy
   extends DefaultExtensionRegistryMergeStrategy
@@ -37,6 +40,16 @@ export class SysONExtensionRegistryMergeStrategy
             contribution.identifier !== `siriusweb_${treeItemContextMenuEntryExtensionPoint.identifier}_object` &&
             contribution.identifier !== `siriusweb_${treeItemContextMenuEntryExtensionPoint.identifier}_document`
           );
+        }),
+        newValues
+      );
+    } else if (_identifier === navigationBarMenuEntryExtensionPoint.identifier) {
+      // Temporary hack to remove the Libraries menu
+      // To remove when the libraries mechanism will be fully implemented in Sirius Web
+      return super.mergeComponentExtensions(
+        _identifier,
+        existingValues.filter((contribution) => {
+          return contribution.identifier !== `siriusweb_${navigationBarMenuEntryExtensionPoint.identifier}_libraries`;
         }),
         newValues
       );

--- a/frontend/syson/src/index.tsx
+++ b/frontend/syson/src/index.tsx
@@ -26,7 +26,9 @@ import {
   DiagramRepresentationConfiguration,
   footerExtensionPoint,
   navigationBarIconExtensionPoint,
+  navigationBarMenuEntryExtensionPoint,
   navigationBarMenuHelpURLExtensionPoint,
+  NavigationBarMenuItemProps,
   NodeTypeRegistry,
   SiriusWebApplication,
 } from '@eclipse-sirius/sirius-web-application';
@@ -113,6 +115,17 @@ extensionRegistry.addComponent(treeItemContextMenuEntryExtensionPoint, {
 extensionRegistry.addComponent(footerExtensionPoint, {
   identifier: `syson_${footerExtensionPoint.identifier}`,
   Component: SysONFooter,
+});
+
+// Temporary hack to remove the Libraries menu
+// To remove when the libraries mechanism will be fully implemented in Sirius Web
+const HideLibrariesButtonContribution = ({}: NavigationBarMenuItemProps) => {
+  return <></>;
+};
+
+extensionRegistry.addComponent(navigationBarMenuEntryExtensionPoint, {
+  identifier: `siriusweb_${navigationBarMenuEntryExtensionPoint.identifier}_libraries`,
+  Component: HideLibrariesButtonContribution,
 });
 
 /*


### PR DESCRIPTION
Temporary hack to remove the Libraries menu
To remove when the libraries mechanism will be fully implemented in Sirius Web

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [ ] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [ ] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
