### PR TITLE
[1895] Implement textual export of StateUsage and StateDefinition

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,8 @@ SysON now uses its own indexing logic instead of the default one provided by Sir
 This allows to limit the size of the indices, and ensure information stored in the indices are useful to perform cross-project search.
 You can find more information on how to setup Elasticsearch, how elements are mapped to index documents, and how to query them in the documentation.
 - https://github.com/eclipse-syson/syson/issues/1861[#1861] [publication] Split `SysONLibraryPublicationHandler` in two distinct classes so the publishing logic can be extended or re-used through the `ISysMLLibraryPublisher` API.
+- https://github.com/eclipse-syson/syson/issues/1895[#1895] [export] Implement textual export of `StateUsage` and `StateDefinition`.
+
 
 === New features
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/export/ImportExportTests.java
@@ -1335,6 +1335,64 @@ public class ImportExportTests extends AbstractIntegrationTests {
                 .check();
     }
 
+    /**
+     * Test import/export on test file StateTest.sysml. The content of StateTest.sysml that have been copied below
+     * is under LGPL-3.0-only license. The LGPL-3.0-only license is accessible at the root of this repository, in the
+     * LICENSE-LGPL file.
+     *
+     * <p><b>NOTE:</b> The TransitionUsage has been remove from the original model for this test.</p>
+     *
+     * @see <a href=
+     * "https://github.com/Systems-Modeling/SysML-v2-Release/blob/master/sysml/src/examples/Simple%20Tests/StateTest.sysml">StateTest.sysml</a>
+     */
+    @Test
+    @DisplayName("GIVEN a model with StateUsage and StateDefinition, WHEN importing and exporting the model, THEN the states are properly exported")
+    public void checkStates() throws IOException {
+        var input = """
+                package StateTest {
+                    attribute def Sig {
+                        x;
+                    }
+                    attribute def Exit;
+                    part p;
+                    action act;
+                    state def S {
+                        do action A;
+                        entry ;
+                        state S1;
+                        state S2 {
+                            state S3;
+                        }
+                        exit act;
+                        state S3 {
+                            state S3a;
+                        }
+                    }
+                    state s0 {
+                        state s1 {
+                            state s2;
+                        }
+                        state s3 {
+                            state s4;
+                        }
+                    }
+                    state s parallel {
+                        state s1;
+                        state s2;
+                    }
+                    state s4 {
+                        do action a;
+                        action c;
+                    }
+                    state s5 :> s4 {
+                        do action b :>> c;
+                    }
+                }""";
+        this.checker.textToImport(input)
+                .expectedResult(input)
+                .check();
+    }
+
     @Test
     @DisplayName("GIVEN with conflicting names used in refence, WHEN importing and exporting the model, THEN the names used in the qualified name should be properly escaped.")
     public void checkNameConflictResolutionWithQn() throws IOException {

--- a/doc/content/modules/user-manual/pages/release-notes/2026.3.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.3.0.adoc
@@ -20,6 +20,8 @@ It's not recommended for production use.
 
 == Improvements
 
+* Implement the textual export for `StateUsage` and `StateDefinition`.
+
 == Technical details
 
 * For technical details on this {product} release (including breaking changes), please refer to https://github.com/eclipse-syson/syson/blob/main/CHANGELOG.adoc[changelog].


### PR DESCRIPTION
# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
