### PR TITLE
[1887] Export fails to escape some names when using qualified name

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,7 @@
 === Bug fixes
 
 - https://github.com/eclipse-syson/syson/issues/1847[#1847] [export] Textual export duplicates "abstract" keyword for `OccurrenceUsage`.
+- https://github.com/eclipse-syson/syson/issues/1887[#1887] [export] Export fails to escape some names when using qualified name.
 
 === Improvements
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVItemAndAttributeExpressionTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVItemAndAttributeExpressionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -170,7 +170,7 @@ public class GVItemAndAttributeExpressionTests extends AbstractIntegrationTests 
         // Here the direct edit input need to explicitly give the qualified name of x3 since the default x3 is the one
         // located in p1_1 whereas we are targeting RootPackage::p1::x3
         this.directEditInitialLabelTester.checkDirectEditInitialLabelOnNode(this.verifier, this.diagram, GeneralViewItemAndAttributeProjectData.GraphicalIds.P1_1_X1_ID,
-                "x1 = p1::x3 / p1::x3 * 10");
+                "x1 = RootPackage::p1::x3 / RootPackage::p1::x3 * 10");
 
     }
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
@@ -18,7 +18,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 
+import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.core.api.IEditingContextSearchService;
 import org.eclipse.sirius.components.core.api.IPayload;
@@ -34,7 +36,9 @@ import org.eclipse.sirius.web.application.project.services.api.IProjectEditingCo
 import org.eclipse.sirius.web.tests.services.api.IGivenInitialServerState;
 import org.eclipse.syson.AbstractIntegrationTests;
 import org.eclipse.syson.application.export.checker.SysmlImportExportChecker;
+import org.eclipse.syson.sysml.ItemUsage;
 import org.eclipse.syson.sysml.export.SysMLv2DocumentExporter;
