### PR TITLE
[fix] Include nested packages in SysML textual export

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -119,6 +119,7 @@ And the following methods have been added:
 
 === Bug fixes
 
+- [export] Fix textual export not including nested packages in the output due to missing `org.eclipse.syson.sysml.Package` import in `SysMLRelationPredicates`.
 - https://github.com/eclipse-syson/syson/issues/1847[#1847] [export] Textual export duplicates "abstract" keyword for `OccurrenceUsage`.
 - https://github.com/eclipse-syson/syson/issues/1887[#1887] [export] Export fails to escape some names when using qualified name.
 - https://github.com/eclipse-syson/syson/issues/1953[#1953] [import] Fix an issue where `TransitionUsage` with `SendActionUsage` were not properly resolved.

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/textual/utils/SysMLRelationPredicates.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/textual/utils/SysMLRelationPredicates.java
@@ -28,6 +28,7 @@ import org.eclipse.syson.sysml.MetadataFeature;
 import org.eclipse.syson.sysml.MetadataUsage;
 import org.eclipse.syson.sysml.OccurrenceUsage;
 import org.eclipse.syson.sysml.OwningMembership;
+import org.eclipse.syson.sysml.Package;
 import org.eclipse.syson.sysml.ReferenceUsage;
 import org.eclipse.syson.sysml.Relationship;
 import org.eclipse.syson.sysml.SuccessionAsUsage;


### PR DESCRIPTION
## Summary

Fixes nested packages being omitted from the SysML textual export output.

## Root Cause

In `SysMLRelationPredicates.java`, the import for `org.eclipse.syson.sysml.Package` was missing. This caused `Package.class` to resolve to `java.lang.Package` instead of the SysML Package type, resulting in nested packages not being recognized during the textual export traversal.

## Fix

Added the missing import:
```java
import org.eclipse.syson.sysml.Package;
```

## Testing

- [x] Export model with nested packages
- [x] Verify nested packages appear in textual output
- [x] Verify re-import produces same structure