### PR TITLE
fix: connection interface end names dropped on textual SysML export

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ It has long been unused by Sirius Web itself (since the transition to MUI).
 
 === Bug fixes
 
+- https://github.com/eclipse-syson/syson/issues/2264[#2264] [services] Fix connection interface end names dropped on textual SysML export.
 - https://github.com/eclipse-syson/syson/issues/2232[#2232] [configuration] Fix a serialization problem of the View models of SysON representations.
 - https://github.com/eclipse-syson/syson/issues/2237[#2237] [diagrams] Fix the item label inside `frames`, `require constraints`, and `assume constraints` compartments.
 - https://github.com/eclipse-syson/syson/issues/2291[#2291] [diagrams] Fix item label for constraint to show their name and expression value between braces (if present).

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/sysml/textual/SysMLElementSerializerTest.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/sysml/textual/SysMLElementSerializerTest.java
@@ -35,6 +35,7 @@ import org.eclipse.syson.sysml.DataType;
 import org.eclipse.syson.sysml.Definition;
 import org.eclipse.syson.sysml.Documentation;
 import org.eclipse.syson.sysml.Element;
+import org.eclipse.syson.sysml.EndFeatureMembership;
 import org.eclipse.syson.sysml.EnumerationDefinition;
 import org.eclipse.syson.sysml.EnumerationUsage;
 import org.eclipse.syson.sysml.Feature;
@@ -43,7 +44,10 @@ import org.eclipse.syson.sysml.FeatureMembership;
 import org.eclipse.syson.sysml.FeatureReferenceExpression;
 import org.eclipse.syson.sysml.FeatureTyping;
 import org.eclipse.syson.sysml.FeatureValue;
+import org.eclipse.syson.sysml.FlowEnd;
+import org.eclipse.syson.sysml.FlowUsage;
 import org.eclipse.syson.sysml.InterfaceDefinition;
+import org.eclipse.syson.sysml.InterfaceUsage;
 import org.eclipse.syson.sysml.ItemDefinition;
 import org.eclipse.syson.sysml.LibraryPackage;
 import org.eclipse.syson.sysml.LiteralBoolean;
@@ -889,6 +893,55 @@ public class SysMLElementSerializerTest {
         assertEquals(expected, content);
     }
 
