### PR TITLE
[1172] Uniformize the import of LiteralString value

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -113,6 +113,9 @@ Importing a "require" `RequirementConstraintMembership` now correctly sets its k
 Importing an "assume" `RequirementConstraintMembership` now explicitly sets its kind to `assumption`.
 - https://github.com/eclipse-syson/syson/issues/1154[#1154] [import] Fix import of `TextualRepresentation`.
 - https://github.com/eclipse-syson/syson/issues/1169[#1169] [syson] Add a new navigation bar menu icon on the top right corner of the appliation.
+- https://github.com/eclipse-syson/syson/issues/1172[#1172] [import] Uniformize the import of `LiteralString` value.
+The `value` field of imported `LiteralString` elements does not contain double quotes anymore.
+This behavior is aligned with how SysON handles quotes in `declaredName` fields.
 
 === Improvements
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/imports/ImportSysMLModelTest.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/imports/ImportSysMLModelTest.java
@@ -45,6 +45,7 @@ import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureChainExpression;
 import org.eclipse.syson.sysml.FeatureReferenceExpression;
 import org.eclipse.syson.sysml.LiteralInteger;
+import org.eclipse.syson.sysml.LiteralString;
 import org.eclipse.syson.sysml.Membership;
 import org.eclipse.syson.sysml.OperatorExpression;
 import org.eclipse.syson.sysml.PartUsage;
@@ -620,6 +621,20 @@ public class ImportSysMLModelTest extends AbstractIntegrationTests {
             RequirementConstraintMembership requirementConstraintMembership = requirementConstraintMemberships.get(0);
             assertThat(requirementConstraintMembership.getKind()).isEqualTo(RequirementConstraintKind.REQUIREMENT);
             assertThat(requirementConstraintMembership.getOwnedConstraint()).isNotNull();
+        }).check(input);
+    }
+
+    @Test
+    @DisplayName("Given an AttributeUsage with a LiteralString, when importing the model, then the LiteralString value does not contain double quotes")
+    public void checkAttributeUsageLiteralStringValueTest() throws IOException {
+        var input = """
+                attribute myAttribute = "value";
+                """;
+        this.checker.checkImportedModel(resource -> {
+            List<LiteralString> literalStrings = EMFUtils.allContainedObjectOfType(resource, LiteralString.class).toList();
+            assertThat(literalStrings).hasSize(1);
+            LiteralString literalString = literalStrings.get(0);
+            assertThat(literalString.getValue()).doesNotContain("\"");
         }).check(input);
     }
 

--- a/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/parser/translation/EAttributeTranslator.java
+++ b/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/parser/translation/EAttributeTranslator.java
@@ -33,6 +33,8 @@ public class EAttributeTranslator {
 
     private static final String QUOTE_CONST = "\'";
 
+    private static final String DOUBLE_QUOTE_CONST = "\"";
+
     private EAttribute matchingAttribute;
 
     private Object value;
@@ -57,6 +59,9 @@ public class EAttributeTranslator {
             this.matchingAttribute = SysmlPackage.eINSTANCE.getMembership_MemberName();
         } else if (SysmlPackage.eINSTANCE.getLiteralExpression().isSuperTypeOf(ownerType) && astFeatureName.equals("literal")) {
             this.matchingAttribute = this.getAttribute(ownerType, "value").orElse(null);
+            if (SysmlPackage.eINSTANCE.getLiteralString().isSuperTypeOf(ownerType)) {
+                forcedValue = this.handleLiteralStringValue(ownerType, astFeatureName, astValue);
+            }
         } else if (astFeatureName.equals("isReference")) {
             forcedValue = this.handleIsReferenceAttribute(ownerType, astValue);
         } else if ((SysmlPackage.eINSTANCE.getComment().isSuperTypeOf(ownerType) || SysmlPackage.eINSTANCE.getTextualRepresentation().isSuperTypeOf(ownerType)) && "body".equals(astFeatureName)) {
@@ -115,6 +120,10 @@ public class EAttributeTranslator {
         // This does not properly handle multiline comment
         forcedValue = this.asCleanedText(astValue).replaceFirst("^/\\*", "").replaceFirst("\\*/", "").trim();
         return forcedValue;
+    }
+
+    private Object handleLiteralStringValue(EClass ownerType, String astFeatureName, JsonNode astValue) {
+        return astValue.asText().replace(DOUBLE_QUOTE_CONST, "");
     }
 
     public Object getValue() {

--- a/doc/content/modules/user-manual/pages/release-notes/2025.4.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2025.4.0.adoc
@@ -58,6 +58,9 @@ They no longuer contain the extra characters:
 * _*/_
 * _"_
 
+- Uniformize the import of `LiteralString`.
+The `value` field of imported `LiteralString` elements does not contain double quotes anymore.
+This behavior is aligned with how SysON handles quotes in `declaredName` fields.
 
 == New features
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/1172

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
