### PR TITLE
[cleanup] Use ServiceMethod instead of getSelfServiceCallExpression

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,17 @@
 
 - [sirius-web] SysON is based on Sirius Web, so please also read https://github.com/eclipse-sirius/sirius-web/blob/master/CHANGELOG.adoc[the breaking changes of Sirius Web].
 - https://github.com/eclipse-syson/syson/issues/1861[#1861] [publication] Split `SysONLibraryPublicationHandler` in two distinct classes so the publishing logic can be extended or re-used through the `ISysMLLibraryPublisher` API.
+- [services] The following methods have been deleted:
+
+** `String getAllReachableExpression(String domainType)` in `UtilService`
+** `List<EObject> getAllReachable(EObject eObject, String type)` in `UtilService`
++
+The following methods have been renamed:
++
+** `List<EObject> getAllReachable(EObject eObject, EClass eClass, boolean withStandardLibs)` to `List<EObject> getAllReachableType(EObject eObject, EClass eClass, boolean withStandardLibs)` in `UtilService`
+The following methods have been added:
++
+** List<EObject> getAllReachableType(EObject eObject, EClass eClass)` in `UtilService`
 
 === Dependency update
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysMLv2PropertiesConfigurer.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/configuration/SysMLv2PropertiesConfigurer.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-import org.apache.logging.log4j.util.Strings;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -75,10 +74,6 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegistryConfigurer {
-
-    private static final String GET_DETAILS_VIEW_LABEL_SERVICE = "getDetailsViewLabel";
-
-    private static final String GET_DETAILS_VIEW_HELP_TEXT_SERVICE = "getDetailsViewHelpText";
 
     private static final String CORE_PROPERTIES = "Core Properties";
 
@@ -312,13 +307,14 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         RadioDescription radio = FormFactory.eINSTANCE.createRadioDescription();
         radio.setName("ExtraRadioKindWidget");
         radio.setLabelExpression("Kind");
-        radio.setCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getEnumCandidates", Strings.quote(SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName())));
+        radio.setCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getEnumCandidates", AQLUtils.aqlString(SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName())));
         radio.setCandidateLabelExpression("aql:candidate.name");
-        radio.setValueExpression(AQLUtils.getSelfServiceCallExpression("getEnumValue", Strings.quote(SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName())));
+        radio.setValueExpression(AQLUtils.getSelfServiceCallExpression("getEnumValue", AQLUtils.aqlString(SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName())));
         radio.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
         setNewValueOperation
-                .setExpression(AQLUtils.getSelfServiceCallExpression("setNewValue", List.of(Strings.quote(SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName()), "newValue.instance")));
+                .setExpression(
+                        AQLUtils.getSelfServiceCallExpression("setNewValue", List.of(AQLUtils.aqlString(SysmlPackage.eINSTANCE.getStateSubactionMembership_Kind().getName()), "newValue.instance")));
         radio.getBody().add(setNewValueOperation);
 
         group.getChildren().add(radio);
@@ -393,7 +389,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         refWidget.setReferenceOwnerExpression(AQLConstants.AQL_SELF);
         refWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setRefWidget = ViewFactory.eINSTANCE.createChangeContext();
-        setRefWidget.setExpression(AQLUtils.getSelfServiceCallExpression("handleFeatureTypingNewValue", ViewFormDescriptionConverter.NEW_VALUE));
+        setRefWidget.setExpression(ServiceMethod.of1(DetailsViewService::handleFeatureTypingNewValue).aqlSelf(ViewFormDescriptionConverter.NEW_VALUE));
         refWidget.getBody().add(setRefWidget);
 
         group.getChildren().add(refWidget);
@@ -439,7 +435,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         radio.setValueExpression(ServiceMethod.of0(DetailsViewService::getVisibilityValue).aqlSelf());
         radio.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
-        setNewValueOperation.setExpression(AQLUtils.getSelfServiceCallExpression("setVisibilityValue", "newValue.instance"));
+        setNewValueOperation.setExpression(ServiceMethod.of1(DetailsViewService::setVisibilityValue).aqlSelf("newValue.instance"));
         radio.getBody().add(setNewValueOperation);
 
         group.getChildren().add(radio);
@@ -461,7 +457,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         payloadRefWidget.setReferenceOwnerExpression(ServiceMethod.of0(DetailsViewService::getAcceptActionUsagePayloadFeatureTyping).aqlSelf());
         payloadRefWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setPayloadRefWidget = ViewFactory.eINSTANCE.createChangeContext();
-        setPayloadRefWidget.setExpression(AQLUtils.getSelfServiceCallExpression("setAcceptActionUsagePayloadParameter", ViewFormDescriptionConverter.NEW_VALUE));
+        setPayloadRefWidget.setExpression(ServiceMethod.of1(DetailsViewService::setAcceptActionUsagePayloadParameter).aqlSelf(ViewFormDescriptionConverter.NEW_VALUE));
         payloadRefWidget.getBody().add(setPayloadRefWidget);
 
         ReferenceWidgetDescription receiverRefWidget = ReferenceFactory.eINSTANCE.createReferenceWidgetDescription();
@@ -471,7 +467,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         receiverRefWidget.setReferenceOwnerExpression(ServiceMethod.of0(DetailsViewService::getAcceptActionUsageReceiverMembership).aqlSelf());
         receiverRefWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setReceiverRefWidget = ViewFactory.eINSTANCE.createChangeContext();
-        setReceiverRefWidget.setExpression(AQLUtils.getSelfServiceCallExpression("setAcceptActionUsageReceiverArgument", ViewFormDescriptionConverter.NEW_VALUE));
+        setReceiverRefWidget.setExpression(ServiceMethod.of1(DetailsViewService::setAcceptActionUsageReceiverArgument).aqlSelf(ViewFormDescriptionConverter.NEW_VALUE));
         receiverRefWidget.getBody().add(setReceiverRefWidget);
 
         group.getChildren().add(payloadRefWidget);
@@ -494,7 +490,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         sourceRefWidget.setReferenceOwnerExpression(AQLConstants.AQL_SELF);
         sourceRefWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setSourceRefWidget = ViewFactory.eINSTANCE.createChangeContext();
-        setSourceRefWidget.setExpression(AQLUtils.getSelfServiceCallExpression("setTransitionSourceParameter", ViewFormDescriptionConverter.NEW_VALUE));
+        setSourceRefWidget.setExpression(ServiceMethod.of1(DetailsViewService::setTransitionSourceParameter).aqlSelf(ViewFormDescriptionConverter.NEW_VALUE));
         sourceRefWidget.getBody().add(setSourceRefWidget);
 
         ReferenceWidgetDescription targetRefWidget = ReferenceFactory.eINSTANCE.createReferenceWidgetDescription();
@@ -504,7 +500,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         targetRefWidget.setReferenceOwnerExpression(AQLConstants.AQL_SELF);
         targetRefWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY);
         ChangeContext setTargetRefWidget = ViewFactory.eINSTANCE.createChangeContext();
-        setTargetRefWidget.setExpression(AQLUtils.getSelfServiceCallExpression("setTransitionTargetParameter", ViewFormDescriptionConverter.NEW_VALUE));
+        setTargetRefWidget.setExpression(ServiceMethod.of1(DetailsViewService::setTransitionTargetParameter).aqlSelf(ViewFormDescriptionConverter.NEW_VALUE));
         targetRefWidget.getBody().add(setTargetRefWidget);
 
         group.getChildren().add(sourceRefWidget);
@@ -536,43 +532,43 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
 
         FormElementIf label = FormFactory.eINSTANCE.createFormElementIf();
         label.setName("Read-only String Attributes");
-        label.setPredicateExpression(AQLUtils.getSelfServiceCallExpression("isReadOnlyStringAttribute", E_STRUCTURAL_FEATURE));
+        label.setPredicateExpression(ServiceMethod.of1(DetailsViewService::isReadOnlyStringAttribute).aqlSelf(E_STRUCTURAL_FEATURE));
         label.getChildren().add(this.createLabelWidget());
         widgets.add(label);
 
         FormElementIf textfield = FormFactory.eINSTANCE.createFormElementIf();
         textfield.setName("String Attributes");
-        textfield.setPredicateExpression(AQLUtils.getSelfServiceCallExpression("isStringAttribute", E_STRUCTURAL_FEATURE));
+        textfield.setPredicateExpression(ServiceMethod.of1(DetailsViewService::isStringAttribute).aqlSelf(E_STRUCTURAL_FEATURE));
         textfield.getChildren().add(this.createTextfieldWidget());
         widgets.add(textfield);
 
         FormElementIf textArea = FormFactory.eINSTANCE.createFormElementIf();
         textArea.setName("Multiline String Attributes");
-        textArea.setPredicateExpression(AQLUtils.getSelfServiceCallExpression("isMultilineStringAttribute", E_STRUCTURAL_FEATURE));
+        textArea.setPredicateExpression(ServiceMethod.of1(DetailsViewService::isMultilineStringAttribute).aqlSelf(E_STRUCTURAL_FEATURE));
         textArea.getChildren().add(this.createTextAreaFieldWidget());
         widgets.add(textArea);
 
         FormElementIf checkbox = FormFactory.eINSTANCE.createFormElementIf();
         checkbox.setName("Boolean Attributes");
-        checkbox.setPredicateExpression(AQLUtils.getServiceCallExpression(E_STRUCTURAL_FEATURE, "isBooleanAttribute"));
+        checkbox.setPredicateExpression(ServiceMethod.of0(DetailsViewService::isBooleanAttribute).aql(E_STRUCTURAL_FEATURE));
         checkbox.getChildren().add(this.createCheckboxWidget());
         widgets.add(checkbox);
 
         FormElementIf radio = FormFactory.eINSTANCE.createFormElementIf();
         radio.setName("Radio Attributes");
-        radio.setPredicateExpression(AQLUtils.getServiceCallExpression(E_STRUCTURAL_FEATURE, "isEnumAttribute"));
+        radio.setPredicateExpression(ServiceMethod.of0(DetailsViewService::isEnumAttribute).aql(E_STRUCTURAL_FEATURE));
         radio.getChildren().add(this.createRadioWidget());
         widgets.add(radio);
 
         FormElementIf refWidget = FormFactory.eINSTANCE.createFormElementIf();
         refWidget.setName("ReferenceWidget References");
-        refWidget.setPredicateExpression(AQLUtils.getServiceCallExpression(E_STRUCTURAL_FEATURE, "isReference"));
+        refWidget.setPredicateExpression(ServiceMethod.of0(DetailsViewService::isReference).aql(E_STRUCTURAL_FEATURE));
         refWidget.getChildren().add(this.createReferenceWidget());
         widgets.add(refWidget);
 
         FormElementIf number = FormFactory.eINSTANCE.createFormElementIf();
         number.setName("Number Attributes");
-        number.setPredicateExpression(AQLUtils.getServiceCallExpression(E_STRUCTURAL_FEATURE, "isNumberAttribute"));
+        number.setPredicateExpression(ServiceMethod.of0(DetailsViewService::isNumberAttribute).aql(E_STRUCTURAL_FEATURE));
         number.getChildren().add(this.createTextfieldWidget());
         widgets.add(number);
 
@@ -582,8 +578,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
     private WidgetDescription createLabelWidget() {
         LabelDescription label = FormFactory.eINSTANCE.createLabelDescription();
         label.setName("LabelWidget");
-        label.setLabelExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_LABEL_SERVICE, E_STRUCTURAL_FEATURE));
-        label.setHelpExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_HELP_TEXT_SERVICE, E_STRUCTURAL_FEATURE));
+        label.setLabelExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewLabel).aqlSelf(E_STRUCTURAL_FEATURE));
+        label.setHelpExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewHelpText).aqlSelf(E_STRUCTURAL_FEATURE));
         label.setValueExpression(AQLUtils.getSelfServiceCallExpression("eGet", E_STRUCTURAL_FEATURE));
         return label;
     }
@@ -591,8 +587,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
     private WidgetDescription createTextAreaFieldWidget() {
         TextAreaDescription textArea = FormFactory.eINSTANCE.createTextAreaDescription();
         textArea.setName("TextAreaWidget");
-        textArea.setLabelExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_LABEL_SERVICE, E_STRUCTURAL_FEATURE));
-        textArea.setHelpExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_HELP_TEXT_SERVICE, E_STRUCTURAL_FEATURE));
+        textArea.setLabelExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewLabel).aqlSelf(E_STRUCTURAL_FEATURE));
+        textArea.setHelpExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewHelpText).aqlSelf(E_STRUCTURAL_FEATURE));
         textArea.setValueExpression(AQLUtils.getSelfServiceCallExpression("eGet", E_STRUCTURAL_FEATURE));
         textArea.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY_E_STRUCTURAL_FEATURE);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
@@ -604,8 +600,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
     private WidgetDescription createTextfieldWidget() {
         TextfieldDescription textfield = FormFactory.eINSTANCE.createTextfieldDescription();
         textfield.setName("TextfieldWidget");
-        textfield.setLabelExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_LABEL_SERVICE, E_STRUCTURAL_FEATURE));
-        textfield.setHelpExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_HELP_TEXT_SERVICE, E_STRUCTURAL_FEATURE));
+        textfield.setLabelExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewLabel).aqlSelf(E_STRUCTURAL_FEATURE));
+        textfield.setHelpExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewHelpText).aqlSelf(E_STRUCTURAL_FEATURE));
         textfield.setValueExpression(AQLUtils.getSelfServiceCallExpression("eGet", E_STRUCTURAL_FEATURE));
         textfield.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY_E_STRUCTURAL_FEATURE);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
@@ -617,9 +613,9 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
     private WidgetDescription createCheckboxWidget() {
         CheckboxDescription checkbox = FormFactory.eINSTANCE.createCheckboxDescription();
         checkbox.setName("CheckboxWidget");
-        checkbox.setLabelExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_LABEL_SERVICE, E_STRUCTURAL_FEATURE));
+        checkbox.setLabelExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewLabel).aqlSelf(E_STRUCTURAL_FEATURE));
         checkbox.setValueExpression(AQLUtils.getSelfServiceCallExpression("eGet", E_STRUCTURAL_FEATURE));
-        checkbox.setHelpExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_HELP_TEXT_SERVICE, E_STRUCTURAL_FEATURE));
+        checkbox.setHelpExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewHelpText).aqlSelf(E_STRUCTURAL_FEATURE));
         checkbox.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY_E_STRUCTURAL_FEATURE);
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
         setNewValueOperation.setExpression(AQLUtils.getSelfServiceCallExpression("setNewValue", List.of(E_STRUCTURAL_FEATURE, ViewFormDescriptionConverter.NEW_VALUE)));
@@ -630,8 +626,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
     private WidgetDescription createRadioWidget() {
         RadioDescription radio = FormFactory.eINSTANCE.createRadioDescription();
         radio.setName("RadioWidget");
-        radio.setLabelExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_LABEL_SERVICE, E_STRUCTURAL_FEATURE));
-        radio.setHelpExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_HELP_TEXT_SERVICE, E_STRUCTURAL_FEATURE));
+        radio.setLabelExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewLabel).aqlSelf(E_STRUCTURAL_FEATURE));
+        radio.setHelpExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewHelpText).aqlSelf(E_STRUCTURAL_FEATURE));
         radio.setCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getEnumCandidates", E_STRUCTURAL_FEATURE));
         radio.setCandidateLabelExpression("aql:candidate.name");
         radio.setValueExpression(AQLUtils.getSelfServiceCallExpression("getEnumValue", E_STRUCTURAL_FEATURE));
@@ -645,8 +641,8 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
     private WidgetDescription createReferenceWidget() {
         ReferenceWidgetDescription refWidget = ReferenceFactory.eINSTANCE.createReferenceWidgetDescription();
         refWidget.setName("ReferenceWidget");
-        refWidget.setLabelExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_LABEL_SERVICE, E_STRUCTURAL_FEATURE));
-        refWidget.setHelpExpression(AQLUtils.getSelfServiceCallExpression(GET_DETAILS_VIEW_HELP_TEXT_SERVICE, E_STRUCTURAL_FEATURE));
+        refWidget.setLabelExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewLabel).aqlSelf(E_STRUCTURAL_FEATURE));
+        refWidget.setHelpExpression(ServiceMethod.of1(DetailsViewService::getDetailsViewHelpText).aqlSelf(E_STRUCTURAL_FEATURE));
         refWidget.setReferenceNameExpression(AQLConstants.AQL + E_STRUCTURAL_FEATURE + ".name");
         refWidget.setReferenceOwnerExpression(AQLConstants.AQL_SELF);
         refWidget.setIsEnabledExpression(AQL_NOT_SELF_IS_READ_ONLY_E_STRUCTURAL_FEATURE);
@@ -664,7 +660,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         textarea.setHelpExpression("Use 'shift + enter' to add new lines");
         textarea.setIsEnabledExpression("aql:not(self.isReadOnly())");
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
-        setNewValueOperation.setExpression(AQLUtils.getSelfServiceCallExpression("setNewDocumentationValue", ViewFormDescriptionConverter.NEW_VALUE));
+        setNewValueOperation.setExpression(ServiceMethod.of1(DetailsViewService::setNewDocumentationValue).aqlSelf(ViewFormDescriptionConverter.NEW_VALUE));
         textarea.getBody().add(setNewValueOperation);
         FormElementIf precondition = FormFactory.eINSTANCE.createFormElementIf();
         precondition.getChildren().add(textarea);
@@ -681,7 +677,7 @@ public class SysMLv2PropertiesConfigurer implements IPropertiesDescriptionRegist
         textarea.setHelpExpression("Use 'shift + enter' to add new lines");
         textarea.setIsEnabledExpression("aql:not(self.isReadOnly())");
         ChangeContext setNewValueOperation = ViewFactory.eINSTANCE.createChangeContext();
-        setNewValueOperation.setExpression(AQLUtils.getSelfServiceCallExpression("setNewCommentValue", ViewFormDescriptionConverter.NEW_VALUE));
+        setNewValueOperation.setExpression(ServiceMethod.of1(DetailsViewService::setNewCommentValue).aqlSelf(ViewFormDescriptionConverter.NEW_VALUE));
         textarea.getBody().add(setNewValueOperation);
         FormElementIf precondition = FormFactory.eINSTANCE.createFormElementIf();
         precondition.getChildren().add(textarea);

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/DiagramDirectEditListener.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/DiagramDirectEditListener.java
@@ -907,7 +907,7 @@ public class DiagramDirectEditListener extends DirectEditBaseListener {
      */
     private Optional<AttributeUsage> getMeasurementAttribute(Element context, String measurementName) {
         AttributeDefinition tensorMeasurementReference = this.utilService.findByNameAndType(context, "MeasurementReferences::TensorMeasurementReference", AttributeDefinition.class);
-        List<EObject> attributes = this.utilService.getAllReachable(context, SysmlPackage.eINSTANCE.getAttributeUsage());
+        List<EObject> attributes = this.utilService.getAllReachableType(context, SysmlPackage.eINSTANCE.getAttributeUsage());
         Optional<AttributeUsage> optUnitAttribute = attributes.stream()
                 .map(AttributeUsage.class::cast)
                 // The short name or the regular name can be use to set units

--- a/backend/services/syson-services/src/main/java/org/eclipse/syson/services/UtilService.java
+++ b/backend/services/syson-services/src/main/java/org/eclipse/syson/services/UtilService.java
@@ -84,8 +84,6 @@ import org.eclipse.syson.sysml.helper.EMFUtils;
 import org.eclipse.syson.sysml.helper.NameHelper;
 import org.eclipse.syson.sysml.metamodel.services.ElementInitializerSwitch;
 import org.eclipse.syson.sysml.util.ElementUtil;
-import org.eclipse.syson.util.AQLUtils;
-import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.SysONEContentAdapter;
 
 /**
@@ -234,28 +232,17 @@ public class UtilService {
     }
 
     /**
-     * Get the AQL service expression getting all reachable elements based on the provided {@code domainType} type.
-     *
-     * @param domainType
-     *            A type to be converted as an EClass name
-     * @return An AQL expression calling {@code self.getAllReachable(domainType)}
-     */
-    public String getAllReachableExpression(String domainType) {
-        return AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType);
-    }
-
-    /**
-     * Get all reachable elements of a type in the {@link ResourceSet} of given {@link EObject}.
+     * Get all reachable elements of the type given by the {@link EClass} in the {@link ResourceSet} of the given type
+     * (represented by its qualified name).
      *
      * @param eObject
      *            the {@link EObject} stored in a {@link ResourceSet}
      * @param type
-     *            the search typed (either simple or qualified named of the EClass ("Package" vs "sysml::Package")
+     *            the searched type, represented by its qualified name
      * @return a list of reachable object
      */
-    public List<EObject> getAllReachable(EObject eObject, String type) {
-        EClass eClass = SysMLMetamodelHelper.toEClass(type);
-        return this.getAllReachable(eObject, eClass);
+    public List<EObject> getAllReachable(EObject eObject, EClass eClass) {
+        return this.getAllReachableType(eObject, eClass);
     }
 
     /**
@@ -268,7 +255,7 @@ public class UtilService {
      *            the searched {@link EClass}
      * @return a list of reachable object
      */
-    public List<EObject> getAllReachable(EObject eObject, EClass eClass) {
+    public List<EObject> getAllReachableType(EObject eObject, EClass eClass) {
         List<EObject> allReachable = new ArrayList<>();
         Adapter adapter = EcoreUtil.getAdapter(eObject.eAdapters(), SysONEContentAdapter.class);
         if (adapter instanceof SysONEContentAdapter cacheAdapter) {
@@ -292,10 +279,10 @@ public class UtilService {
      *            include standard libraries elements into list result
      * @return a list of reachable object
      */
-    public List<EObject> getAllReachable(EObject eObject, EClass eClass, boolean withStandardLibs) {
+    public List<EObject> getAllReachableType(EObject eObject, EClass eClass, boolean withStandardLibs) {
         List<EObject> allReachable = new ArrayList<>();
         if (withStandardLibs) {
-            return this.getAllReachable(eObject, eClass);
+            return this.getAllReachableType(eObject, eClass);
         }
         var userResources = eObject.eResource().getResourceSet().getResources().stream()
                 .filter(r -> r.getURI().toString().startsWith(IEMFEditingContext.RESOURCE_SCHEME))
@@ -325,12 +312,12 @@ public class UtilService {
      */
     public List<StateUsage> getAllReachableStatesWithoutReferentialExhibit(Element eObject) {
         List<StateUsage> result = new ArrayList<>();
-        this.getAllReachable(eObject, SysmlPackage.eINSTANCE.getExhibitStateUsage()).stream().forEach(su -> {
+        this.getAllReachableType(eObject, SysmlPackage.eINSTANCE.getExhibitStateUsage()).stream().forEach(su -> {
             if (((ExhibitStateUsage) su).getExhibitedState() == null) {
                 result.add((StateUsage) su);
             }
         });
-        this.getAllReachable(eObject, SysmlPackage.eINSTANCE.getStateUsage()).stream().forEach(su -> {
+        this.getAllReachableType(eObject, SysmlPackage.eINSTANCE.getStateUsage()).stream().forEach(su -> {
             result.add((StateUsage) su);
         });
         return result;

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDependencyEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractDependencyEdgeDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -28,10 +28,10 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.diagram.services.aql.DiagramMutationAQLService;
 import org.eclipse.syson.diagram.services.aql.DiagramQueryAQLService;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.Dependency;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -90,7 +90,7 @@ public abstract class AbstractDependencyEdgeDescriptionProvider extends Abstract
                 .isDomainBasedEdge(true)
                 .centerLabelExpression(ServiceMethod.of0(DiagramQueryAQLService::getDependencyLabel).aqlSelf())
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .sourceExpression(AQLConstants.AQL_SELF + "." + SysmlPackage.eINSTANCE.getDependency_Client().getName())
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractFeatureValueEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractFeatureValueEdgeDescriptionProvider.java
@@ -26,10 +26,10 @@ import org.eclipse.sirius.components.view.diagram.LineStyle;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.diagram.common.view.services.ViewEdgeService;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.BindingConnectorAsUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
@@ -80,7 +80,7 @@ public abstract class AbstractFeatureValueEdgeDescriptionProvider extends Abstra
                 .isDomainBasedEdge(true)
                 .centerLabelExpression("=")
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .sourceExpression(AQLConstants.AQL_SELF + "." + SysmlPackage.eINSTANCE.getFeatureValue_FeatureWithValue().getName())
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractFlowUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractFlowUsageEdgeDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.diagram.services.aql.DiagramMutationAQLService;
 import org.eclipse.syson.diagram.services.aql.DiagramQueryAQLService;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.FlowUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
@@ -87,7 +88,7 @@ public abstract class AbstractFlowUsageEdgeDescriptionProvider extends AbstractE
                 .isDomainBasedEdge(true)
                 .centerLabelExpression(ServiceMethod.of0(DiagramQueryAQLService::getEdgeLabel).aqlSelf())
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .sourceExpression("aql:self.sourceOutputFeature.unwrapFeature()")
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSubsettingEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSubsettingEdgeDescriptionProvider.java
@@ -22,8 +22,9 @@ import org.eclipse.sirius.components.view.diagram.EdgeDescription;
 import org.eclipse.sirius.components.view.diagram.EdgeStyle;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.Subsetting;
-import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 
 /**
@@ -101,7 +102,7 @@ public abstract class AbstractSubsettingEdgeDescriptionProvider extends Abstract
                 .centerLabelExpression("")
                 .name(this.getName())
                 .preconditionExpression("aql:self.oclIsTypeOf(" + domainType + ")")
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .sourceExpression(this.getSourceExpression())
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSuccessionEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractSuccessionEdgeDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -27,6 +27,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.diagram.services.aql.DiagramMutationAQLService;
 import org.eclipse.syson.diagram.services.aql.DiagramQueryAQLService;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
 import org.eclipse.syson.util.AQLUtils;
@@ -78,7 +79,7 @@ public abstract class AbstractSuccessionEdgeDescriptionProvider extends Abstract
                 .isDomainBasedEdge(true)
                 .centerLabelExpression(ServiceMethod.of0(DiagramQueryAQLService::getEdgeLabel).aqlSelf())
                 .name(this.descriptionNameGenerator.getEdgeName(SysmlPackage.eINSTANCE.getSuccession()))
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
                 .sourceExpression("aql:self.getSource()")

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractTransitionEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AbstractTransitionEdgeDescriptionProvider.java
@@ -36,10 +36,10 @@ import org.eclipse.syson.diagram.common.view.nodes.DoneActionNodeDescriptionProv
 import org.eclipse.syson.diagram.common.view.nodes.StartActionNodeDescriptionProvider;
 import org.eclipse.syson.diagram.common.view.services.ViewEdgeService;
 import org.eclipse.syson.diagram.services.aql.DiagramQueryAQLService;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.TransitionUsage;
 import org.eclipse.syson.util.AQLConstants;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -73,7 +73,7 @@ public abstract class AbstractTransitionEdgeDescriptionProvider extends Abstract
                 .name(this.getEdgeDescriptionName())
                 .preconditionExpression(ServiceMethod.of2(ViewEdgeService::isInSameGraphicalContainer).aql(org.eclipse.sirius.components.diagrams.description.EdgeDescription.GRAPHICAL_EDGE_SOURCE,
                         org.eclipse.sirius.components.diagrams.description.EdgeDescription.GRAPHICAL_EDGE_TARGET, org.eclipse.sirius.components.diagrams.description.DiagramDescription.CACHE))
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .sourceExpression(AQLConstants.AQL_SELF + "." + SysmlPackage.eINSTANCE.getTransitionUsage_Source().getName())
                 .style(this.createDefaultEdgeStyle())
                 .conditionalStyles(this.createStateConditionalStyle())

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AnnotationEdgeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/edges/AnnotationEdgeDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -26,10 +26,12 @@ import org.eclipse.sirius.components.view.diagram.EdgeStyle;
 import org.eclipse.sirius.components.view.diagram.LineStyle;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -54,7 +56,7 @@ public class AnnotationEdgeDescriptionProvider extends AbstractEdgeDescriptionPr
                 .domainType(domainType)
                 .isDomainBasedEdge(false)
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)
                 .targetExpression(AQLConstants.AQL_SELF + ".annotatedElement")

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/ImportedPackageNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/ImportedPackageNodeDescriptionProvider.java
@@ -36,9 +36,9 @@ import org.eclipse.syson.diagram.common.view.services.description.ToolDescriptio
 import org.eclipse.syson.diagram.common.view.services.dto.NodeDefaultSizeExpression;
 import org.eclipse.syson.diagram.services.aql.DiagramQueryAQLService;
 import org.eclipse.syson.services.DeleteService;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysmlcustomnodes.SysMLCustomnodesFactory;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -73,7 +73,7 @@ public class ImportedPackageNodeDescriptionProvider extends AbstractNodeDescript
                 .domainType(domainType)
                 .insideLabel(this.createInsideLabelDescription())
                 .name(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getNamespaceImport()))
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .style(this.createImportedPackageNodeStyle())
                 .userResizable(UserResizableDirection.BOTH)
                 .synchronizationPolicy(SynchronizationPolicy.UNSYNCHRONIZED)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/InheritedCompartmentItemNodeDescriptionProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/nodes/InheritedCompartmentItemNodeDescriptionProvider.java
@@ -28,6 +28,7 @@ import org.eclipse.sirius.components.view.diagram.NodePalette;
 import org.eclipse.sirius.components.view.diagram.NodeStyleDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.sirius.components.view.diagram.UserResizableDirection;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.diagram.common.view.services.ViewLabelService;
 import org.eclipse.syson.util.AQLConstants;
 import org.eclipse.syson.util.AQLUtils;
@@ -64,7 +65,7 @@ public class InheritedCompartmentItemNodeDescriptionProvider extends AbstractNod
                 .domainType(SysMLMetamodelHelper.buildQualifiedName(this.eReference.getEType()))
                 .insideLabel(this.createInsideLabelDescription())
                 .name(this.descriptionNameGenerator.getInheritedCompartmentItemName(this.eClass, this.eReference))
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getInheritedCompartmentItems", "'" + this.eReference.getName() + "'"))
+                .semanticCandidatesExpression(ServiceMethod.of1(ViewCreateService::getInheritedCompartmentItems).aqlSelf(AQLUtils.aqlString(this.eReference.getName())))
                 .style(this.createCompartmentItemNodeStyle())
                 .userResizable(UserResizableDirection.NONE)
                 .palette(this.createInheritedCompartmentItemNodePalette())

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewEdgeService.java
@@ -52,7 +52,6 @@ import org.eclipse.syson.sysml.TransitionUsage;
 import org.eclipse.syson.sysml.Usage;
 import org.eclipse.syson.sysml.UseCaseUsage;
 import org.eclipse.syson.sysml.metamodel.services.MetamodelMutationElementService;
-import org.eclipse.syson.util.SysMLMetamodelHelper;
 
 /**
  * Edge-related Java services used by several diagrams.
@@ -81,8 +80,7 @@ public class ViewEdgeService {
      * @return a list of allocate edge objects
      */
     public List<AllocationUsage> getAllReachableAllocateEdges(EObject eObject) {
-        String type = SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getAllocationUsage());
-        var allAllocationUsages = this.utilService.getAllReachable(eObject, type);
+        var allAllocationUsages = this.utilService.getAllReachableType(eObject, SysmlPackage.eINSTANCE.getAllocationUsage());
         return allAllocationUsages.stream()
                 .filter(AllocationUsage.class::isInstance)
                 .map(AllocationUsage.class::cast)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/ViewNodeService.java
@@ -407,8 +407,8 @@ public class ViewNodeService {
     }
 
     public List<Element> getAllReachableRequirements(EObject eObject) {
-        List<EObject> allRequirementUsages = this.utilService.getAllReachable(eObject, SysmlPackage.eINSTANCE.getRequirementUsage(), false);
-        List<EObject> allRequirementDefinitions = this.utilService.getAllReachable(eObject, SysmlPackage.eINSTANCE.getRequirementDefinition(), false);
+        List<EObject> allRequirementUsages = this.utilService.getAllReachableType(eObject, SysmlPackage.eINSTANCE.getRequirementUsage(), false);
+        List<EObject> allRequirementDefinitions = this.utilService.getAllReachableType(eObject, SysmlPackage.eINSTANCE.getRequirementDefinition(), false);
         return Stream.concat(allRequirementUsages.stream(), allRequirementDefinitions.stream())
                 .filter(Element.class::isInstance)
                 .map(Element.class::cast)

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/description/ToolDescriptionService.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/services/description/ToolDescriptionService.java
@@ -32,6 +32,7 @@ import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.NodeTool;
 import org.eclipse.sirius.components.view.diagram.NodeToolSection;
 import org.eclipse.sirius.components.view.emf.diagram.ViewDiagramDescriptionConverter;
+import org.eclipse.syson.diagram.common.view.services.ViewToolService;
 import org.eclipse.syson.diagram.services.aql.DiagramMutationAQLService;
 import org.eclipse.syson.model.services.aql.ModelMutationAQLService;
 import org.eclipse.syson.services.UtilService;
@@ -489,8 +490,8 @@ public class ToolDescriptionService {
                 .iconURLsExpression(iconPath.toString())
                 .body(changeContextRoot.build())
                 .elementsToSelectExpression("aql:newInstance")
-                .preconditionExpression(AQLUtils.getSelfServiceCallExpression("toolShouldBeAvailable",
-                        List.of(IEditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT, SysMLMetamodelHelper.buildQualifiedName(eClass))))
+                .preconditionExpression(ServiceMethod.of3(ViewToolService::toolShouldBeAvailable).aqlSelf(IEditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT,
+                        SysMLMetamodelHelper.buildQualifiedName(eClass)))
                 .build();
     }
 
@@ -580,8 +581,8 @@ public class ToolDescriptionService {
                 .iconURLsExpression(iconPath.toString())
                 .body(changeContextRoot.build())
                 .elementsToSelectExpression("aql:newInstance")
-                .preconditionExpression(AQLUtils.getSelfServiceCallExpression("toolShouldBeAvailable",
-                        List.of(IEditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT, SysMLMetamodelHelper.buildQualifiedName(eClass))))
+                .preconditionExpression(ServiceMethod.of3(ViewToolService::toolShouldBeAvailable).aqlSelf(IEditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT,
+                        SysMLMetamodelHelper.buildQualifiedName(eClass)))
                 .build();
     }
 }

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/CompartmentNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/CompartmentNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 Obeo.
+ * Copyright (c) 2024, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.syson.diagram.common.view.tools;
 
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.emf.ecore.EReference;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Node tool provider for elements inside compartments.
@@ -48,10 +48,10 @@ public class CompartmentNodeToolProvider extends AbstractCompartmentNodeToolProv
     @Override
     protected String getServiceCallExpression() {
         if (this.featureDirectionKind != null) {
-            List<String> params = List.of(AQLUtils.aqlString(this.eReference.getName()), AQLUtils.aqlString(this.featureDirectionKind.getLiteral()));
-            return AQLUtils.getSelfServiceCallExpression("createCompartmentItemWithDirection", params);
+            return ServiceMethod.of2(ViewCreateService::createCompartmentItemWithDirection).aqlSelf(AQLUtils.aqlString(this.eReference.getName()),
+                    AQLUtils.aqlString(this.featureDirectionKind.getLiteral()));
         } else {
-            return AQLUtils.getSelfServiceCallExpression("createCompartmentItem", AQLUtils.aqlString(this.eReference.getName()));
+            return ServiceMethod.of1(ViewCreateService::createCompartmentItem).aqlSelf(AQLUtils.aqlString(this.eReference.getName()));
         }
     }
 

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ExhibitStateWithReferenceNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ExhibitStateWithReferenceNodeToolProvider.java
@@ -31,7 +31,6 @@ import org.eclipse.syson.diagram.services.aql.DiagramMutationAQLService;
 import org.eclipse.syson.model.services.aql.ModelMutationAQLService;
 import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -104,7 +103,7 @@ public class ExhibitStateWithReferenceNodeToolProvider implements INodeToolProvi
         var domainType = SysMLMetamodelHelper.buildQualifiedName(SysmlPackage.eINSTANCE.getStateUsage());
 
         var selectionDialogTree = this.diagramBuilderHelper.newSelectionDialogTreeDescription()
-                .elementsExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .elementsExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .build();
 
         var selectExistingStateUsage = this.diagramBuilderHelper.newSelectionDialogDescription()

--- a/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ParameterCompartmentNodeToolProvider.java
+++ b/backend/views/syson-diagram-common-view/src/main/java/org/eclipse/syson/diagram/common/view/tools/ParameterCompartmentNodeToolProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,10 @@ package org.eclipse.syson.diagram.common.view.tools;
 
 import java.util.Objects;
 
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
 import org.eclipse.syson.util.AQLUtils;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Node tool provider for Parameters compartment in the element that need such compartment.
@@ -32,7 +34,7 @@ public class ParameterCompartmentNodeToolProvider extends AbstractCompartmentNod
 
     @Override
     protected String getServiceCallExpression() {
-        return AQLUtils.getSelfServiceCallExpression("createActionParameter", AQLUtils.aqlString(this.direction.getName()));
+        return ServiceMethod.of1(ViewCreateService::createActionParameter).aqlSelf(AQLUtils.aqlString(this.direction.getName()));
     }
 
     @Override

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/edges/ConnectionUsageEdgeDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/edges/ConnectionUsageEdgeDescriptionProvider.java
@@ -31,9 +31,9 @@ import org.eclipse.syson.diagram.common.view.DescriptionFinder;
 import org.eclipse.syson.diagram.common.view.edges.AbstractEdgeDescriptionProvider;
 import org.eclipse.syson.diagram.services.aql.DiagramMutationAQLService;
 import org.eclipse.syson.diagram.services.aql.DiagramQueryAQLService;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
@@ -91,7 +91,7 @@ public class ConnectionUsageEdgeDescriptionProvider extends AbstractEdgeDescript
                 .isDomainBasedEdge(true)
                 .centerLabelExpression(ServiceMethod.of0(DiagramQueryAQLService::getEdgeLabel).aqlSelf())
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .sourceExpression("aql:self.getSource()")
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/edges/IncludeUseCaseDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/edges/IncludeUseCaseDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Obeo.
+ * Copyright (c) 2025, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -28,12 +28,14 @@ import org.eclipse.sirius.components.view.diagram.LineStyle;
 import org.eclipse.sirius.components.view.diagram.NodeDescription;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.syson.diagram.common.view.edges.AbstractEdgeDescriptionProvider;
+import org.eclipse.syson.services.UtilService;
 import org.eclipse.syson.sysml.IncludeUseCaseUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.helper.LabelConstants;
 import org.eclipse.syson.util.AQLConstants;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
 
@@ -59,7 +61,7 @@ public class IncludeUseCaseDescriptionProvider extends AbstractEdgeDescriptionPr
                 .isDomainBasedEdge(true)
                 .centerLabelExpression(LabelConstants.OPEN_QUOTE + "include" + LabelConstants.CLOSE_QUOTE)
                 .name(this.getName())
-                .semanticCandidatesExpression(AQLUtils.getSelfServiceCallExpression("getAllReachable", domainType))
+                .semanticCandidatesExpression(ServiceMethod.of1(UtilService::getAllReachable).aqlSelf(domainType))
                 .sourceExpression("aql:self.owningUsage")
                 .style(this.createEdgeStyle())
                 .synchronizationPolicy(SynchronizationPolicy.SYNCHRONIZED)

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/ActorNodeDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/ActorNodeDescriptionProvider.java
@@ -29,12 +29,12 @@ import org.eclipse.sirius.components.view.diagram.OutsideLabelPosition;
 import org.eclipse.sirius.components.view.diagram.SynchronizationPolicy;
 import org.eclipse.sirius.components.view.diagram.UserResizableDirection;
 import org.eclipse.syson.diagram.common.view.services.ViewLabelService;
+import org.eclipse.syson.diagram.common.view.services.ViewNodeService;
 import org.eclipse.syson.diagram.services.aql.DiagramQueryAQLService;
 import org.eclipse.syson.model.services.aql.ModelQueryAQLService;
 import org.eclipse.syson.standard.diagrams.view.SDVDescriptionNameGenerator;
 import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.SysmlPackage;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 import org.eclipse.syson.util.ViewConstants;
@@ -117,8 +117,8 @@ public class ActorNodeDescriptionProvider extends UsageNodeDescriptionProvider {
 
     @Override
     protected String getSemanticCandidatesExpression(String domainType) {
-        return AQLUtils.getSelfServiceCallExpression("getExposedActors",
-                List.of(domainType, org.eclipse.sirius.components.diagrams.description.NodeDescription.ANCESTORS, IEditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT));
+        return ServiceMethod.of4(ViewNodeService::getExposedActors).aqlSelf(domainType, org.eclipse.sirius.components.diagrams.description.NodeDescription.ANCESTORS, IEditingContext.EDITING_CONTEXT,
+                DiagramContext.DIAGRAM_CONTEXT);
     }
 
     @Override

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/InheritedPortUsageBorderNodeDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/InheritedPortUsageBorderNodeDescriptionProvider.java
@@ -27,10 +27,13 @@ import org.eclipse.sirius.components.view.diagram.OutsideLabelDescription;
 import org.eclipse.sirius.components.view.diagram.OutsideLabelPosition;
 import org.eclipse.sirius.web.application.editingcontext.EditingContext;
 import org.eclipse.syson.diagram.common.view.nodes.AbstractPortUsageBorderNodeDescriptionProvider;
+import org.eclipse.syson.diagram.common.view.services.ViewCreateService;
+import org.eclipse.syson.diagram.services.aql.DiagramMutationAQLService;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.util.AQLConstants;
 import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.ServiceMethod;
 
 /**
  * Used to create the inherited port usage border node description.
@@ -51,7 +54,7 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
 
     @Override
     protected String getSemanticCandidatesExpression() {
-        return AQLUtils.getSelfServiceCallExpression("getInheritedCompartmentItems", "'" + this.eReference.getName() + "'");
+        return ServiceMethod.of1(ViewCreateService::getInheritedCompartmentItems).aqlSelf(AQLUtils.aqlString(this.eReference.getName()));
     }
 
     @Override
@@ -111,7 +114,7 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
                         .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, REDEFINE_INHERITED_PORT_SERVICE, List.of(
                                 EdgeDescription.EDGE_SOURCE, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT)))
                         .children(this.viewBuilderHelper.newChangeContext()
-                                .expression(AQLUtils.getSelfServiceCallExpression("createBindingConnectorAsUsage", EdgeDescription.SEMANTIC_EDGE_TARGET))
+                                .expression(ServiceMethod.of1(ViewCreateService::createBindingConnectorAsUsage).aqlSelf(EdgeDescription.SEMANTIC_EDGE_TARGET))
                                 .build())
                         .build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -126,7 +129,8 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
                         .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, REDEFINE_INHERITED_PORT_SERVICE, List.of(
                                 EdgeDescription.EDGE_SOURCE, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT)))
                         .children(this.viewBuilderHelper.newChangeContext()
-                                .expression(AQLUtils.getSelfServiceCallExpression("createInterfaceUsage", EdgeDescription.SEMANTIC_EDGE_TARGET))
+                                .expression(ServiceMethod.of5(DiagramMutationAQLService::createInterfaceUsage).aqlSelf(EdgeDescription.SEMANTIC_EDGE_TARGET, EdgeDescription.EDGE_SOURCE,
+                                        EdgeDescription.EDGE_TARGET, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT))
                                 .build())
                         .build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -141,7 +145,7 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
                         .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, REDEFINE_INHERITED_PORT_SERVICE, List.of(
                                 EdgeDescription.EDGE_SOURCE, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT)))
                         .children(this.viewBuilderHelper.newChangeContext()
-                                .expression(AQLUtils.getSelfServiceCallExpression("createFlowUsage", EdgeDescription.SEMANTIC_EDGE_TARGET))
+                                .expression(ServiceMethod.of1(ViewCreateService::createFlowUsage).aqlSelf(EdgeDescription.SEMANTIC_EDGE_TARGET))
                                 .build())
                         .build())
                 .targetElementDescriptions(targetElementDescriptions.toArray(NodeDescription[]::new))
@@ -162,7 +166,7 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
                                         .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, REDEFINE_INHERITED_PORT_SERVICE, List.of(
                                                 EdgeDescription.EDGE_SOURCE, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT)))
                                         .children(this.viewBuilderHelper.newChangeContext()
-                                                .expression(AQLUtils.getSelfServiceCallExpression("createBindingConnectorAsUsage", REDEFINED_TARGET))
+                                                .expression(ServiceMethod.of1(ViewCreateService::createBindingConnectorAsUsage).aqlSelf(REDEFINED_TARGET))
                                                 .build())
                                         .build())
                                 .build())
@@ -186,7 +190,8 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
                                         .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, REDEFINE_INHERITED_PORT_SERVICE, List.of(
                                                 EdgeDescription.EDGE_SOURCE, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT)))
                                         .children(this.viewBuilderHelper.newChangeContext()
-                                                .expression(AQLUtils.getSelfServiceCallExpression("createInterfaceUsage", REDEFINED_TARGET))
+                                                .expression(ServiceMethod.of5(DiagramMutationAQLService::createInterfaceUsage).aqlSelf(REDEFINED_TARGET, EdgeDescription.EDGE_SOURCE,
+                                                        EdgeDescription.EDGE_TARGET, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT))
                                                 .build())
                                         .build())
                                 .build())
@@ -209,7 +214,7 @@ public class InheritedPortUsageBorderNodeDescriptionProvider extends AbstractPor
                                         .expression(AQLUtils.getServiceCallExpression(EdgeDescription.SEMANTIC_EDGE_SOURCE, REDEFINE_INHERITED_PORT_SERVICE, List.of(
                                                 EdgeDescription.EDGE_SOURCE, EditingContext.EDITING_CONTEXT, DiagramContext.DIAGRAM_CONTEXT)))
                                         .children(this.viewBuilderHelper.newChangeContext()
-                                                .expression(AQLUtils.getSelfServiceCallExpression("createFlowUsage", REDEFINED_TARGET))
+                                                .expression(ServiceMethod.of1(ViewCreateService::createFlowUsage).aqlSelf(REDEFINED_TARGET))
                                                 .build())
                                         .build())
                                 .build())

--- a/backend/views/syson-table-requirements-view/src/main/java/org/eclipse/syson/table/requirements/view/RTVTableDescriptionProvider.java
+++ b/backend/views/syson-table-requirements-view/src/main/java/org/eclipse/syson/table/requirements/view/RTVTableDescriptionProvider.java
@@ -27,8 +27,8 @@ import org.eclipse.sirius.components.view.table.ColumnDescription;
 import org.eclipse.sirius.components.view.table.RowContextMenuEntry;
 import org.eclipse.syson.services.DeleteService;
 import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.table.requirements.view.services.RTVMutationServices;
 import org.eclipse.syson.util.AQLConstants;
-import org.eclipse.syson.util.AQLUtils;
 import org.eclipse.syson.util.ServiceMethod;
 import org.eclipse.syson.util.SysMLMetamodelHelper;
 
@@ -143,7 +143,7 @@ public class RTVTableDescriptionProvider implements IRepresentationDescriptionPr
                 .valueExpression("aql:self.getDocumentationBody()")
                 .cellWidgetDescription(this.tableBuilders.newCellTextareaWidgetDescription()
                         .body(this.viewBuilders.newChangeContext()
-                                .expression(AQLUtils.getSelfServiceCallExpression("editDocumentation", "newValue"))
+                                .expression(ServiceMethod.of1(RTVMutationServices::editDocumentation).aqlSelf("newValue"))
                                 .build())
                         .build())
                 .build();
@@ -163,7 +163,7 @@ public class RTVTableDescriptionProvider implements IRepresentationDescriptionPr
                 .labelExpression("Delete from table")
                 .iconURLExpression("/images/graphicalDelete.svg")
                 .body(this.viewBuilders.newChangeContext()
-                        .expression(AQLUtils.getSelfServiceCallExpression("removeFromExposedElements", List.of(IEditingContext.EDITING_CONTEXT, TableDescription.TABLE)))
+                        .expression(ServiceMethod.of2(RTVMutationServices::removeFromExposedElements).aqlSelf(IEditingContext.EDITING_CONTEXT, TableDescription.TABLE))
                         .build())
                 .build();
 


### PR DESCRIPTION
# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [ ] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [ ] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