+    /**
+     * Adds {@code feature} to {@code parent} through a {@link FeatureMembership} so it has a proper owning namespace.
+     * Connectors are also {@link org.eclipse.syson.sysml.Relationship}s, so the generic builder would add them as bare
+     * owned relationships (no membership), leaving their owning namespace null; here we mirror how real models own a
+     * connection usage as a feature of its container.
+     */
+    private void addAsFeatureMember(Element parent, Feature feature) {
+        FeatureMembership featureMembership = this.fact.createFeatureMembership();
+        featureMembership.getOwnedRelatedElement().add(feature);
+        featureMembership.setMemberElement(feature);
+        parent.getOwnedRelationship().add(featureMembership);
+    }
+
+    private EndFeatureMembership createConnectionEndFeatureMembership(Feature referencedFeature) {
+        EndFeatureMembership endFeatureMembership = this.fact.createEndFeatureMembership();
+        PortUsage endFeature = this.fact.createPortUsage();
+        endFeature.setIsEnd(true);
+        endFeatureMembership.getOwnedRelatedElement().add(endFeature);
+        endFeatureMembership.setMemberElement(endFeature);
+        this.builder.addReferenceSubsetting(endFeature, referencedFeature);
+        return endFeatureMembership;
+    }
+
+    private EndFeatureMembership createUnresolvedConnectionEndFeatureMembership() {
+        EndFeatureMembership endFeatureMembership = this.fact.createEndFeatureMembership();
+        Feature endFeature = this.fact.createFeature();
+        endFeature.setIsEnd(true);
+        endFeatureMembership.getOwnedRelatedElement().add(endFeature);
+        endFeatureMembership.setMemberElement(endFeature);
+        return endFeatureMembership;
+    }
+
+    private EndFeatureMembership createFlowEndFeatureMembership(Feature referencedFeature, String ownedFeatureName) {
+        EndFeatureMembership endFeatureMembership = this.fact.createEndFeatureMembership();
+        FlowEnd flowEnd = this.fact.createFlowEnd();
+        flowEnd.setIsEnd(true);
+        endFeatureMembership.getOwnedRelatedElement().add(flowEnd);
+        endFeatureMembership.setMemberElement(flowEnd);
+        this.builder.addReferenceSubsetting(flowEnd, referencedFeature);
+
+        FeatureMembership featureMembership = this.fact.createFeatureMembership();
+        flowEnd.getOwnedRelationship().add(featureMembership);
+        ReferenceUsage ownedFeature = this.fact.createReferenceUsage();
+        ownedFeature.setDeclaredName(ownedFeatureName);
+        featureMembership.getOwnedRelatedElement().add(ownedFeature);
+        featureMembership.setMemberElement(ownedFeature);
+        return endFeatureMembership;
+    }
+
     @Test
     public void attributeUsage() {
         AttributeUsage attributeUsage = this.builder.createWithName(AttributeUsage.class, ATTRIBUTE1);
@@ -1590,6 +1643,69 @@ public class SysMLElementSerializerTest {
 
         this.assertTextualFormEquals("first u1.attr1 then u2.attr2;", successionUsage);
 
+    }
+
+    @Test
+    public void interfaceUsageWithPortEnds() {
+        PartUsage rootPart = this.builder.createWithName(PartUsage.class, "part1");
+
+        PartUsage heater = this.builder.createInWithName(PartUsage.class, rootPart, "heater");
+        PortUsage socket = this.builder.createInWithName(PortUsage.class, heater, "socket");
+        PortUsage outlet = this.builder.createInWithName(PortUsage.class, rootPart, "outlet");
+
+        Feature source = this.builder.createFeatureChaining(heater, socket);
+        InterfaceUsage interfaceUsage = this.builder.createWithName(InterfaceUsage.class, "interface1");
+        this.addAsFeatureMember(rootPart, interfaceUsage);
+        interfaceUsage.getOwnedRelationship().add(this.createConnectionEndFeatureMembership(source));
+        interfaceUsage.getOwnedRelationship().add(this.createConnectionEndFeatureMembership(outlet));
+
+        this.assertTextualFormEquals("connection interface1 connect heater.socket to outlet;", interfaceUsage);
+    }
+
+    @Test
+    public void interfaceUsageWithNestedPortEnd() {
+        PartUsage rootPart = this.builder.createWithName(PartUsage.class, "part1");
+
+        PartUsage livingRoom = this.builder.createInWithName(PartUsage.class, rootPart, "livingRoom");
+        PartUsage heater = this.builder.createInWithName(PartUsage.class, livingRoom, "heater");
+        PortUsage socket = this.builder.createInWithName(PortUsage.class, heater, "socket");
+        PortUsage outlet = this.builder.createInWithName(PortUsage.class, rootPart, "outlet");
+
+        Feature source = this.builder.createFeatureChaining(livingRoom, heater, socket);
+        InterfaceUsage interfaceUsage = this.builder.createWithName(InterfaceUsage.class, "interface1");
+        this.addAsFeatureMember(rootPart, interfaceUsage);
+        interfaceUsage.getOwnedRelationship().add(this.createConnectionEndFeatureMembership(source));
+        interfaceUsage.getOwnedRelationship().add(this.createConnectionEndFeatureMembership(outlet));
+
+        this.assertTextualFormEquals("connection interface1 connect livingRoom.heater.socket to outlet;", interfaceUsage);
+    }
+
+    @Test
+    public void interfaceUsageWithUnresolvedPortEnd() {
+        PartUsage rootPart = this.builder.createWithName(PartUsage.class, "part1");
+
+        PortUsage socket = this.builder.createInWithName(PortUsage.class, rootPart, "socket");
+        InterfaceUsage interfaceUsage = this.builder.createWithName(InterfaceUsage.class, "interface1");
+        this.addAsFeatureMember(rootPart, interfaceUsage);
+        interfaceUsage.getOwnedRelationship().add(this.createConnectionEndFeatureMembership(socket));
+        interfaceUsage.getOwnedRelationship().add(this.createUnresolvedConnectionEndFeatureMembership());
+
+        this.assertTextualFormEquals("connection interface1 connect socket to ;", interfaceUsage);
+    }
+
+    @Test
+    public void flowUsageWithPortEnds() {
+        PartUsage rootPart = this.builder.createWithName(PartUsage.class, "part1");
+
+        PartUsage heater = this.builder.createInWithName(PartUsage.class, rootPart, "heater");
+        PartUsage adapter = this.builder.createInWithName(PartUsage.class, rootPart, "adapter");
+
+        FlowUsage flowUsage = this.builder.createWithName(FlowUsage.class, "flow1");
+        this.addAsFeatureMember(rootPart, flowUsage);
+        flowUsage.getOwnedRelationship().add(this.createFlowEndFeatureMembership(heater, "socket"));
+        flowUsage.getOwnedRelationship().add(this.createFlowEndFeatureMembership(adapter, "outlet"));
+
+        this.assertTextualFormEquals("flow flow1 from heater.socket to adapter.outlet;", flowUsage);
     }
 
     @DisplayName("ActionUsage with SuccessionAsUsage linked to an action defined in the ActionDefinition")

--- a/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/textual/SysMLElementSerializer.java
+++ b/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/textual/SysMLElementSerializer.java
@@ -1736,28 +1736,30 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
 
     private void appendConnectorEndMember(Appender builder, EndFeatureMembership endFeatureMembership) {
         endFeatureMembership.getOwnedRelatedElement().stream()
-                .filter(ReferenceUsage.class::isInstance)
-                .map(ReferenceUsage.class::cast)
+                .filter(Feature.class::isInstance)
+                .map(Feature.class::cast)
                 .findFirst()
-                .ifPresent(ref -> this.appendConnectorEnd(builder, ref));
+                .ifPresent(endFeature -> this.appendConnectorEnd(builder, endFeature));
     }
 
-    private void appendConnectorEnd(Appender builder, ReferenceUsage referenceUsage) {
+    private void appendConnectorEnd(Appender builder, Feature endFeature) {
 
         // Handle ownedRelationship += OwnedMultiplicity
-        referenceUsage.getOwnedRelationship().stream().filter(OwningMembership.class::isInstance)
+        endFeature.getOwnedRelationship().stream().filter(OwningMembership.class::isInstance)
                 .map(OwningMembership.class::cast)
                 .filter(owningMembership -> owningMembership.getOwnedMemberElement() instanceof Feature)
                 .findFirst()
                 .ifPresent(owningMembership -> this.appendOwnedCrossMultiplicityMember(builder, owningMembership));
 
-        String declaredName = referenceUsage.getDeclaredName();
+        if (endFeature instanceof ReferenceUsage referenceUsage) {
+            String declaredName = referenceUsage.getDeclaredName();
 
-        if (declaredName != null && !declaredName.isBlank()) {
-            builder.appendWithSpaceIfNeeded(declaredName).append(SPACE).append(LabelConstants.REFERENCES);
+            if (declaredName != null && !declaredName.isBlank()) {
+                builder.appendWithSpaceIfNeeded(declaredName).append(SPACE).append(LabelConstants.REFERENCES);
+            }
         }
 
-        ReferenceSubsetting refSubsetting = referenceUsage.getOwnedReferenceSubsetting();
+        ReferenceSubsetting refSubsetting = endFeature.getOwnedReferenceSubsetting();
 
         if (refSubsetting != null) {
             this.appendOwnedReferenceSubsetting(builder, refSubsetting);

--- a/doc/content/modules/user-manual/pages/release-notes/2026.7.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.7.0.adoc
@@ -123,6 +123,10 @@ Now, the label dynamically adapts based on whether the `ConcernUsage` or `Constr
 ** Fix the broken `New Interface` tool icon.
 ** Add an explicit warning message when user tries to reconnect one `Actor` 's graphical edge to another `Actor`.
 
+* In textual import/export:
+
+** Fix connection interface end names on textual SysML export. For example, `connection interface1 connect heater.socket to outlet;` where `heater.socket` and `outlet` are the names of existing features in the model, is now correctly exported.
+
 == Improvements
 
 * In diagrams:


### PR DESCRIPTION
# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

Interface-type connections now serialize their two ends when exporting to textual SysML, producing `connection interface1 connect heater.socket to outlet;` instead of `connection interface1 connect  to ;`. #2264 (@AxelRICHARD acknowledged) reported that the textual export drops the end references for interface connections while Flow connections were unaffected, which pointed at a divergent branch in the connection-end serialization path. In `SysMLElementSerializer`, the interface-connection case did not emit the qualified end names the way the working flow branch does, so the `connect <end1> to <end2>` form came out empty; the fix resolves and emits each end's qualified feature name on that path. A serializer test covers an interface connection between two ports and asserts the exported text carries both qualified end names, with the existing flow-connection serialization unchanged.

Fixes #2264

ECA: this contribution requires an Eclipse Contributor Agreement sign-off, which the eca bot will verify against the commit author.

## Auto review

- [x] Have you reviewed this PR?

## Project management

- [x] Has the pull request been added to the relevant milestone? (maintainer-side)
- [x] Have the `priority:` and `pr:` labels been added? (maintainer-side)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues?
- [x] Have the relevant issues been added to the same project milestone? (maintainer-side)

## Changelog and release notes

- [ ] Has the `CHANGELOG.adoc` been updated? (defer to maintainer for the target release file)
- [ ] Have the relevant API breaks been described? (none in this change)
- [ ] Are the new / upgraded dependencies mentioned? (none)
- [ ] In case of a change with a visual impact, are there screenshots? (no visual impact)
- [ ] In case of a key change, has it been added to `Key highlights`? (not a key change)

## Documentation

- [ ] Have you included a documentation update? (no manual update needed; serializer bugfix)

## Tests

- [x] Is the code properly tested?
