### PR TITLE
[releng] Avoid template-injection in github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,13 @@ on:
       - "doc/**"
   workflow_dispatch:
 
+env:
+  GITHUB_EVENT_NAME: ${{ github.event_name }}
+  GITHUB_EVENT_PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+  GITHUB_EVENT_PR_BASE_REPO_FULL_NAME: ${{ github.event.pull_request.base.repo.full_name }}
+  GITHUB_EVENT_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  GITHUB_REF: ${{ github.ref }}
+
 jobs:
   build:
     name: Build
@@ -28,21 +35,21 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: env.GITHUB_EVENT_NAME != 'pull_request' || env.GITHUB_EVENT_PR_HEAD_REPO_FULL_NAME != env.GITHUB_EVENT_PR_BASE_REPO_FULL_NAME
 
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name != 'pull_request'
+        if: ${{ env.GITHUB_EVENT_NAME }} != 'pull_request'
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name == 'pull_request'
+        if: ${{ env.GITHUB_EVENT_NAME }} == 'pull_request'
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ env.GITHUB_EVENT_PR_HEAD_SHA }}
           persist-credentials: false
 
       - name: Setup Node SDK
@@ -115,7 +122,7 @@ jobs:
         run: jshell scripts/check-coverage.jsh
 
       - name: Publish the backend
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(env.GITHUB_REF, 'refs/tags/v')
         env:
           USERNAME: ${{github.actor}}
           PASSWORD: ${{secrets.GITHUB_TOKEN}}
@@ -123,7 +130,7 @@ jobs:
         run: mvn -B deploy -DskipTests --settings settings.xml
 
       - name: Publish the frontend packages
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(env.GITHUB_REF, 'refs/tags/v')
         run: |
           npm publish --workspaces
         env:
@@ -154,7 +161,7 @@ jobs:
         working-directory: integration-tests
 
       - name: Run end to end tests against the application
-        if: startsWith(github.ref, 'refs/tags/v') == false && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/cooldown'
+        if: startsWith(env.GITHUB_REF, 'refs/tags/v') == false && env.GITHUB_REF != 'refs/heads/main' && env.GITHUB_REF != 'refs/heads/cooldown'
         uses: cypress-io/github-action@6c143abc292aa835d827652c2ea025d098311070 # v6.10.1
         with:
           build: docker compose -f docker-compose-integration-tests.yml up -d
@@ -176,14 +183,17 @@ jobs:
           retention-days: 5
 
       - name: Log in to Docker Hub
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        if: env.GITHUB_EVENT_NAME == 'push' && (env.GITHUB_REF == 'refs/heads/main' || startsWith(env.GITHUB_REF, 'refs/tags/v'))
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          username: ${{ secrets.ORG_DOCKER_HUB_USER }}
-          password: ${{ secrets.ORG_DOCKER_HUB_TOKEN }}
+          username: ${{ env.DOCKER_HUB_USER }}
+          password: ${{ env.DOCKER_HUB_TOKEN }}
+        env:
+          DOCKER_HUB_USER: ${{ secrets.ORG_DOCKER_HUB_USER }}
+          DOCKER_HUB_TOKEN: ${{ secrets.ORG_DOCKER_HUB_TOKEN }}
 
       - name: Push Docker image
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        if: env.GITHUB_EVENT_NAME == 'push' && (env.GITHUB_REF == 'refs/heads/main' || startsWith(env.GITHUB_REF, 'refs/tags/v'))
         id: push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:

--- a/.github/workflows/doc-gen.yml
+++ b/.github/workflows/doc-gen.yml
@@ -22,7 +22,9 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ env.STEPS_DEPLOYMENT_OUTPUTS_PAGE_URL }}
+    env:
+      STEPS_DEPLOYMENT_OUTPUTS_PAGE_URL: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -17,6 +17,12 @@ env:
   PRODUCT_PATH: "backend/application"
   PLUGIN_VERSION: "2.7.8"
   SBOM_TYPE: "makeAggregateBom"
+  WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+  WORKFLOW_EVENT: ${{ github.event.workflow_run.event }}
+  WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  GITHUB_REF: ${{ github.ref }}
+  INPUTS_VERSION: ${{ github.event.inputs.version }}
+  EVENT_NAME: ${{ github.event_name }}
 
 permissions:
   contents: read
@@ -25,21 +31,21 @@ jobs:
   generate-sbom:
     name: Generate SBOM for backend
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request' && (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) }}
+    if: env.WORKFLOW_CONCLUSION == 'success' && env.WORKFLOW_EVENT != 'pull_request' && (env.WORKFLOW_HEAD_BRANCH == 'main' || startsWith(env.WORKFLOW_HEAD_BRANCH, 'v')) }}
     outputs:
       project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
     steps:
       - name: Display metadata of workflow that has been completed before this one
         run: |