+import org.eclipse.syson.sysml.helper.EMFUtils;
 import org.eclipse.syson.sysml.upload.SysMLExternalResourceLoaderService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -111,7 +115,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
         var input = """
                 private import ScalarValues::*;
                 package p1;""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -126,7 +132,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         attribute z1 : Enum1 = Enum1::e1;
                     }
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -142,7 +150,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         attribute 'comment';
                     }
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -165,7 +175,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     flow from p2.po1.item1 to p3.item2;
                     flow f1 from p2.po1.item1 to p3.item2;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -244,7 +256,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         flow of Fuel from eng.engineFuelPort.fuelReturn to tankAssy.fuelTankPort.fuelReturn;
                     }
                 }""";
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -275,7 +289,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                 requirement def R1 {
                     require constraint c1 :>> c;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -294,7 +310,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         doc /* Some doc */
                     }
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -311,7 +329,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     assume #goal constraint c1;
                     require #goal constraint c2;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -336,7 +356,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     then a2;
                     first start then fork1;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -376,7 +398,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     first a2 then join1;
                     first join1 then done;
                 }""";
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -394,7 +418,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     first a1 then merge1;
                     first a2 then merge1;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -407,7 +433,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     rep l2 language "naturalLanguage2"
                         /* some comment 3 */
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -425,7 +453,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         doc /* Some documentation on that succession */
                     }
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -447,7 +477,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         render asTreeDiagram;
                     }
                 } """;
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -474,7 +506,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         accept when b.f;
                     }
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -507,7 +541,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     succession sd2 first d1 if x == 0 then a2;
                     succession sd3 first d1 then a3;
                 }""";
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -524,7 +560,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     if x >= 1.1 and x < 2.1 then a2;
                     else a3;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -544,7 +582,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     }
                 }""";
 
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -557,7 +597,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     succession s1 first a1 then a2;
                 }""";
 
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -572,7 +614,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     then a0;
                 }""";
 
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -602,7 +646,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     action a2;
                 }""";
 
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -628,7 +674,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     first start then a2;
                 }""";
 
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -643,7 +691,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     first a1 then a2;
                 }""";
 
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -657,7 +707,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     action 'a 2' : 'p 2'::'A 1';
                 }""";
 
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     /**
@@ -742,7 +794,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     }
                 }""";
 
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     /**
@@ -758,7 +812,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                 part part1 {
                     port port1 : Port1;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     /**
@@ -808,7 +864,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         enum1;
                     }
                 }""";
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     /**
@@ -863,7 +921,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     }
                 }""";
 
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     /**
@@ -898,7 +958,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     }
                 }""";
 
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -924,7 +986,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         actor partU_1;
                     }
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
 
     }
 
@@ -996,7 +1060,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     }
                 }""";
 
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -1009,7 +1075,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                 part p2 :> p1 {
                     attribute :>> attr1;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -1020,7 +1088,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     abstract occurrence test;
                     abstract occurrence def Test;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -1053,7 +1123,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     attribute attribute4 : Enum1 = Enum1::enumeration2;
                     attribute attribute5 = Enum1::enumeration1;
                 }""";
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
 
@@ -1070,7 +1142,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     }
                 }""";
 
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -1092,7 +1166,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     attribute :>> a;
                 }""";
 
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
 
@@ -1101,7 +1177,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
     public void checkLiteralString() throws IOException {
         var input = """
                 attribute myAttribute = "value";""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -1109,7 +1187,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
     public void checkMultiplicityRangeWithLiteralIntegerBounds() throws IOException {
         var input = """
                 part myPart [1..2];""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -1141,7 +1221,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                 metadata def MD2 :> SemanticMetadata {
                     :>> baseType default = p meta SysML::Systems::PartUsage;
                 }""";
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -1155,7 +1237,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     attribute c : Integer = +1;
                     attribute d : Boolean = not true;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -1194,7 +1278,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     assert satisfy Req1 by Context1;
                     assert satisfy requirement Req2 : REQ2 by Context1.'System 1';
                 }""";
-        this.checker.check(input, expected);
+        this.checker.textToImport(input)
+                .expectedResult(expected)
+                .check();
     }
 
     @Test
@@ -1220,7 +1306,9 @@ public class ImportExportTests extends AbstractIntegrationTests {
                     connect (p1, p2, Parts::part3);
                     connect p1.po1 to p2.po2;
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
 
     @Test
@@ -1242,6 +1330,65 @@ public class ImportExportTests extends AbstractIntegrationTests {
                         end #derive ::> Sre1;
                     }
                 }""";
-        this.checker.check(input, input);
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
     }
+
+    @Test
+    @DisplayName("GIVEN with conflicting names used in refence, WHEN importing and exporting the model, THEN the names used in the qualified name should be properly escaped.")
+    public void checkNameConflictResolutionWithQn() throws IOException {
+        var input = """
+                package 'root && root' {
+                    package 'AA & BB' {
+                        item def ItemDef0;
+                        requirement def RecDef1 {
+                            requirementsSpecification : ItemDef0;
+                        }
+                        package 'JJ & GG' {
+                            item requirements : ItemDef0;
+                            item requirements2 : ItemDef0;
+                        }
+                    }
+                    package 'CC & DD' {
+                        private import 'AA & BB'::'JJ & GG'::*;
+                        requirement rec0 : 'AA & BB'::RecDef1 {
+                            requirementsSpecification :> 'AA & BB'::RecDef1::requirementsSpecification = 'root && root'::'AA & BB'::'JJ & GG'::requirements2;
+                        }
+                    }
+                }""";
+        // Modify the model to generate a name conflict between "'root && root'::'AA & BB'::'JJ & GG'::requirements" and "'root && root'::'AA & BB'::'JJ & GG'::requirements2"
+        // This will cause an issue the value of "'root && root'::'CC & DD'::rec0::requirementsSpecification"
+        Consumer<Resource> createNameConflicts = resource -> {
+            EMFUtils.allContainedObjectOfType(resource, ItemUsage.class)
+                    .filter(item -> "requirements2".equals(item.getName()))
+                    .findFirst()
+                    .orElseThrow()
+                    .setDeclaredName("requirements");
+        };
+        var expected = """
+                package 'root && root' {
+                    package 'AA & BB' {
+                        item def ItemDef0;
+                        requirement def RecDef1 {
+                            requirementsSpecification : ItemDef0;
+                        }
+                        package 'JJ & GG' {
+                            item requirements : ItemDef0;
+                            item requirements : ItemDef0;
+                        }
+                    }
+                    package 'CC & DD' {
+                        private import 'AA & BB'::'JJ & GG'::*;
+                        requirement rec0 : 'AA & BB'::RecDef1 {
+                            requirementsSpecification :> 'AA & BB'::RecDef1::requirementsSpecification = 'root && root'::'AA & BB'::'JJ & GG'::requirements;
+                        }
+                    }
+                }""";
+        this.checker.textToImport(input)
+                .modifyLoadedModel(createNameConflicts)
+                .expectedResult(expected)
+                .check();
+    }
+
 }

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/checker/SysmlImportExportChecker.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/checker/SysmlImportExportChecker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -41,6 +42,12 @@ public class SysmlImportExportChecker {
 
     private final EditingContext editingContext;
 
+    private Consumer<Resource> loadedModelModifier;
+
+    private String textToImport;
+
+    private String expectedResult;
+
     public SysmlImportExportChecker(SysMLExternalResourceLoaderService sysmlLoader, SysMLv2DocumentExporter exporter, EditingContext editingContext) {
         super();
         this.editingContext = Objects.requireNonNull(editingContext);
@@ -48,20 +55,60 @@ public class SysmlImportExportChecker {
         this.exporter = Objects.requireNonNull(exporter);
     }
 
-    public void check(String importedText, String expectedResult) throws IOException {
+    /**
+     * Optional consumer used to modify the loaded model.
+     *
+     * @param modifier
+     *         a consumer to modify the loaded {@link Resource}
+     * @return this for convenience
+     */
+    public SysmlImportExportChecker modifyLoadedModel(Consumer<Resource> modifier) {
+        this.loadedModelModifier = modifier;
+        return this;
+    }
 
