### PR TITLE
[cleanup] Inline StepVerifier logic in GVIncludeUseCaseUsageTests

### DIFF
--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVIncludeUseCaseUsageTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVIncludeUseCaseUsageTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,11 +13,13 @@
 package org.eclipse.syson.application.controllers.diagrams.general.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.components.diagrams.tests.DiagramEventPayloadConsumer.assertRefreshedDiagramThat;
 import static org.eclipse.sirius.components.diagrams.tests.assertions.DiagramAssertions.assertThat;
 
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramEventInput;
 import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramRefreshedEventPayload;
@@ -30,11 +32,10 @@ import org.eclipse.sirius.components.diagrams.events.ReconnectEdgeKind;
 import org.eclipse.sirius.components.view.emf.diagram.IDiagramIdProvider;
 import org.eclipse.sirius.web.tests.services.api.IGivenInitialServerState;
 import org.eclipse.syson.AbstractIntegrationTests;
+import org.eclipse.syson.GivenSysONServer;
 import org.eclipse.syson.SysONTestsProperties;
 import org.eclipse.syson.application.controller.editingContext.checkers.SemanticCheckerService;
 import org.eclipse.syson.application.controllers.diagrams.checkers.CheckDiagramElementCount;
-import org.eclipse.syson.application.controllers.diagrams.checkers.DiagramCheckerService;
-import org.eclipse.syson.application.controllers.diagrams.checkers.IDiagramChecker;
 import org.eclipse.syson.application.controllers.diagrams.testers.EdgeCreationTester;
 import org.eclipse.syson.application.controllers.diagrams.testers.EdgeReconnectionTester;
 import org.eclipse.syson.application.data.IncludeUseCaseUsageProjectData;
@@ -42,7 +43,6 @@ import org.eclipse.syson.services.SemanticRunnableFactory;
 import org.eclipse.syson.services.diagrams.DiagramComparator;
 import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
 import org.eclipse.syson.services.diagrams.api.IGivenDiagramDescription;
-import org.eclipse.syson.services.diagrams.api.IGivenDiagramReference;
 import org.eclipse.syson.services.diagrams.api.IGivenDiagramSubscription;
 import org.eclipse.syson.standard.diagrams.view.SDVDescriptionNameGenerator;
 import org.eclipse.syson.sysml.IncludeUseCaseUsage;
@@ -50,16 +50,14 @@ import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.helper.LabelConstants;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.SysONRepresentationDescriptionIdentifiers;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.transaction.annotation.Transactional;
 
