### PR TITLE
[cleanup] Use ServiceMethod instead of getSelfServiceCallExpression

### DIFF
--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysMLv2PropertiesConfigurer.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysMLv2PropertiesConfigurer.java
@@ -219,8 +219,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         TextAreaDescription expressionWidget = FormFactory.eINSTANCE.createTextAreaDescription();
         expressionWidget.setName("ValueExpression");
         expressionWidget.setLabelExpression("Value");
-        expressionWidget.setValueExpression(AQLUtils.getSelfServiceCallExpression("getValueExpressionTextualRepresentation"));
-        expressionWidget.setIsEnabledExpression("aql:false");
+        expressionWidget.setValueExpression(ServiceMethod.of0(DetailsViewService::getValueExpressionTextualRepresentation).aqlSelf());
+        expressionWidget.setIsEnabledExpression(AQLConstants.AQL_FALSE);
 
         group.getChildren().add(expressionWidget);
 
@@ -434,9 +434,9 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         RadioDescription radio = FormFactory.eINSTANCE.createRadioDescription();
         radio.setName("ExtraRadioVisibilityWidget");
         radio.setLabelExpression("Visibility");
-        radio.setCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getVisibilityEnumLiterals"));
+        radio.setCandidatesExpression(ServiceMethod.of0(DetailsViewService::getVisibilityEnumLiterals).aqlSelf());
         radio.setCandidateLabelExpression("aql:candidate.name");
-        radio.setValueExpression(AQLUtils.getSelfServiceCallExpression("getVisibilityValue"));
+        radio.setValueExpression(ServiceMethod.of0(DetailsViewService::getVisibilityValue).aqlSelf());
         radio.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
         setNewValueOperation.setExpression(AQLUtils.getSelfServiceCallExpression("setVisibilityValue", "newValue.instance"));
@@ -458,7 +458,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         payloadRefWidget.setName("ExtraPayloadWidget");
         payloadRefWidget.setLabelExpression("Payload");
         payloadRefWidget.setReferenceNameExpression(SysmlPackage.eINSTANCE.getFeatureTyping_Type().getName());
-        payloadRefWidget.setReferenceOwnerExpression(AQLUtils.getSelfServiceCallExpression("getAcceptActionUsagePayloadFeatureTyping"));
+        payloadRefWidget.setReferenceOwnerExpression(ServiceMethod.of0(DetailsViewService::getAcceptActionUsagePayloadFeatureTyping).aqlSelf());
         payloadRefWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setPayloadRefWidget = ViewFactory.eINSTANCE.createChangeContext();
         setPayloadRefWidget.setExpression(AQLUtils.getSelfServiceCallExpression("setAcceptActionUsagePayloadParameter", ViewFormDescriptionConverter.NEW_VALUE));
@@ -468,7 +468,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         receiverRefWidget.setName("ExtraReceiverWidget");
         receiverRefWidget.setLabelExpression("Receiver");
         receiverRefWidget.setReferenceNameExpression(SysmlPackage.eINSTANCE.getMembership_MemberElement().getName());
-        receiverRefWidget.setReferenceOwnerExpression(AQLUtils.getSelfServiceCallExpression("getAcceptActionUsageReceiverMembership"));
+        receiverRefWidget.setReferenceOwnerExpression(ServiceMethod.of0(DetailsViewService::getAcceptActionUsageReceiverMembership).aqlSelf());
         receiverRefWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setReceiverRefWidget = ViewFactory.eINSTANCE.createChangeContext();
         setReceiverRefWidget.setExpression(AQLUtils.getSelfServiceCallExpression("setAcceptActionUsageReceiverArgument", ViewFormDescriptionConverter.NEW_VALUE));

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractEdgeDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -31,7 +31,8 @@ import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.SourceEdgeEndReconnectionTool;
 import org.eclipse.sirius.components.view.diagram.TargetEdgeEndReconnectionTool;
 import org.eclipse.sirius.components.view.diagram.provider.DefaultToolsFactory;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.services.DeleteService;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Common pieces of edge descriptions shared by {@link IEdgeDescriptionProvider} in all view.
