### PR TITLE
[1091] Fix qualified names in FeatureReferenceExpression export

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,8 @@
 - https://github.com/eclipse-syson/syson/issues/870[#870] [metamodel] Fix an issue while computing the name of `VariantMembership`. 
 - https://github.com/eclipse-syson/syson/issues/1083[#1083] [metamodel] Fix an issue where resolving against "unrestricted" name did not work
 - https://github.com/eclipse-syson/syson/issues/1075[#1075] [import] Fix a ClassCastException thrown while importing a model with a name conflict.
+- https://github.com/eclipse-syson/syson/issues/1091[#1091] [export] Fix `FeatureReferenceExpression` export for elements that should be exported as qualified names.
+Exporting a SysML model containing a `FeatureReferenceExpression` now correctly procudes qualified names where it should.
 
 === Improvements
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
@@ -477,4 +477,20 @@ public class ImportExportTests extends AbstractIntegrationTests {
 
         this.checker.check(input, expected);
     }
+
+    @Test
+    @DisplayName("Given a model with a FeatureReferenceExpression set with a qualified name, when importing and exporting the model, then the exported text file should be the same as the imported one.")
+    public void checkFeatureReferenceExpressionWithQualifiedNameDeresolution() throws IOException {
+        var input = """
+                package P1 {
+                    part p1;
+                }
+                package P2 {
+                    part part2 {
+                        part p = P1::p1;
+                    }
+                }""";
+
+        this.checker.check(input, input);
+    }
 }

--- a/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/SysMLElementSerializer.java
+++ b/backend/application/syson-sysml-export/src/main/java/org/eclipse/syson/sysml/export/SysMLElementSerializer.java
@@ -575,7 +575,7 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
         if (membership instanceof FeatureMembership feature && feature.getOwnedMemberFeature() instanceof Expression exp) {
             this.reportConsumer.accept(Status.warning("BodyExpression are not handled yet ({0})", exp.getElementId()));
         } else {
-            this.appendFeatureReferenceMember(builder, membership);
+            this.appendFeatureReferenceMember(builder, membership, expression);
         }
         return builder.toString();
     }
@@ -1316,9 +1316,9 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
         }
     }
 
-    private void appendFeatureReferenceMember(Appender builder, Membership membership) {
+    private void appendFeatureReferenceMember(Appender builder, Membership membership, Expression context) {
         if (membership.getMemberElement() instanceof Feature feature) {
-            builder.appendSpaceIfNeeded().append(this.getDeresolvableName(feature, membership));
+            builder.appendSpaceIfNeeded().append(this.getDeresolvableName(feature, context));
         }
     }
 

--- a/doc/content/modules/user-manual/pages/release-notes/2025.4.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2025.4.0.adoc
@@ -21,6 +21,7 @@ package p1 {
 }
 ```
 - Fix a problem encountered during the import of a SysML textual file in a specific model configuration. The model incorrectly resolved the target of a `Redefinition` when a name conflict was detected.
+- Fix an issue that prevented the export functionality to correctly produce qualified name for elements referenced in `FeatureReferenceExpression`.
 
 == New features
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/1091

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