-          echo "Run from workflow_run branch ${{ github.event.workflow_run.head_branch }}"
-          echo "Run from workflow_run event ${{ github.event.workflow_run.event }}"
-          echo "Run on github.ref ${{ github.ref }}"
+          echo "Run from workflow_run branch ${WORKFLOW_HEAD_BRANCH}"
+          echo "Run from workflow_run event ${WORKFLOW_EVENT}"
+          echo "Run on github.ref ${GITHUB_REF}"
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.version }}
+          ref: ${{ env.INPUTS_VERSION }}
           persist-credentials: false
 
       - name: Setup Java SDK
@@ -58,10 +64,10 @@ jobs:
         id: version
         shell: bash
         run: |
-          event="${{ github.event_name }}"
-          event_workflow_run_head_branch="${{ github.event.workflow_run.head_branch }}"
-          ref="${{ github.ref }}"
-          input="${{ github.event.inputs.version }}"
+          event="${EVENT_NAME}"
+          event_workflow_run_head_branch="${WORKFLOW_HEAD_BRANCH}"
+          ref="${GITHUB_REF}"
+          input="${INPUTS_VERSION}"
 
           VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/target/bom.json)"
 
@@ -83,7 +89,9 @@ jobs:
     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
     with:
       projectName: "backend"
-      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      projectVersion: ${{ env.OUTPUT_PROJECT_VERSION }}
       bomArtifact: "backend-sbom"
       bomFilename: "bom.json"
       parentProject: "75152c84-655b-4618-b23c-e5d3c3b562ae"
+    env:
+      OUTPUT_PROJECT_VERSION: ${{ needs.generate-sbom.outputs.project-version }}

--- a/.github/workflows/generate-npm-sbom.yml
+++ b/.github/workflows/generate-npm-sbom.yml
@@ -15,6 +15,12 @@ env:
   NODE_VERSION: "18.7"
   REGISTRY_URL: "https://npm.pkg.github.com/"
   PRODUCT_PATH: "./"
+  WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+  WORKFLOW_EVENT: ${{ github.event.workflow_run.event }}
+  WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  GITHUB_REF: ${{ github.ref }}
+  INPUTS_VERSION: ${{ github.event.inputs.version }}
+  EVENT_NAME: ${{ github.event_name }}
 
 permissions:
   contents: read
@@ -23,7 +29,7 @@ jobs:
   generate-sbom:
     name: Generate SBOM for frontend
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request' && (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) }}
+    if: env.WORKFLOW_CONCLUSION == 'success' && env.WORKFLOW_EVENT != 'pull_request' && (env.WORKFLOW_HEAD_BRANCH == 'main' || startsWith(env.WORKFLOW_HEAD_BRANCH, 'v')) }}
     outputs:
       project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
     permissions:
@@ -32,15 +38,15 @@ jobs:
     steps:
       - name: Display metadata of workflow that has been completed before this one
         run: |
-          echo "Run from workflow_run branch ${{ github.event.workflow_run.head_branch }}"
-          echo "Run from workflow_run event ${{ github.event.workflow_run.event }}"
-          echo "Run on github.ref ${{ github.ref }}"
+          echo "Run from workflow_run branch ${WORKFLOW_HEAD_BRANCH}"
+          echo "Run from workflow_run event ${WORKFLOW_EVENT}"
+          echo "Run on github.ref ${GITHUB_REF}"
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.version }}
+          ref: ${{ env.INPUTS_VERSION }}
           persist-credentials: false
 
       - name: Setup Node SDK
@@ -67,10 +73,10 @@ jobs:
         id: version
         shell: bash
         run: |
-          event="${{ github.event_name }}"
-          event_workflow_run_head_branch="${{ github.event.workflow_run.head_branch }}"
-          ref="${{ github.ref }}"
-          input="${{ github.event.inputs.version }}"
+          event="${EVENT_NAME}"
+          event_workflow_run_head_branch="${WORKFLOW_HEAD_BRANCH}"
+          ref="${GITHUB_REF}"
+          input="${INPUTS_VERSION}"
 
           VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/bom.json)"
 
@@ -92,7 +98,9 @@ jobs:
     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
     with:
       projectName: "frontend"
-      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      projectVersion: ${{ env.OUTPUT_PROJECT_VERSION }}
       bomArtifact: "frontend-sbom"
       bomFilename: "bom.json"
       parentProject: "1b099ee7-62ee-48e1-986b-b7f0309dd344"
+    env:
+      OUTPUT_PROJECT_VERSION: ${{ needs.generate-sbom.outputs.project-version }}


### PR DESCRIPTION
Replace template expansions ${{...}} with exporting VAR in env and using ${VAR} instead

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [ ] Has the pull request been added to the relevant milestone?
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [ ] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [ ] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
