### PR TITLE
[1786] Implement textual export of RequirementConstraintMembership

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -51,6 +51,7 @@ A new compartment named _satisfy requirements_ has also been added to `PartDefin
 - https://github.com/eclipse-syson/syson/issues/1737[#1737] [diagrams] Add creation tools to InterconnectionCompartmentNode
 - https://github.com/eclipse-syson/syson/issues/1395[#1395] Provide a way to duplicate a semantic element ans its representation node in the _General View_ diagram.
 - https://github.com/eclipse-syson/syson/issues/1740[#1740] [diagrams] Add _items_ compartment and graphical border node on `PortDefinition` graphical nodes in the _General View_ diagram.
+- https://github.com/eclipse-syson/syson/issues/1786[#1786] [export] Implement textual export of `RequirementConstraintMembership`.
 
 == v2025.12.0
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
@@ -217,6 +217,73 @@ public class ImportExportTests extends AbstractIntegrationTests {
     }
 
     @Test
+    @DisplayName("GIVEN a model with RequirementConstraintMembership, WHEN importing/exporting the file, THEN the exported text file should be the same as the imported one using the full notation.")
+    public void checkRequirementConstraintMembershipFullNotation() throws IOException {
+        var input = """
+                private import SI::kilogram;
+                private import ScalarValues::*;
+                part def P1 {
+                    attribute x : Real;
+                }
+                requirement r1 {
+                    subject sub : P1;
+                    attribute actualMass :> ISQBase::mass;
+                    attribute maxMass :> ISQBase::mass;
+                    assume constraint NamedRequirementConstraint {
+                        actualMass <= maxMass
+                    }
+                    assume constraint {
+                        sub.x <= 500
+                    }
+                    require constraint {
+                        actualMass >= 500 [kg]
+                    }
+                }
+                constraint def C;
+                constraint c : C;
+                requirement def R1 {
+                    require constraint c1 :>> c;
+                }""";
+        this.checker.check(input, input);
+    }
+
+    @Test
+    @DisplayName("GIVEN a model with RequirementConstraintMembership having ReferenceSubsetting, WHEN importing/exporting the file, THEN the exported text file should be the same as the imported one"
+            + "using the shorthand notation when possible.")
+    public void checkRequirementConstraintMembershipShorthandNotation() throws IOException {
+        var input = """
+                requirement r1;
+                requirement r3 {
+                    requirement r4 {
+                        requirement r5;
+                    }
+                    require r1;
+                    require r4.r5;
+                    require r4 {
+                        doc /* Some doc */
+                    }
+                }""";
+        this.checker.check(input, input);
+    }
+
+    @Test
+    @DisplayName("GIVEN a model with RequirementConstraintMembership having MetadataUsage, WHEN importing/exporting the file, THEN the exported text file should be the same as the imported one.")
+    public void checkRequirementConstraintMembershipWithMetadataUsage() throws IOException {
+        var input = """
+                private import Metaobjects::SemanticMetadata;
+                requirement def Goal;
+                requirement goals : Goal;
+                metadata def goal :> SemanticMetadata {
+                    :>> baseType = goals meta SysML::Systems::RequirementUsage;
+                }
+                #goal requirement r2 {
+                    assume #goal constraint c1;
+                    require #goal constraint c2;
+                }""";
+        this.checker.check(input, input);
+    }
+
+    @Test
     @DisplayName("GIVEN a model with ForkNode, WHEN importing/exporting the file, THEN the exported text file should be the same as the imported one.")
     public void checkForkNode() throws IOException {
         var input = """

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/textual/utils/SysMLKeywordSwitch.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/textual/utils/SysMLKeywordSwitch.java
@@ -22,6 +22,7 @@ import org.eclipse.syson.sysml.AttributeDefinition;
 import org.eclipse.syson.sysml.AttributeUsage;
 import org.eclipse.syson.sysml.ConcernDefinition;
 import org.eclipse.syson.sysml.ConcernUsage;
+import org.eclipse.syson.sysml.ConstraintDefinition;
 import org.eclipse.syson.sysml.ConstraintUsage;
 import org.eclipse.syson.sysml.EnumerationDefinition;
 import org.eclipse.syson.sysml.EnumerationUsage;
@@ -127,6 +128,11 @@ public class SysMLKeywordSwitch extends SysmlSwitch<String> {
     @Override
     public String caseActionUsage(ActionUsage object) {
         return ACTION;
+    }
+
+    @Override
+    public String caseConstraintDefinition(ConstraintDefinition object) {
+        return CONSTRAINT_KEYWORD;
     }
 
     @Override

--- a/doc/content/modules/user-manual/pages/release-notes/2026.1.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.1.0.adoc
@@ -18,6 +18,36 @@ image::explorer-duplicate-object-dialog.png[Duplicate Object dialog, width=25%,h
 
 image::manage-elements-duplicate-from-diagram.png[Duplicate element from Diagram]
 
+- `RequirementConstraintMembership` are now properly exported in the textual format such as in:
+
+```
+private import SI::kilogram;
+private import ScalarValues::*;
+part def P1 {
+    attribute x : Real;
+}
+requirement r1 {
+    subject sub : P1;
+    attribute actualMass :> ISQBase::mass;
+    attribute maxMass :> ISQBase::mass;
+    assume constraint NamedRequirementConstraint { //Here
+        actualMass <= maxMass
+    }
+    assume constraint { // And here
+        sub.x <= 500
+    }
+    require constraint { // And here
+        actualMass >= 500 [kg]
+    }
+}
+constraint def C;
+constraint c : C;
+requirement def R1 {
+    require constraint c1 :>> c; // And here
+}
+```
+
+
 == Bug fixes
 
 - Fix an issue that displayed imported libraries at the root of the project if they contained `LibraryPackage` elements and non-`Namespace` elements.


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/1786

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