+import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 /**
@@ -75,9 +73,6 @@ public class GVIncludeUseCaseUsageTests extends AbstractIntegrationTests {
 
     @Autowired
     private IGivenInitialServerState givenInitialServerState;
-
-    @Autowired
-    private IGivenDiagramReference givenDiagram;
 
     @Autowired
     private IGivenDiagramDescription givenDiagramDescription;
@@ -106,56 +101,44 @@ public class GVIncludeUseCaseUsageTests extends AbstractIntegrationTests {
     @Autowired
     private IIdentityService identityService;
 
-    private DiagramDescriptionIdProvider diagramDescriptionIdProvider;
-
-    private DiagramCheckerService diagramCheckerService;
-
-    private StepVerifier.Step<DiagramRefreshedEventPayload> verifier;
-
     private SemanticCheckerService semanticCheckerService;
 
-    private AtomicReference<Diagram> diagram;
+    private Flux<DiagramRefreshedEventPayload> givenSubscriptionToDiagram() {
+        var diagramEventInput = new DiagramEventInput(UUID.randomUUID(), IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID, IncludeUseCaseUsageProjectData.GraphicalIds.DIAGRAM_ID);
+        return this.givenDiagramSubscription.subscribe(diagramEventInput);
+    }
 
     @BeforeEach
     public void setUp() {
         this.givenInitialServerState.initialize();
-        var diagramEventInput = new DiagramEventInput(UUID.randomUUID(),
-                IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
-                IncludeUseCaseUsageProjectData.GraphicalIds.DIAGRAM_ID);
-        var flux = this.givenDiagramSubscription.subscribe(diagramEventInput);
-        this.verifier = StepVerifier.create(flux);
-        this.diagram = this.givenDiagram.getDiagram(this.verifier);
-        var diagramDescription = this.givenDiagramDescription.getDiagramDescription(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
-                SysONRepresentationDescriptionIdentifiers.GENERAL_VIEW_DIAGRAM_DESCRIPTION_ID);
-        this.diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(diagramDescription, this.diagramIdProvider);
-        this.diagramCheckerService = new DiagramCheckerService(this.diagramComparator, this.descriptionNameGenerator);
         this.semanticCheckerService = new SemanticCheckerService(this.semanticRunnableFactory, this.objectSearchService, IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
                 IncludeUseCaseUsageProjectData.SemanticIds.PACKAGE_1_ID);
     }
 
-    @AfterEach
-    public void tearDown() {
-        if (this.verifier != null) {
-            this.verifier.thenCancel()
-                    .verify(Duration.ofSeconds(10));
-        }
-    }
-
     @DisplayName("GIVEN two UseCaseUsages, WHEN creating an IncludeUseCaseUsage between them, THEN an edge should be displayed to represent that new element as an edge")
-    @Sql(scripts = { IncludeUseCaseUsageProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
-    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    @GivenSysONServer({ IncludeUseCaseUsageProjectData.SCRIPT_PATH })
     @Test
     public void checkIncludeUsageActionCreation() {
-        String creationToolId = this.diagramDescriptionIdProvider.getEdgeCreationToolId(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getUseCaseUsage()),
+        var flux = this.givenSubscriptionToDiagram();
+
+        AtomicReference<Diagram> diagram = new AtomicReference<>();
+        Consumer<Object> initialDiagramContentConsumer = assertRefreshedDiagramThat(diagram::set);
+
+        var diagramDescription = this.givenDiagramDescription.getDiagramDescription(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
+                SysONRepresentationDescriptionIdentifiers.GENERAL_VIEW_DIAGRAM_DESCRIPTION_ID);
+        var diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(diagramDescription, this.diagramIdProvider);
+
+        String creationToolId = diagramDescriptionIdProvider.getEdgeCreationToolId(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getUseCaseUsage()),
                 "New Include Use Case");
-        this.verifier.then(() -> this.edgeCreationTester.createEdgeUsingNodeId(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
-                this.diagram,
+        Runnable creationToolRunnable = () -> this.edgeCreationTester.createEdgeUsingNodeId(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
+                diagram,
                 IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDING_USE_CASE_ID,
                 IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDED_USE_CASE_2_ID,
-                creationToolId));
+                creationToolId);
 
         String[] newInclude = new String[1];
-        IDiagramChecker diagramChecker = (initialDiagram, newDiagram) -> {
+        Consumer<Object> diagramCheck = assertRefreshedDiagramThat(newDiagram -> {
+            var initialDiagram = diagram.get();
             new CheckDiagramElementCount(this.diagramComparator)
                     .hasNewNodeCount(1) // New element in the Perform action compartment
                     .hasNewEdgeCount(1)
@@ -166,30 +149,42 @@ public class GVIncludeUseCaseUsageTests extends AbstractIntegrationTests {
             assertThat(newEdge).hasTargetId(IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDED_USE_CASE_2_ID);
             assertThat(newEdge.getStyle()).hasTargetArrow(ArrowStyle.InputFillClosedArrow);
             assertThat(newEdge.getCenterLabel().text()).isEqualTo(LabelConstants.OPEN_QUOTE + "include" + LabelConstants.CLOSE_QUOTE);
-        };
+        });
 
-        this.diagramCheckerService.checkDiagram(diagramChecker, this.diagram, this.verifier);
-
-        this.semanticCheckerService.checkElement(this.verifier, IncludeUseCaseUsage.class, () -> newInclude[0], includeUsage -> {
+        Runnable semanticCheck = this.semanticCheckerService.checkElement(IncludeUseCaseUsage.class, () -> newInclude[0], includeUsage -> {
             assertThat(this.identityService.getId(includeUsage.getUseCaseIncluded()))
                     .isEqualTo(IncludeUseCaseUsageProjectData.SemanticIds.INCLUDED_USE_CASE_2_ID);
             assertThat(this.identityService.getId(includeUsage.getOwningUsage()))
                     .isEqualTo(IncludeUseCaseUsageProjectData.SemanticIds.INCLUDING_USE_CASE_ID);
         });
+
+        StepVerifier.create(flux)
+                .consumeNextWith(initialDiagramContentConsumer)
+                .then(creationToolRunnable)
+                .consumeNextWith(diagramCheck)
+                .then(semanticCheck)
+                .thenCancel()
+                .verify(Duration.ofSeconds(10));
     }
 
     @Test
     @DisplayName("GIVEN an IncludeUseCaseUsage, WHEN reconnecting the target, THEN the new target of the IncludeUseCaseUsage is correct")
-    @Sql(scripts = { IncludeUseCaseUsageProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
-    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    @GivenSysONServer({ IncludeUseCaseUsageProjectData.SCRIPT_PATH })
+
     public void reconnectIncludeUsaceCaseUsageTarget() {
-        this.verifier.then(() -> this.edgeReconnectionTester.reconnectEdge(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
-                this.diagram,
+        var flux = this.givenSubscriptionToDiagram();
+
+        AtomicReference<Diagram> diagram = new AtomicReference<>();
+        Consumer<Object> initialDiagramContentConsumer = assertRefreshedDiagramThat(diagram::set);
+
+        Runnable reconnectEdgeRunnable = () -> this.edgeReconnectionTester.reconnectEdge(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
+                diagram,
                 IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDE_USE_CASE_USAGE_ID,
                 IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDED_USE_CASE_2_ID,
-                ReconnectEdgeKind.TARGET));
+                ReconnectEdgeKind.TARGET);
 
-        IDiagramChecker diagramCheckerTarget = (initialDiagram, newDiagram) -> {
+        Consumer<Object> diagramCheck = assertRefreshedDiagramThat(newDiagram -> {
+            var initialDiagram = diagram.get();
             new CheckDiagramElementCount(this.diagramComparator)
                     .hasNewEdgeCount(1)
                     .check(initialDiagram, newDiagram);
@@ -197,30 +192,41 @@ public class GVIncludeUseCaseUsageTests extends AbstractIntegrationTests {
             Edge newEdge = this.diagramComparator.newEdges(initialDiagram, newDiagram).get(0);
             assertThat(newEdge).hasSourceId(IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDING_USE_CASE_ID);
             assertThat(newEdge).hasTargetId(IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDED_USE_CASE_2_ID);
-        };
+        });
 
-        this.diagramCheckerService.checkDiagram(diagramCheckerTarget, this.diagram, this.verifier);
-
-        this.semanticCheckerService.checkElement(this.verifier, IncludeUseCaseUsage.class, () -> IncludeUseCaseUsageProjectData.SemanticIds.INCLUDE_USE_CASE_USAGE_ID, includeUsage -> {
+        Runnable semanticCheck = this.semanticCheckerService.checkElement(IncludeUseCaseUsage.class, () -> IncludeUseCaseUsageProjectData.SemanticIds.INCLUDE_USE_CASE_USAGE_ID, includeUsage -> {
             assertThat(this.identityService.getId(includeUsage.getUseCaseIncluded()))
                     .isEqualTo(IncludeUseCaseUsageProjectData.SemanticIds.INCLUDED_USE_CASE_2_ID);
             assertThat(this.identityService.getId(includeUsage.getOwningUsage()))
                     .isEqualTo(IncludeUseCaseUsageProjectData.SemanticIds.INCLUDING_USE_CASE_ID);
         });
+
+        StepVerifier.create(flux)
+                .consumeNextWith(initialDiagramContentConsumer)
+                .then(reconnectEdgeRunnable)
+                .consumeNextWith(diagramCheck)
+                .then(semanticCheck)
+                .thenCancel()
+                .verify(Duration.ofSeconds(10));
     }
 
     @Test
     @DisplayName("GIVEN an IncludeUseCaseUsage, WHEN reconnecting the source, THEN the new source of the IncludeUseCaseUsage is correct")
-    @Sql(scripts = { IncludeUseCaseUsageProjectData.SCRIPT_PATH }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
-    @Sql(scripts = { "/scripts/cleanup.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD, config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED))
+    @GivenSysONServer({ IncludeUseCaseUsageProjectData.SCRIPT_PATH })
     public void reconnectIncludeUseCaseUsageSource() {
-        this.verifier.then(() -> this.edgeReconnectionTester.reconnectEdge(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
-                this.diagram,
+        var flux = this.givenSubscriptionToDiagram();
+
+        AtomicReference<Diagram> diagram = new AtomicReference<>();
+        Consumer<Object> initialDiagramContentConsumer = assertRefreshedDiagramThat(diagram::set);
+
+        Runnable reconnectEdgeRunnable = () -> this.edgeReconnectionTester.reconnectEdge(IncludeUseCaseUsageProjectData.EDITING_CONTEXT_ID,
+                diagram,
                 IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDE_USE_CASE_USAGE_ID,
                 IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDED_USE_CASE_2_ID,
-                ReconnectEdgeKind.SOURCE));
+                ReconnectEdgeKind.SOURCE);
 
-        IDiagramChecker diagramCheckerTarget = (initialDiagram, newDiagram) -> {
+        Consumer<Object> diagramCheck = assertRefreshedDiagramThat(newDiagram -> {
+            var initialDiagram = diagram.get();
             new CheckDiagramElementCount(this.diagramComparator)
                     .hasNewNodeCount(1) // New element in the Perform action compartment
                     .hasNewEdgeCount(1)
@@ -229,16 +235,22 @@ public class GVIncludeUseCaseUsageTests extends AbstractIntegrationTests {
             Edge newEdge = this.diagramComparator.newEdges(initialDiagram, newDiagram).get(0);
             assertThat(newEdge).hasSourceId(IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDED_USE_CASE_2_ID);
             assertThat(newEdge).hasTargetId(IncludeUseCaseUsageProjectData.GraphicalIds.INCLUDED_USE_CASE_ID);
-        };
+        });
 
-        this.diagramCheckerService.checkDiagram(diagramCheckerTarget, this.diagram, this.verifier);
-
-        this.semanticCheckerService.checkElement(this.verifier, IncludeUseCaseUsage.class, () -> IncludeUseCaseUsageProjectData.SemanticIds.INCLUDE_USE_CASE_USAGE_ID, includeUsage -> {
+        Runnable semanticCheck = this.semanticCheckerService.checkElement(IncludeUseCaseUsage.class, () -> IncludeUseCaseUsageProjectData.SemanticIds.INCLUDE_USE_CASE_USAGE_ID, includeUsage -> {
             assertThat(this.identityService.getId(includeUsage.getUseCaseIncluded()))
                     .isEqualTo(IncludeUseCaseUsageProjectData.SemanticIds.INCLUDED_USE_CASE_ID);
             assertThat(this.identityService.getId(includeUsage.getOwningUsage()))
                     .isEqualTo(IncludeUseCaseUsageProjectData.SemanticIds.INCLUDED_USE_CASE_2_ID);
         });
+
+        StepVerifier.create(flux)
+                .consumeNextWith(initialDiagramContentConsumer)
+                .then(reconnectEdgeRunnable)
+                .consumeNextWith(diagramCheck)
+                .then(semanticCheck)
+                .thenCancel()
+                .verify(Duration.ofSeconds(10));
     }
 
 }


### PR DESCRIPTION
# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [ ] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [ ] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
