### PR TITLE
[1647] Import: memberFeature of EndFeatureMembership

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -66,6 +66,7 @@ Also introduces new `ServiceMethod` helper class to build AQL service call expre
 
 - https://github.com/eclipse-syson/syson/issues/1620[#1620] [services] Handle short names in qualified names when direct editing.
 - https://github.com/eclipse-syson/syson/issues/1636[#1636] [export] Implement `OperationExpression` using operator 'meta'.
+- https://github.com/eclipse-syson/syson/issues/1647[#1647] [import] Textual import should enforce `Feature` reference as _memberFeature_ in `EndFeatureMembership` to have _isEnd_ set to _true_.
 
 === New features
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/imports/ImportSysMLModelTest.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/imports/ImportSysMLModelTest.java
@@ -47,6 +47,7 @@ import org.eclipse.syson.sysml.BindingConnectorAsUsage;
 import org.eclipse.syson.sysml.ConjugatedPortDefinition;
 import org.eclipse.syson.sysml.DecisionNode;
 import org.eclipse.syson.sysml.Element;
+import org.eclipse.syson.sysml.EndFeatureMembership;
 import org.eclipse.syson.sysml.Expression;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureChainExpression;
@@ -272,6 +273,27 @@ public class ImportSysMLModelTest extends AbstractIntegrationTests {
             assertThat(flow.getSourceOutputFeature().getFeatureTarget().getName()).isEqualTo("item1");
             assertThat(flow.getTargetInputFeature().getFeatureTarget().getName()).isEqualTo("item2");
 
+        }).check(input);
+    }
+
+    @Test
+    @DisplayName("GIVEN a model with an EndFeatureMembership, WHEN importing the model, THEN the ReferenceUsage of the feature end should have isFeature = true")
+    public void checkMemberFeatureOfEndFeatureMembership() throws IOException {
+        var input = """
+                package pa1 {
+                    part pa1;
+                    part pa2;
+                
+                    connect pa1 to pa2;
+                }
+                """;
+
+        this.checker.checkImportedModel(resource -> {
+            List<EndFeatureMembership> endFeatureMemberships = EMFUtils.allContainedObjectOfType(resource, EndFeatureMembership.class)
+                    .toList();
+            assertThat(endFeatureMemberships)
+                    .hasSize(2)
+                    .allMatch(endFeatureMembership -> endFeatureMembership.getOwnedMemberFeature() != null && endFeatureMembership.getOwnedMemberFeature().isIsEnd());
         }).check(input);
     }
 

--- a/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/ASTTransformer.java
+++ b/backend/application/syson-sysml-import/src/main/java/org/eclipse/syson/sysml/ASTTransformer.java
@@ -165,7 +165,21 @@ public class ASTTransformer {
             this.fixTransitionUsageImplicitSource(root);
             this.fixOperatorExpressionUsedAsRanges(root);
             this.fixReferenceSubsettingWithNestedFeature(root);
+            this.fixEndFeatureMembership(root);
         }
+    }
+
+    /**
+     * The current implementation of the parser does not force the memberFeature of EndFeatureMembership to have "isEnd = true" like stated in the SysML specification see "8.3.3.3.3
+     * EndFeatureMembership".
+     *
+     * @param root
+     *         the root of the imported object
+     */
+    private void fixEndFeatureMembership(EObject root) {
+        EMFUtils.allContainedObjectOfType(root, EndFeatureMembership.class)
+                .filter(endFeatureMembership -> endFeatureMembership.getOwnedMemberFeature() != null)
+                .forEach(endFeatureMembership -> endFeatureMembership.getOwnedMemberFeature().setIsEnd(true));
     }
 
     /**

--- a/doc/content/modules/user-manual/pages/release-notes/2025.12.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2025.12.0.adoc
@@ -213,6 +213,18 @@ metadata def MD2 :> SemanticMetadata {
 }
 ```
 
+- The textual import now forces all the _memberFeature_ of _EndFeatureMemberships_ to have _isEnd = true_ like stated in the SysML Specification "8.3.3.3.3 EndFeatureMembership".
+For example, it means that the two features used as connector ends in the following models now have _isEnd = true_.
+
+```
+package pa1 {
+    part pa1;
+    part pa2;
+
+    connect pa1 to pa2; // Connector end features pa1 and pa2 now have isEnd = true
+}
+```
+
 == Technical details
 
 * For technical details on this {product} release (including breaking changes and dependency updates), please refer to https://github.com/eclipse-syson/syson/blob/main/CHANGELOG.adoc[changelog].


### PR DESCRIPTION
Textual import should enforce Feature reference as memberFeature in EndFeatureMembership to have isEnd set to true

Bug: https://github.com/eclipse-syson/syson/issues/1647

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
