### PR TITLE
[1321] Prevent TransitionUsage source/target reconnection to another

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -59,6 +59,7 @@ When creating a new `Perform Action` referencing an existing `Action`, all compa
 The import now correctly creates a `MultiplicityRange` containing `LiteralInteger` elements for integer bounds, and `FeatureReferenceExpression` elements for feature bounds.
 - https://github.com/eclipse-syson/syson/issues/1318[#1318] [details] Fix an issue that prevents adding a new value to a multi-valued reference in the reference widget.
 - https://github.com/eclipse-syson/syson/issues/1331[#1331] [general-view] Fix an issue that prevents dropping a `Definition` element from the _Explorer view_ on a _General View_.
+- https://github.com/eclipse-syson/syson/issues/1321[#1321] [general-view] Prevent `TransitionUsage` graphical edges source/target reconnection to another `TransitionUsage`.
 
 === Improvements
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVActionFlowTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVActionFlowTests.java
@@ -149,7 +149,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         }
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given two ActionUsages nested in each other,"
@@ -178,7 +179,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given two ActionUsages nested in each other,"
@@ -207,7 +209,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given two ActionUsage,"
@@ -242,7 +245,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given a TransitionUsage,"
@@ -274,7 +278,41 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    @Test
+    @DisplayName("Given a TransitionUsage,"
+            + "when reconnecting the target, "
+            + "then the reconnection to a TransitionUsage should be forbidden")
+    public void reconnectTransitionUsageTargetOnTransitionForbidden() {
+        this.verifier.then(() -> this.edgeReconnectionTester.reconnectEdge(ActionFlowCompartmentTestProjectData.EDITING_CONTEXT_ID,
+                this.diagram,
+                ActionFlowCompartmentTestProjectData.GraphicalIds.TRANSITION_A2_A3_ID,
+                ActionFlowCompartmentTestProjectData.GraphicalIds.TRANSITION_A2_A3_ID,
+                ReconnectEdgeKind.TARGET));
+
+        IDiagramChecker diagramCheckerTarget = (initialDiagram, newDiagram) -> {
+            new CheckDiagramElementCount(this.diagramComparator)
+                    .hasNewEdgeCount(0)
+                    .check(initialDiagram, newDiagram);
+
+            Edge existingEdge = newDiagram.getEdges().stream().filter(e -> e.getId().equals(ActionFlowCompartmentTestProjectData.GraphicalIds.TRANSITION_A2_A3_ID)).findFirst().get();
+            assertThat(existingEdge).hasSourceId(ActionFlowCompartmentTestProjectData.GraphicalIds.SUB_ACTION2_ID);
+            assertThat(existingEdge).hasTargetId(ActionFlowCompartmentTestProjectData.GraphicalIds.SUB_ACTION3_ID);
+            assertThat(existingEdge.getStyle()).hasTargetArrow(ArrowStyle.InputArrow);
+        };
+
+        this.diagramCheckerService.checkDiagram(diagramCheckerTarget, this.diagram, this.verifier);
+
+        this.semanticCheckerService.checkElement(this.verifier, TransitionUsage.class, () -> ActionFlowCompartmentTestProjectData.SemanticIds.TRANSITION_A2_A3_ID, transitionUsage -> {
+            assertThat(this.identityService.getId(transitionUsage.getSource())).isEqualTo(ActionFlowCompartmentTestProjectData.SemanticIds.SUB_ACTION2_ID);
+            assertThat(this.identityService.getId(transitionUsage.getTarget())).isEqualTo(ActionFlowCompartmentTestProjectData.SemanticIds.SUB_ACTION3_ID);
+        });
+    }
+
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given a TransitionUsage,"
@@ -306,7 +344,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given two ActionUsage,"
@@ -342,7 +381,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given SuccessionAsUsage from 2 ActionUsages,"
@@ -375,7 +415,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given a start action and an ActionUsage,"
@@ -410,7 +451,8 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given a start action and  ActionUsage,"
@@ -448,12 +490,13 @@ public class GVActionFlowTests extends AbstractIntegrationTests {
         });
     }
 
-    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(scripts = { ActionFlowCompartmentTestProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD,
+            config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
     @Test
     @DisplayName("Given a sub action node and a done action,"
             + "when using the 'New Transition' tool between them, "
-            + "then a TransitionUsage is created between the decisionNode to the 'done' element. The new TransitionUsage is store in the container action")
+            + "then a TransitionUsage is created between the decisionNode to the 'done' element. The new TransitionUsage is stored in the container action")
     public void createTransitionUsageToDone() {
         String creationToolId = this.diagramDescriptionIdProvider.getEdgeCreationToolId(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getActionUsage()), "New Transition");
         this.verifier.then(() -> this.edgeCreationTester.createEdgeUsingNodeId(ActionFlowCompartmentTestProjectData.EDITING_CONTEXT_ID,

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeService.java
@@ -270,7 +270,7 @@ public class ViewEdgeService {
      * @return the given {@link TransitionUsage}.
      */
     public TransitionUsage reconnectSourceTransitionEdge(TransitionUsage transition, ActionUsage newSource) {
-        if (!(newSource instanceof ActionUsage) || !this.checkTransitionEdgeTarget(newSource, transition.getTarget())) {
+        if (!(newSource instanceof ActionUsage) || newSource instanceof TransitionUsage || !this.checkTransitionEdgeTarget(newSource, transition.getTarget())) {
             this.feedbackMessageService.addFeedbackMessage(new Message("Invalid new source for transition", MessageLevel.WARNING));
             return transition;
         }
@@ -309,7 +309,7 @@ public class ViewEdgeService {
      * @return the given {@link TransitionUsage}.
      */
     public TransitionUsage reconnectTargetTransitionEdge(TransitionUsage transition, ActionUsage newTarget) {
-        if (!(newTarget instanceof ActionUsage) || !this.checkTransitionEdgeTarget(transition.getSource(), newTarget)) {
+        if (!(newTarget instanceof ActionUsage) || newTarget instanceof TransitionUsage || !this.checkTransitionEdgeTarget(transition.getSource(), newTarget)) {
             this.feedbackMessageService.addFeedbackMessage(new Message("Invalid new target for transition", MessageLevel.WARNING));
             return transition;
         }

--- a/doc/content/modules/user-manual/pages/release-notes/2025.6.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2025.6.0.adoc
@@ -43,6 +43,10 @@ They are now named:
 The textual import now correctly creates a `MultiplicityRange` containing `LiteralInteger` elements for integer bounds, and `FeatureReferenceExpression` elements for feature bounds.
 - Fix an issue where dragging and dropping a `Definition` element from the _Explorer view_ on a _General View_ did not create the associated node.
 
+- In diagrams, prevent `TransitionUsage` graphical edges to be reconnected to another `TransitionUsage`.
+In the previous implementation, it was possible during a graphical edge reconnection to drop the source or target to another `TransitionUsage`.
+The semantic of the `TransitionUsage` being reconnected was changed and the graphical edge was removed from the diagram.
+
 == New features
 
 - `ViewUsage` may now be displayed and created from the _General View_.


### PR DESCRIPTION
TransitionUsage

Bug: https://github.com/eclipse-syson/syson/issues/1321

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [X] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [X] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