@@ -128,12 +129,11 @@ public abstract class AbstractEdgeDescriptionProvider implements IEdgeDescriptio
      * @return the delete tool to use for the edge
      */
     protected DeleteTool getEdgeDeleteTool() {
-        var changeContext = this.viewBuilderHelper.newChangeContext()
-                .expression(AQLUtils.getSelfServiceCallExpression("deleteFromModel"));
-
         return this.diagramBuilderHelper.newDeleteTool()
                 .name("Delete from Model")
-                .body(changeContext.build())
+                .body(this.viewBuilderHelper.newChangeContext()
+                        .expression(ServiceMethod.of0(DeleteService::deleteFromModel).aqlSelf())
+                        .build())
                 .build();
     }
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractItemUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/AbstractItemUsageBorderNodeDescriptionProvider.java
@@ -38,7 +38,6 @@ import org.eclipse.syson.services.DeleteService;
 import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -100,7 +99,7 @@ public abstract class AbstractItemUsageBorderNodeDescriptionProvider extends Abs
 
     private OutsideLabelDescription createOutsideLabelDescription() {
         return this.diagramBuilderHelper.newOutsideLabelDescription()
-                .labelExpression(AQLUtils.getSelfServiceCallExpression("getBorderNodeUsageLabel"))
+                .labelExpression(ServiceMethod.of0(DiagramQueryAQLService::getBorderNodeUsageLabel).aqlSelf())
                 .position(OutsideLabelPosition.BOTTOM_CENTER)
                 .style(this.createOutsideLabelStyle())
                 .build();

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/StatesCompartmentItemNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/StatesCompartmentItemNodeDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -16,9 +16,10 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.ExhibitStateUsage;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * {@link ExhibitStateUsage} compartment item Node description.
@@ -48,9 +49,9 @@ public class StatesCompartmentItemNodeDescriptionProvider extends CompartmentIte
     @Override
     protected String getSemanticCandidateExpression() {
         if (this.showsExhibitOnly) {
-            return AQLUtils.getSelfServiceCallExpression("getAllExhibitedStates");
+            return ServiceMethod.of0(UtilService::getAllExhibitedStates).aqlSelf();
         } else {
-            return AQLUtils.getSelfServiceCallExpression("getAllNonExhibitStates");
+            return ServiceMethod.of0(UtilService::getAllNonExhibitStates).aqlSelf();
         }
     }
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/AcceptActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/AcceptActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,9 +14,10 @@ package org.eclipse.syson.diagram.common.view.tools;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.sysml.SysmlPackage;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add an accept action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class AcceptActionNodeToolProvider extends AbstractFreeFormCompartmentNod
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("createAcceptAction");
+        return ServiceMethod.of0(ViewCreateService::createAcceptAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/AssignmentActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/AssignmentActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,9 +14,10 @@ package org.eclipse.syson.diagram.common.view.tools;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.sysml.SysmlPackage;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add an assignment action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class AssignmentActionNodeToolProvider extends AbstractFreeFormCompartmen
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("createAssignmentAction");
+        return ServiceMethod.of0(ViewCreateService::createAssignmentAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/DecisionActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/DecisionActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ package org.eclipse.syson.diagram.common.view.tools;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.nodes.DecisionActionNodeDescriptionProvider;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add the decision action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class DecisionActionNodeToolProvider extends AbstractFreeFormCompartmentN
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("createDecisionAction");
+        return ServiceMethod.of0(ViewCreateService::createDecisionAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/DoneActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/DoneActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ package org.eclipse.syson.diagram.common.view.tools;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.nodes.DoneActionNodeDescriptionProvider;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add the standard done action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class DoneActionNodeToolProvider extends AbstractFreeFormCompartmentNodeT
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("addDoneAction");
+        return ServiceMethod.of0(ViewCreateService::addDoneAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ForkActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ForkActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ package org.eclipse.syson.diagram.common.view.tools;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.nodes.ForkActionNodeDescriptionProvider;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add the fork action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class ForkActionNodeToolProvider extends AbstractFreeFormCompartmentNodeT
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("createForkAction");
+        return ServiceMethod.of0(ViewCreateService::createForkAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/JoinActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/JoinActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ package org.eclipse.syson.diagram.common.view.tools;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.nodes.JoinActionNodeDescriptionProvider;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add the join action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class JoinActionNodeToolProvider extends AbstractFreeFormCompartmentNodeT
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("createJoinAction");
+        return ServiceMethod.of0(ViewCreateService::createJoinAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/MergeActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/MergeActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ package org.eclipse.syson.diagram.common.view.tools;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.nodes.MergeActionNodeDescriptionProvider;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add the merge action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class MergeActionNodeToolProvider extends AbstractFreeFormCompartmentNode
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("createMergeAction");
+        return ServiceMethod.of0(ViewCreateService::createMergeAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StakeholdersCompartmentNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StakeholdersCompartmentNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,10 +12,16 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.common.view.tools;
 
+import org.eclipse.sirius.components.core.api.IEditingContext;
 import org.eclipse.sirius.components.view.diagram.SelectionDialogDescription;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
+import org.eclipse.syson.diagram.common.view.services.ViewToolService;
 import org.eclipse.syson.sysml.RequirementDefinition;
 import org.eclipse.syson.sysml.RequirementUsage;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.util.AQLConstants;
+import org.eclipse.syson.util.ServiceMethod;
+import org.eclipse.syson.util.SysMLMetamodelHelper;
 
 /**
  * {@link ActorCompartmentNodeToolProvider} specialization for {@link RequirementDefinition#getStakeholderParameter()}
@@ -27,15 +33,16 @@ public class StakeholdersCompartmentNodeToolProvider extends AbstractCompartment
 
     @Override
     protected String getServiceCallExpression() {
-        return "aql:self.createPartUsageAsStakeholder(selectedObject)";
+        return ServiceMethod.of1(ViewCreateService::createPartUsageAsStakeholder).aqlSelf("selectedObject");
     }
 
     @Override
     protected SelectionDialogDescription getSelectionDialogDescription() {
+        var domainName = SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getPartUsage());
         var selectionDialogTree = this.diagramBuilderHelper.newSelectionDialogTreeDescription()
-                .elementsExpression(AQLUtils.getServiceCallExpression("editingContext", "getStakeholderSelectionDialogElements"))
-                .childrenExpression(AQLUtils.getSelfServiceCallExpression("getStakeholderSelectionDialogChildren"))
-                .isSelectableExpression("aql:self.oclIsKindOf(sysml::PartUsage)")
+                .elementsExpression(ServiceMethod.of0(ViewToolService::getStakeholderSelectionDialogElements).aql(IEditingContext.EDITING_CONTEXT))
+                .childrenExpression(ServiceMethod.of0(ViewToolService::getStakeholderSelectionDialogChildren).aqlSelf())
+                .isSelectableExpression(AQLConstants.AQL_SELF + ".oclIsKindOf(" + domainName + ")")
                 .build();
         return this.diagramBuilderHelper.newSelectionDialogDescription()
                 .selectionDialogTreeDescription(selectionDialogTree)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StartActionNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/StartActionNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,8 +15,9 @@ package org.eclipse.syson.diagram.common.view.tools;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.syson.diagram.common.view.nodes.ActionFlowCompartmentNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.nodes.StartActionNodeDescriptionProvider;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to add the standard start action in actions body for all diagrams.
@@ -36,7 +37,7 @@ public class StartActionNodeToolProvider extends AbstractFreeFormCompartmentNode
 
     @Override
     protected String getCreationServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("addStartAction");
+        return ServiceMethod.of0(ViewCreateService::addStartAction).aqlSelf();
     }
 
     @Override

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/PerformActionsCompartmentItemNodeDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/PerformActionsCompartmentItemNodeDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -17,8 +17,9 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.sirius.components.view.builder.providers.IColorProvider;
 import org.eclipse.syson.diagram.common.view.nodes.CompartmentItemNodeDescriptionProvider;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to create an item node description of the perform actions compartment of Parts for general view diagram.
@@ -38,6 +39,6 @@ public class PerformActionsCompartmentItemNodeDescriptionProvider extends Compar
 
     @Override
     protected String getSemanticCandidateExpression() {
-        return AQLUtils.getSelfServiceCallExpression("getAllPerformActions");
+        return ServiceMethod.of0(UtilService::getAllPerformActions).aqlSelf();
     }
 }

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/ReferenceUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/ReferenceUsageBorderNodeDescriptionProvider.java
@@ -39,7 +39,6 @@ import org.eclipse.syson.services.DeleteService;
 import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -107,7 +106,7 @@ public class ReferenceUsageBorderNodeDescriptionProvider extends AbstractNodeDes
     }
 
     protected String getSemanticCandidatesExpression() {
-        return AQLUtils.getSelfServiceCallExpression("getReferenceUsagesParameters");
+        return ServiceMethod.of0(UtilService::getReferenceUsagesParameters).aqlSelf();
     }
 
     protected NodePalette createNodePalette(IViewDiagramElementFinder cache, NodeDescription nodeDescription) {


### PR DESCRIPTION
# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [ ] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [ ] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
