### PR TITLE
[1090] Fix the import of MultiplicityRange with lower and upper bounds

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,8 @@ When creating a new `Perform Action` referencing an existing `Action`, all compa
 - https://github.com/eclipse-syson/syson/issues/1300[#1300] [general-view] Fix wrong tool section name found in some compartments' palette.
 - https://github.com/eclipse-syson/syson/issues/1303[#1303] [general-view] Fix the name of `Constraint` creation tools inside `Requirement`.
 - https://github.com/eclipse-syson/syson/issues/1324[#1324] [details] Fix an issue that prevents ending up with a `null` reference in the reference widget.
+- https://github.com/eclipse-syson/syson/issues/1090[#1090] [import] Fix the textual import of `MultiplicityRange` with lower and upper bounds.
+The import now correctly creates a `MultiplicityRange` containing `LiteralInteger` elements for integer bounds, and `FeatureReferenceExpression` elements for feature bounds.
 
 === Improvements
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
@@ -737,4 +737,12 @@ public class ImportExportTests extends AbstractIntegrationTests {
                 attribute myAttribute = "value";""";
         this.checker.check(input, input);
     }
+
+    @Test
+    @DisplayName("Given a model with a PartUsage containing a Multiplicity with LiteralInteger bounds, when importing and exporting the model, then the exported text file should be the same as the imported one")
+    public void checkMultiplicityRangeWithLiteralIntegerBounds() throws IOException {
+        var input = """
+                part myPart [1..2];""";
+        this.checker.check(input, input);
+    }
 }

--- a/backend/application/syson-sysml-import/pom.xml
+++ b/backend/application/syson-sysml-import/pom.xml
@@ -68,6 +68,11 @@
 			<version>2025.4.5</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.syson</groupId>
+			<artifactId>syson-services</artifactId>
+			<version>2025.4.5</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/doc/content/modules/user-manual/pages/release-notes/2025.6.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2025.6.0.adoc
@@ -39,6 +39,8 @@ They are now named:
 * `New Assume constraint`
 
 - In the _Details_ view, fix an issue that prevents opening the candidates on a reference widget.
+- Fix an issue in the textual import of `MultiplicityRange` with explicit lower and upper bounds.
+The textual import now correctly creates a `MultiplicityRange` containing `LiteralInteger` elements for integer bounds, and `FeatureReferenceExpression` elements for feature bounds.
 
 == New features
 


### PR DESCRIPTION
SysIDE does a bad job at parsing multiplicity ranges with upper and lower bounds: it produces a `MultiplicityRange` with an  `OperatorExpression` containing features ultimately containing `LiteralIntegers`, while the specification (and the pilot implementation) indicate to create a `MultiplicityRange` containing directly the `LiteralIntegers`.

Similarly, SysIDE creates `FeatureChainExpression` and `FeatureChaining` inside the `OperatorExpression` for bounds that refer to a `Feature`, while the specification indicate to create a `FeatureReferenceExpression` with a referent to the `Feature`.

Note that in this second case the pilot implementation does not implement the specification, and it is not possible to have `Feature` as upper and lower bounds of a `MultiplicityRange`.

The fix is implemented in the _post resolving fixing phase_ of the import, because it needs to access the features effectively referenced by the produced `FeatureChainExpression`. We can't manipulate proxies because the resolution of `FeatureChainExpression` is not the same as the resolution of `FeatureReferenceExpression`:  a proxy used in the context of a `FeatureChainExpression` can't be resolved as is in the context of a `FeatureReferenceExpression`.

I think it could be a good idea to have @adaussy take an additional look at this pull request, as it touches core parts of the import mechanism and I am not sure I understand all the implications of it.

Fixes #1090 

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
