### PR TITLE
[1581] Remove rename and delete tools from inherited port palette in …

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@
 
 - https://github.com/eclipse-syson/syson/issues/1604[#1604] [export] Fix an issue where the `Imports` located in the root `Namespace` were not exported in the textual format.
 - https://github.com/eclipse-syson/syson/issues/1602[#1602] [diagrams] Fix an issue where the drag and drop of a `RequirementUsage` (or any other `Element`) with a declared short name but no declared name from the _Explorer_ view to a diagram was not possible.
+- https://github.com/eclipse-syson/syson/issues/1581[#1581] [diagrams] Remove rename and delete tools from inherited port palette.
 
 === Improvements
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPortUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractPortUsageBorderNodeDescriptionProvider.java
@@ -69,6 +69,8 @@ public abstract class AbstractPortUsageBorderNodeDescriptionProvider extends Abs
 
     protected abstract OutsideLabelDescription createOutsideLabelDescription();
 
+    protected abstract NodePalette createNodePalette(IViewDiagramElementFinder cache, NodeDescription nodeDescription);
+
     protected abstract String getName();
 
     @Override
@@ -93,7 +95,7 @@ public abstract class AbstractPortUsageBorderNodeDescriptionProvider extends Abs
         cache.getNodeDescription(this.getName()).ifPresent(portUsageBorderNodeDescription -> portUsageBorderNodeDescription.setPalette(this.createNodePalette(cache, portUsageBorderNodeDescription)));
     }
 
-    private NodeStyleDescription createPortUnsetNodeStyle() {
+    protected NodeStyleDescription createPortUnsetNodeStyle() {
         return this.diagramBuilderHelper.newRectangularNodeStyleDescription()
                 .borderColor(this.colorProvider.getColor(ViewConstants.DEFAULT_BORDER_COLOR))
                 .borderRadius(0)
@@ -114,7 +116,7 @@ public abstract class AbstractPortUsageBorderNodeDescriptionProvider extends Abs
                 .build();
     }
 
-    private List<ConditionalNodeStyle> createPortUsageConditionalNodeStyles() {
+    protected List<ConditionalNodeStyle> createPortUsageConditionalNodeStyles() {
         var borderColor = this.colorProvider.getColor(ViewConstants.DEFAULT_BORDER_COLOR);
         return List.of(
                 this.diagramBuilderHelper.newConditionalNodeStyle()
@@ -132,33 +134,7 @@ public abstract class AbstractPortUsageBorderNodeDescriptionProvider extends Abs
         );
     }
 
-    private NodePalette createNodePalette(IViewDiagramElementFinder cache, NodeDescription nodeDescription) {
-        var changeContext = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getSelfServiceCallExpression("deleteFromModel"));
-
-        var deleteTool = this.diagramBuilderHelper.newDeleteTool()
-                .name("Delete from Model")
-                .body(changeContext.build());
-
-        var callEditService = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getSelfServiceCallExpression("directEdit", "newLabel"));
-
-        var editTool = this.diagramBuilderHelper.newLabelEditTool()
-                .name("Edit")
-                .initialDirectEditLabelExpression(AQLUtils.getSelfServiceCallExpression("getDefaultInitialDirectEditLabel"))
-                .body(callEditService.build());
-
-
-        return this.diagramBuilderHelper.newNodePalette()
-                .deleteTool(deleteTool.build())
-                .labelEditTool(editTool.build())
-                .toolSections(this.defaultToolsFactory.createDefaultHideRevealNodeToolSection())
-                .edgeTools(this.getEdgeTools(cache, nodeDescription).toArray(EdgeTool[]::new))
-                .build();
-    }
-
     protected String getToolIconURLsExpression(String elementName) {
         return "/icons/full/obj16/" + elementName + ".svg";
     }
-
 }