-        try (var inputStream = new ByteArrayInputStream(importedText.getBytes())) {
+    /**
+     * Expected String result.
+     *
+     * @param expected
+     *         the expected result
+     * @return this for convenience
+     */
+    public SysmlImportExportChecker expectedResult(String expected) {
+        this.expectedResult = expected;
+        return this;
+    }
+
+    /**
+     * Expected String result.
+     *
+     * @param toImport
+     *         the text about to be imported
+     * @return this for convenience
+     */
+    public SysmlImportExportChecker textToImport(String toImport) {
+        this.textToImport = toImport;
+        return this;
+    }
+
+    public void check() throws IOException {
+        Objects.requireNonNull(this.textToImport);
+        Objects.requireNonNull(this.expectedResult);
+        try (var inputStream = new ByteArrayInputStream(this.textToImport.getBytes())) {
             Optional<Resource> optLoadedResources = this.sysmlLoader.getResource(inputStream, this.createFakeURI(UUID.randomUUID()), this.editingContext.getDomain().getResourceSet(),
                     false);
 
             assertTrue(optLoadedResources.isPresent());
+            if (this.loadedModelModifier != null) {
+                // Modify loaded model
+                this.loadedModelModifier.accept(optLoadedResources.get());
+            }
             Optional<byte[]> bytes = this.exporter.getBytes(optLoadedResources.get(), MediaType.TEXT_HTML.toString());
             assertTrue(bytes.isPresent());
 
             String content = new String(bytes.get());
-            assertEquals(this.normalize(expectedResult), this.normalize(content));
+            assertEquals(this.normalize(this.expectedResult), this.normalize(content));
         }
-
     }
 
     private URI createFakeURI(UUID uuid) {

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/textual/utils/FileNameDeresolver.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/textual/utils/FileNameDeresolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -229,13 +229,7 @@ public class FileNameDeresolver implements INameDeresolver {
         // conflict.
         // In that case keep we need a more detailed qualified name
         if (resolvedElement != null && !this.match(element, resolvedElement)) {
-            // Last try if the element is in the containment tree find the shortest qualified name
-            String qualifiedName = this.getQualifiedName(owningNamespace);
-            if (!qualifiedName.isBlank() && elementQn.startsWith(qualifiedName)) {
-                relativeQualifiedName = owningNamespace.getName() + "::" + elementQn.substring(qualifiedName.length() + 2);
-            } else {
-                relativeQualifiedName = elementQn;
-            }
+            relativeQualifiedName = elementQn;
         }
 
         return relativeQualifiedName;

--- a/backend/metamodel/syson-sysml-metamodel/src/test/java/org/eclipse/syson/sysml/textual/FileNameDeresolverTest.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/test/java/org/eclipse/syson/sysml/textual/FileNameDeresolverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -87,7 +87,7 @@ public class FileNameDeresolverTest {
          *       ref attribute mass; // Needs qualified name since the attribute p3::mass hides the imported element
          *       package p3x1 {
          *           ref attribute mass2 :> Lib2::mass; // Needs qualified name since the attribute p3::mass hides the imported element
-         *           part Part1 : p3::Part1; // We need relative qualified name because Part1 usage conflict with Part1 definition
+         *           part Part1 : p3::Part1; // We need qualified name because Part1 usage conflict with Part1 definition
          *   }
          *       }
          * }
@@ -143,8 +143,8 @@ public class FileNameDeresolverTest {
         assertEquals("Lib2::mass", this.getDeresolvedName(massAttr, p3Mass));
         // Needs qualified name since the attribute p3::mass hides the imported element
         assertEquals("Lib2::mass", this.getDeresolvedName(massAttr, p3x1Mass));
-        // Need relative qualified name
-        assertEquals("p3::Part1", this.getDeresolvedName(part1Def, part1Usage));
+        // Need qualified name cause name conflict
+        assertEquals("Root::p3::Part1", this.getDeresolvedName(part1Def, part1Usage));
     }
 
     @Test

--- a/doc/content/modules/user-manual/pages/release-notes/2026.3.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.3.0.adoc
@@ -16,6 +16,7 @@ It's not recommended for production use.
 == Bug fixes
 
 * Fix the textual export of `OccurrenceUsage` to avoid duplication of the _abstract_ keyword.
+* Fix the textual export to properly escape names used in qualified names in some references.
 
 == Improvements
 


### PR DESCRIPTION
# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
