### PR TITLE
[1244] Make LibraryPackage's isStandard checkbox read-only

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -56,6 +56,8 @@ When end-users click on _New Object_ on a semantic element, and select a `ViewUs
 - https://github.com/eclipse-syson/syson/issues/1257[#1257] [general-view] Add the `perform actions` compartment on `PartUsage` and `PartDefinition` graphical nodes in the _General View_ diagram.
 - https://github.com/eclipse-syson/syson/issues/1277[#1277] [general-view] Add the `perform actions` compartment on `ActionUsage` and `ActionDefinition` graphical nodes in the _General View_ diagram.
 - https://github.com/eclipse-syson/syson/issues/1287[#1287] [general-view] Reduce the initial width of the `Package` graphical node.
+- https://github.com/eclipse-syson/syson/issues/1244[#1244] [details] Make `LibraryPackage`'s `isStandard` checkbox read-only in the _Details_ view.
+At the moment SysON only supports KerML and SysML, and does not support the definition of other normative model libraries.
 
 === New features
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/DetailsViewService.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/DetailsViewService.java
@@ -155,6 +155,12 @@ public class DetailsViewService {
             isReadOnly = true;
         } else if (SysmlPackage.eINSTANCE.getPortConjugation_OriginalPortDefinition().equals(eStructuralFeature)) {
             isReadOnly = true;
+        } else if (SysmlPackage.eINSTANCE.getLibraryPackage_IsStandard().equals(eStructuralFeature)) {
+            // Based on KerML 8.3.4.13.3, this feature should be set for LibraryPackages in the standard Kernel Model
+            // Libraries or normative model libraries for a language built on KerML.
+            // SysON only allows to work with SysML at the moment, and does not support the definition of other
+            // normative model libraries.
+            isReadOnly = true;
         } else {
             isReadOnly = eStructuralFeature.isDerived() || !eStructuralFeature.isChangeable();
         }

--- a/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/DetailsViewServiceTest.java
+++ b/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/DetailsViewServiceTest.java
@@ -92,4 +92,9 @@ public class DetailsViewServiceTest {
         ElementUtil.setIsImported(resource, true);
         assertThat(this.detailsViewService.isReadOnly(pack)).isFalse();
     }
+
+    @Test
+    public void isReadOnlyLibraryPackageIsStandardEAttribute() {
+        assertThat(this.detailsViewService.isReadOnly(SysmlPackage.eINSTANCE.getLibraryPackage_IsStandard()));
+    }
 }

--- a/doc/content/modules/user-manual/pages/release-notes/2025.6.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2025.6.0.adoc
@@ -183,6 +183,8 @@ image::StateTransitionUsageLabels.png[TransitionUsage labels]
 image::release-notes-GV-actionDefinition-parameters.png[Parameters compartment on ActionDefinition]
 
 - In the _General View_ diagram, the selection dialog to reference an existing `Action` when creating a new `Perform Action` has been improved to present those `Actions` in a hierarchical way.
+- Make LibraryPackage's `isStandard` checkbox read-only in the details view.
+At the moment SysON only supports KerML and SysML, and does not support the definition of other normative model libraries.
 
 - Add a `perform actions` compartment `PartUsage` and `PartDefinition` to display `PerformActionUsage` in the _General View_ diagram.
 


### PR DESCRIPTION
This PR makes LibraryPackage's `isStandard` checkbox read-only in the details view. The issue originally proposes to remove the checkbox, but I think it provide relevant information to the end user. 
Making it read-only let the user get the information while enforcing the fact that SysON does not support non-SysML, non-KerML standard libraries.

Note that the PR does not address the question of the textual import of a standard library package.

Fixes #1244 

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