--- a/backend/views/syson-diagram-tests/src/main/java/org/eclipse/syson/diagram/tests/predicates/DiagramPredicates.java
+++ b/backend/views/syson-diagram-tests/src/main/java/org/eclipse/syson/diagram/tests/predicates/DiagramPredicates.java
@@ -40,6 +40,8 @@ public class DiagramPredicates {
 
     private final Predicate<NodeDescription> isInheritedCompartmentItemNode;
 
+    private final Predicate<NodeDescription> isInheritedBorderNode;
+
     private final Predicate<NodeDescription> isNamespaceImportNode;
 
     private final Predicate<NodeDescription> isStartOrDoneNode;
@@ -51,6 +53,8 @@ public class DiagramPredicates {
         this.isCompartmentNode = n -> n.getName().contains(compartmentNameFragment);
         String inheritedCompartmentItemNameFragment = this.getInheritedCompartmentItemNameFragment(descriptionNameGenerator);
         this.isInheritedCompartmentItemNode = n -> n.getName().contains(inheritedCompartmentItemNameFragment);
+        String inheritedBorderNodeNameFragment = this.getInheritedBorderNodeNameFragment(descriptionNameGenerator);
+        this.isInheritedBorderNode = n -> n.getName().contains(inheritedBorderNodeNameFragment);
         this.isNamespaceImportNode = n -> n.getName().equals(diagramPrefix + " Node NamespaceImport");
         this.isStartOrDoneNode = n -> n.getName().equals(descriptionNameGenerator.getNodeName(StartActionNodeDescriptionProvider.START_ACTION_NAME))
                 || n.getName().equals(descriptionNameGenerator.getNodeName(DoneActionNodeDescriptionProvider.DONE_ACTION_NAME));
@@ -70,6 +74,10 @@ public class DiagramPredicates {
 
     public Predicate<NodeDescription> isInheritedCompartmentItemNode() {
         return this.isInheritedCompartmentItemNode;
+    }
+
+    public Predicate<NodeDescription> isInheritedBorderNode() {
+        return this.isInheritedBorderNode;
     }
 
     public Predicate<NodeDescription> getIsNamespaceImportNode() {
@@ -107,6 +115,15 @@ public class DiagramPredicates {
 
         return fullName.replace(element.getName(), "")
                 .replace(reference.getName(), "")
+                .strip()
+                .concat(" ");
+    }
+
+    private String getInheritedBorderNodeNameFragment(IDescriptionNameGenerator nameGenerator) {
+        EClass element = SysmlPackage.eINSTANCE.getElement();
+        String fullName = nameGenerator.getInheritedBorderNodeName(element);
+
+        return fullName.replace(element.getName(), "")
                 .strip()
                 .concat(" ");
     }

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/InheritedPortUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/InheritedPortUsageBorderNodeDescriptionProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.sirius.components.view.builder.IViewDiagramElementFinder;
 import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
 import org.eclipse.sirius.components.view.diagram.EdgeTool;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.sirius.components.view.diagram.NodePalette;
 import org.eclipse.sirius.components.view.diagram.OutsideLabelDescription;
 import org.eclipse.sirius.components.view.diagram.OutsideLabelPosition;
 import org.eclipse.sirius.web.application.editingcontext.EditingContext;
@@ -64,6 +65,14 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
     @Override
     protected String getName() {
         return this.nameGenerator.getInheritedBorderNodeName(SysmlPackage.eINSTANCE.getPortUsage());
+    }
+
+    @Override
+    protected NodePalette createNodePalette(IViewDiagramElementFinder cache, NodeDescription nodeDescription) {
+        return this.diagramBuilderHelper.newNodePalette()
+                .toolSections(this.defaultToolsFactory.createDefaultHideRevealNodeToolSection())
+                .edgeTools(this.getEdgeTools(cache, nodeDescription).toArray(EdgeTool[]::new))
+                .build();
     }
 
     @Override

--- a/backend/views/syson-standard-diagrams-view/src/test/java/org/eclipse/syson/standard/diagrams/view/SDVDiagramDescriptionTests.java
+++ b/backend/views/syson-standard-diagrams-view/src/test/java/org/eclipse/syson/standard/diagrams/view/SDVDiagramDescriptionTests.java
@@ -113,6 +113,7 @@ public class SDVDiagramDescriptionTests {
                         .and(this.diagramPredicates.isEmptyDiagramNode().negate())
                         .and(this.diagramPredicates.isCompartmentNode().negate())
                         .and(this.diagramPredicates.isInheritedCompartmentItemNode().negate())
+                        .and(this.diagramPredicates.isInheritedBorderNode().negate())
                         .and(this.diagramPredicates.getIsNamespaceImportNode().negate())
                 )
                 .filter(nodeDescription -> nodeDescription.getInsideLabel() != null && nodeDescription.getInsideLabel().getLabelExpression() != null
@@ -129,6 +130,7 @@ public class SDVDiagramDescriptionTests {
                         .and(this.diagramPredicates.isEmptyDiagramNode().negate())
                         .and(this.diagramPredicates.isCompartmentNode().negate())
                         .and(this.diagramPredicates.isInheritedCompartmentItemNode().negate())
+                        .and(this.diagramPredicates.isInheritedBorderNode().negate())
                         .and(this.diagramPredicates.isStartOrDoneNode().negate()))
                 .toList();
         new NodeDescriptionHasDeleteToolChecker().checkAll(nodeDescriptionCandidates);

--- a/doc/content/modules/user-manual/pages/release-notes/2025.12.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2025.12.0.adoc
@@ -7,6 +7,7 @@
 == New features
 
 - In diagrams, inherited _PortUsages_ are now displayed as graphical border nodes.
+These graphical border nodes cannot be edited or deleted.
 
 image::gv-inherited-port.png[Inherited port, width=65%,height=65%]
 


### PR DESCRIPTION
…diagrams

Bug: https://github.com/eclipse-syson/syson/issues/1581

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [x] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
