### PR TITLE
[1864] Log DiagramDirectEditErrorListener instead of sending it to th…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -94,6 +94,7 @@ The tools are still available in the palette of e.g. `Parts`.
 - https://github.com/eclipse-syson/syson/issues/1813[#1813] [diagrams] Add creation tool for `Comment` graphical nodes in the _General View_ diagram background.
 - https://github.com/eclipse-syson/syson/issues/1828[#1828] [metamodel] Implement missing derived references of `UseCaseUsage` and `UseCaseDefinition`.
 - https://github.com/eclipse-syson/syson/issues/1819[#1819] [diagrams] Add `DiagramDirectEditErrorListener` in order to send syntax error thrown by ANTLR to the direct edit mutation.
+- https://github.com/eclipse-syson/syson/issues/1864[#1864] [diagrams] The `DiagramDirectEditErrorListener` no longer send the syntax error to the user but log it instead.
 
 == v2025.12.0
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVDirectEditTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVDirectEditTests.java
@@ -628,21 +628,24 @@ public class GVDirectEditTests extends AbstractIntegrationTests {
 
             String typename = JsonPath.read(result.data(), "$.data.editLabel.__typename");
             assertThat(typename).isEqualTo(EditLabelSuccessPayload.class.getSimpleName());
-            List<String> messages = JsonPath.read(result.data(), "$.data.editLabel.messages[*].body");
-            assertThat(messages).hasSize(1);
-            assertThat(messages).containsExactly("Invalid expression provided during direct edit.");
         };
 
-        Consumer<Object> updatedDiagramContentMatcher = assertRefreshedDiagramThat(diagram -> {
+        Consumer<Object> updatedDiagramContentMatcherBefore = assertRefreshedDiagramThat(diagram -> {
             var node = new DiagramNavigator(diagram).nodeWithId(partNodeId.get()).getNode();
             DiagramAssertions.assertThat(node.getInsideLabel()).hasText("t1 [4] = 1 [g]");
+        });
+
+        Consumer<Object> updatedDiagramContentMatcherAfter = assertRefreshedDiagramThat(diagram -> {
+            var node = new DiagramNavigator(diagram).nodeWithId(partNodeId.get()).getNode();
+            DiagramAssertions.assertThat(node.getInsideLabel()).hasText("t1 [4]");
         });
 
         StepVerifier.create(flux)
                 .consumeNextWith(initialDiagramContentConsumer)
                 .then(editLabelWithMultiplicityBefore)
-                .consumeNextWith(updatedDiagramContentMatcher)
+                .consumeNextWith(updatedDiagramContentMatcherBefore)
                 .then(editLabelWithMultiplicityAfter)
+                .consumeNextWith(updatedDiagramContentMatcherAfter)
                 .thenCancel()
                 .verify(Duration.ofSeconds(10));
     }

--- a/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/DiagramMutationLabelService.java
+++ b/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/DiagramMutationLabelService.java
@@ -96,7 +96,7 @@ public class DiagramMutationLabelService {
         DirectEditLexer lexer = new DirectEditLexer(CharStreams.fromString(newLabel));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         DirectEditParser parser = new DirectEditParser(tokens);
-        parser.addErrorListener(new DiagramDirectEditErrorListener(this.feedbackMessageService));
+        parser.addErrorListener(new DiagramDirectEditErrorListener());
         ParseTree tree;
         if (element instanceof ConstraintUsage && element.getOwningMembership() instanceof RequirementConstraintMembership && isCompartmentItem) {
             // Use the constraint expression parser only if the element is a constraint owned by a requirement, other

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/api/DiagramDirectEditErrorListener.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/api/DiagramDirectEditErrorListener.java
@@ -15,11 +15,8 @@ package org.eclipse.syson.services.api;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.eclipse.sirius.components.core.api.IFeedbackMessageService;
-import org.eclipse.sirius.components.representations.Message;
-import org.eclipse.sirius.components.representations.MessageLevel;
-
-import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The ANTLR Error Listener for the direct edit grammar for SysON diagrams.
@@ -28,15 +25,11 @@ import java.util.Objects;
  */
 public class DiagramDirectEditErrorListener extends BaseErrorListener {
 
-    private final IFeedbackMessageService feedbackMessageService;
-
-    public DiagramDirectEditErrorListener(IFeedbackMessageService feedbackMessageService) {
-        this.feedbackMessageService = Objects.requireNonNull(feedbackMessageService);
-    }
+    private final Logger logger = LoggerFactory.getLogger(DiagramDirectEditErrorListener.class);
 
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
-        this.feedbackMessageService.addFeedbackMessage(new Message("Invalid expression provided during direct edit.", MessageLevel.ERROR));
+        this.logger.info(msg);
     }
 
 }


### PR DESCRIPTION
…e user

Bug: https://github.com/eclipse-syson/syson/issues/1864

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
