### PR TITLE
[2284] Move expression-related tools in diagram palette into the default Edit section

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -51,6 +51,7 @@ Users should use the dedicated tools to edit expressions instead, as they ensure
 - https://github.com/eclipse-syson/syson/issues/2301[#2301] [diagram] Constraint nodes now display their corresponding expression directly in their label if it is set.
 - https://github.com/eclipse-syson/syson/issues/2292[#2292] [diagrams] Add inheritance of "Behavior" and "Step" graphical elements in list items.
 It concerns, at least, _actions_ and _items_ compartments list items.
+- https://github.com/eclipse-syson/syson/issues/2284[#2284] [diagrams] The expression-related tools in diagram palette are now available in the default _Edit_ section.
 
 === New features
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/expressions/services/ExpressionsPaletteToolsProvider.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/expressions/services/ExpressionsPaletteToolsProvider.java
@@ -62,9 +62,9 @@ public class ExpressionsPaletteToolsProvider implements IPaletteToolsProvider {
 
     private static final String DELETE_EXPRESSION_TOOL_LABEL = "Delete expression";
 
-    private static final String EXPRESSION_TOOL_SECTION_ID = "toolSection_expression";
+    private static final String EXPRESSION_TOOL_SECTION_ID = "edit-section";
 
-    private static final String EXPRESSION_TOOL_SECTION_LABEL = "Expression";
+    private static final String EXPRESSION_TOOL_SECTION_LABEL = "Edit";
 
     private final IObjectSearchService objectSearchService;
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/ImagePathService.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/ImagePathService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class ImagePathService implements IImagePathService {
 
-    private static final List<String> IMAGES_PATHS = List.of("/img", "/images", "/icons");
+    private static final List<String> IMAGES_PATHS = List.of("/img", "/images", "/icons", "/palette");
 
     @Override
     public List<String> getPaths() {

--- a/backend/application/syson-application-configuration/src/main/resources/palette/create.svg
+++ b/backend/application/syson-application-configuration/src/main/resources/palette/create.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/interconnection/view/IVInterconnectionCompartmentToolsTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/interconnection/view/IVInterconnectionCompartmentToolsTests.java
@@ -113,8 +113,8 @@ public class IVInterconnectionCompartmentToolsTests extends AbstractIntegrationT
             assertThat(quickToolsLabels).hasSize(4);
             assertThat(quickToolsLabels).containsSequence("Pin", "Adjust size", "Fade", "Hide");
             List<String> paletteEntriesLabels = JsonPath.read(result.data(), "$.data.viewer.editingContext.representation.description.palette.paletteEntries[*].label");
-            assertThat(paletteEntriesLabels).hasSize(6);
-            assertThat(paletteEntriesLabels).containsSequence("Requirements", "Structure", "Show/Hide", "Related Elements", "Edit", "Expression");
+            assertThat(paletteEntriesLabels).hasSize(5);
+            assertThat(paletteEntriesLabels).containsSequence("Requirements", "Structure", "Show/Hide", "Related Elements", "Edit");
 
             List<String> paletteRequirementsSectionToolsLabels = JsonPath.read(result.data(), "$.data.viewer.editingContext.representation.description.palette.paletteEntries[0].tools[*].label");
             assertThat(paletteRequirementsSectionToolsLabels).hasSize(1);

--- a/doc/content/modules/user-manual/pages/features/expressions.adoc
+++ b/doc/content/modules/user-manual/pages/features/expressions.adoc
@@ -29,7 +29,7 @@ To _create_ an expression, invoke the _New expression_ action on a compatible el
 The action is only available on elements which _can_ own an expression but do not have one yet.
 
 * In the {explorer} view, this is available in the element's context menu.
-* In a _Diagram_, it is available in the _Expression_ section of the element's palette (if applicable).
+* In a _Diagram_, it is available in the _Edit_ section of the element's palette (if applicable).
 * In the {details} view, it is available as a `+` button on the _Expression value_ widget (if present).
 
 A modal will open where you can enter the textual representation of the expression to create.
@@ -46,7 +46,7 @@ image::edit-expression-modal-error.png[Edit expression modal showing an error me
 
 To edit an already existing expression, invoke the _Edit expression_ action directly on the existing expression or on its parent element.
 In the {explorer} view, this is available in the element's context menu.
-In a _Diagram_, it is avilable in the _Expression_ section of the element's palette (if applicable).
+In a _Diagram_, it is avilable in the _Edit_ section of the element's palette (if applicable).
 
 The same modal as for expression creation will open, but with the current textual representation of the expression pre-filled.
 

--- a/frontend/syson-components/src/extensions/expressions/DeleteExpressionDiagramToolOverriddenContribution.tsx
+++ b/frontend/syson-components/src/extensions/expressions/DeleteExpressionDiagramToolOverriddenContribution.tsx
@@ -10,10 +10,9 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
-import { useDeletionConfirmationDialog } from '@eclipse-sirius/sirius-components-core';
+import { IconOverlay, useDeletionConfirmationDialog } from '@eclipse-sirius/sirius-components-core';
 import { DiagramContext, DiagramContextValue, EdgeData, NodeData } from '@eclipse-sirius/sirius-components-diagrams';
 import { PaletteToolContributionComponentProps, usePalette } from '@eclipse-sirius/sirius-components-palette';
-import DeleteIcon from '@mui/icons-material/Delete';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -76,6 +75,9 @@ export const DeleteExpressionDiagramToolOverriddenContribution = ({
     });
   };
 
+  const toolLabel = 'Delete Expression';
+  const toolIconURL = '/api/images/diagram-images/semanticDelete.svg';
+
   return (
     <ListItemButton
       key="overridden_tool_delete_expression"
@@ -84,9 +86,9 @@ export const DeleteExpressionDiagramToolOverriddenContribution = ({
       disabled={readOnly}
       className={classes.listItemButton}>
       <ListItemIcon className={classes.listItemIcon}>
-        <DeleteIcon fontSize="small" />
+        <IconOverlay iconURLs={[toolIconURL]} alt={toolLabel} customIconHeight={16} customIconWidth={16} />
       </ListItemIcon>
-      <ListItemText primary={'Delete expression'} className={classes.listItemText} />
+      <ListItemText primary={toolLabel} className={classes.listItemText} />
     </ListItemButton>
   );
 };

--- a/frontend/syson-components/src/extensions/expressions/EditExpressionDiagramToolOverriddenContribution.tsx
+++ b/frontend/syson-components/src/extensions/expressions/EditExpressionDiagramToolOverriddenContribution.tsx
@@ -10,9 +10,9 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+import { IconOverlay } from '@eclipse-sirius/sirius-components-core';
 import { DiagramContext, DiagramContextValue, EdgeData, NodeData } from '@eclipse-sirius/sirius-components-diagrams';
 import { PaletteToolContributionComponentProps, usePalette } from '@eclipse-sirius/sirius-components-palette';
-import EditIcon from '@mui/icons-material/Edit';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -84,6 +84,9 @@ export const EditExpressionDiagramToolOverriddenContribution = ({
     );
   }
 
+  const toolLabel = 'Edit Expression';
+  const toolIconURL = '/api/images/diagram-images/edit.svg';
+
   return (
     <Fragment key="overridden_tool_edit_expression">
       <ListItemButton
@@ -92,9 +95,9 @@ export const EditExpressionDiagramToolOverriddenContribution = ({
         disabled={readOnly}
         className={classes.listItemButton}>
         <ListItemIcon className={classes.listItemIcon}>
-          <EditIcon fontSize="small" />
+          <IconOverlay iconURLs={[toolIconURL]} alt={toolLabel} customIconHeight={16} customIconWidth={16} />
         </ListItemIcon>
-        <ListItemText primary="Edit expression" className={classes.listItemText} />
+        <ListItemText primary={toolLabel} className={classes.listItemText} />
       </ListItemButton>
       {modalElement}
     </Fragment>

--- a/frontend/syson-components/src/extensions/expressions/NewExpressionDiagramToolOverriddenContribution.tsx
+++ b/frontend/syson-components/src/extensions/expressions/NewExpressionDiagramToolOverriddenContribution.tsx
@@ -10,9 +10,9 @@
  * Contributors:
  *     Obeo - initial API and implementation
  *******************************************************************************/
+import { IconOverlay } from '@eclipse-sirius/sirius-components-core';
 import { DiagramContext, DiagramContextValue, EdgeData, NodeData } from '@eclipse-sirius/sirius-components-diagrams';
 import { PaletteToolContributionComponentProps, usePalette } from '@eclipse-sirius/sirius-components-palette';
-import AddIcon from '@mui/icons-material/Add';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -84,6 +84,9 @@ export const NewExpressionDiagramToolOverriddenContribution = ({
     );
   }
 
+  const toolLabel = 'New Expression';
+  const toolIconURL = '/api/images/palette/create.svg';
+
   return (
     <Fragment key="new-overridden_tool_new_expression-modal-contribution">
       <ListItemButton
@@ -92,9 +95,9 @@ export const NewExpressionDiagramToolOverriddenContribution = ({
         disabled={readOnly}
         className={classes.listItemButton}>
         <ListItemIcon className={classes.listItemIcon}>
-          <AddIcon fontSize="small" />
+          <IconOverlay iconURLs={[toolIconURL]} alt={toolLabel} customIconHeight={16} customIconWidth={16} />
         </ListItemIcon>
-        <ListItemText primary={'New Expression'} className={classes.listItemText} />
+        <ListItemText primary={toolLabel} className={classes.listItemText} />
       </ListItemButton>
       {modalElement}
     </Fragment>


### PR DESCRIPTION
Needs a Sirius Web 2026.5.3 with [this change](https://github.com/eclipse-sirius/sirius-web/commit/53f2748c19052a12c3f02b1a75eb8641fcca3b77) to be released for this to be mergeable.

Bug: https://github.com/eclipse-syson/syson/issues/2284
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
