### PR TITLE
enhancements for podman

### DIFF
--- a/doc/content/modules/installation-guide/pages/troubleshooting.adoc
+++ b/doc/content/modules/installation-guide/pages/troubleshooting.adoc
@@ -53,3 +53,11 @@ This is done via mounting a local directory as volume. Add following lines to th
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
 ----
+
+== Problems when not using a standard Docker environment (i.e. docker desktop)
+If your container environment is not a standard Docker installation you may run into access problems.
+These can be solved by adding
+----
+    privileged: true
+----
+to both containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ version: "3.8"
 services:
   database:
     image: postgres:15
-    # A default Docker installation runs containers with root privileges. If your Container runtime
-    # is configured to run without root prigilegesu ncomment this option to solve 'access denied' problems.
-    #privileged: true
     # Uncomment this option if you want to run this docker compose file on ARM architectures
     # platform: linux/amd64
     environment:
@@ -17,9 +14,6 @@ services:
       - syson
   app:
     image: "${IMAGE_TAG:-eclipsesyson/syson:v2025.10.0}"
-    # A default Docker installation runs containers with root privileges. If your Container runtime
-    # is configured to run without root prigilegesu ncomment this option to solve 'access denied' problems.
-    #privileged: true
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Getting the environment to work when using podman as container engine needs root privileges set.
It may also be of interest to others to keep the work between restarts of the postgres container.

Both features must be activated by uncommenting the respective lines..
