### PR TITLE
[2386] Fix the inheritance of PortUsage as end in ends compartment

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -98,6 +98,7 @@ It has long been unused by Sirius Web itself (since the transition to MUI).
 The initial value is now an empty string instead of the computed display label, so validating it without changes no longer writes the display label into the element's declared name.
 - https://github.com/eclipse-syson/syson/issues/2342[#2342] [diagrams] Fix the creation of `Succession` and `Transition` elements from _New Succession_ and _New Transition_ graphical edge tools.
 The problem was that the `Succession` and `Transition` were created in the wrong container, which was the `ViewUsage` instead of the common ancestor `Element` containing the source and target.
+- https://github.com/eclipse-syson/syson/issues/2386[#2386] [diagrams] Fix inheritance of `PortUsage as end` in _ends_ compartment of `InterfaceDefinition` graphical node.
 
 === Improvements
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVInterfaceDefinitionEndsCompartmentItemInheritanceTests.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/controllers/diagrams/general/view/GVInterfaceDefinitionEndsCompartmentItemInheritanceTests.java
@@ -1,0 +1,192 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.controllers.diagrams.general.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.sirius.components.diagrams.tests.DiagramEventPayloadConsumer.assertRefreshedDiagramThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramEventInput;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.DiagramRefreshedEventPayload;
+import org.eclipse.sirius.components.collaborative.diagrams.dto.ToolVariable;
+import org.eclipse.sirius.components.diagrams.Diagram;
+import org.eclipse.sirius.components.diagrams.tests.navigation.DiagramNavigator;
+import org.eclipse.sirius.components.view.emf.diagram.IDiagramIdProvider;
+import org.eclipse.sirius.web.tests.services.api.IGivenInitialServerState;
+import org.eclipse.syson.AbstractIntegrationTests;
+import org.eclipse.syson.application.controllers.diagrams.checkers.CheckDiagramElementCount;
+import org.eclipse.syson.application.controllers.diagrams.testers.EdgeCreationTester;
+import org.eclipse.syson.application.controllers.diagrams.testers.ToolTester;
+import org.eclipse.syson.application.data.GeneralViewWithTopNodesTestProjectData;
+import org.eclipse.syson.services.diagrams.DiagramComparator;
+import org.eclipse.syson.services.diagrams.DiagramDescriptionIdProvider;
+import org.eclipse.syson.services.diagrams.api.IGivenDiagramDescription;
+import org.eclipse.syson.services.diagrams.api.IGivenDiagramSubscription;
+import org.eclipse.syson.standard.diagrams.view.SDVDescriptionNameGenerator;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.eclipse.syson.tests.api.GivenSysONServer;
+import org.eclipse.syson.util.IDescriptionNameGenerator;
+import org.eclipse.syson.util.SysONRepresentationDescriptionIdentifiers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+/**
+ * Tests the inheritance of PortUsage as end inside ends compartment of InterfaceDefinition.
+ *
+ * @author Jerome Gout
+ */
+@Transactional
+@GivenSysONServer({ GeneralViewWithTopNodesTestProjectData.SCRIPT_PATH })
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class GVInterfaceDefinitionEndsCompartmentItemInheritanceTests extends AbstractIntegrationTests {
+
+    private final IDescriptionNameGenerator descriptionNameGenerator = new SDVDescriptionNameGenerator();
+
+    @Autowired
+    private IGivenInitialServerState givenInitialServerState;
+
+    @Autowired
+    private IGivenDiagramDescription givenDiagramDescription;
+
+    @Autowired
+    private IGivenDiagramSubscription givenDiagramSubscription;
+
+    @Autowired
+    private IDiagramIdProvider diagramIdProvider;
+
+    @Autowired
+    private ToolTester toolTester;
+
+    @Autowired
+    private EdgeCreationTester edgeCreationTester;
+
+    @Autowired
+    private DiagramComparator diagramComparator;
+
+    private Flux<DiagramRefreshedEventPayload> givenSubscriptionToDiagram() {
+        var diagramEventInput = new DiagramEventInput(UUID.randomUUID(),
+                GeneralViewWithTopNodesTestProjectData.EDITING_CONTEXT_ID,
+                GeneralViewWithTopNodesTestProjectData.GraphicalIds.DIAGRAM_ID);
+        return this.givenDiagramSubscription.subscribe(diagramEventInput);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        this.givenInitialServerState.initialize();
+    }
+
+    @DisplayName("GIVEN a base InterfaceDefinition with a port as end, WHEN a InterfaceDefinition is subclassifying the base InterfaceDefinition, THEN the InterfaceDefinition ends are inherited from the base InterfaceDefinition")
+    @Test
+    public void checkActionDefinitionParameterFilter() {
+        var flux = this.givenSubscriptionToDiagram();
+        var diagramDescription = this.givenDiagramDescription.getDiagramDescription(GeneralViewWithTopNodesTestProjectData.EDITING_CONTEXT_ID,
+                SysONRepresentationDescriptionIdentifiers.GENERAL_VIEW_DIAGRAM_DESCRIPTION_ID);
+        var diagramDescriptionIdProvider = new DiagramDescriptionIdProvider(diagramDescription, this.diagramIdProvider);
+
+        AtomicReference<Diagram> diagram = new AtomicReference<>();
+        Consumer<Object> initialDiagramContentConsumer = assertRefreshedDiagramThat(diagram::set);
+
+        List<ToolVariable> toolVariables = new ArrayList<>();
+        // Create an element in the base element to inherit
+        String createPortAsEndToolId = diagramDescriptionIdProvider.getNodeToolId(this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getInterfaceDefinition()), "New Port as end");
+        Runnable newCreationTool = () -> this.toolTester.invokeTool(GeneralViewWithTopNodesTestProjectData.EDITING_CONTEXT_ID, diagram.get().getId(), GeneralViewWithTopNodesTestProjectData.GraphicalIds.INTERFACE_DEFINITION_ID, createPortAsEndToolId, toolVariables);
+        Consumer<Object> createdPortAsEndDiagramConsumer = assertRefreshedDiagramThat(newDiagram -> {
+            new CheckDiagramElementCount(this.diagramComparator)
+                    .hasNewBorderNodeCount(1) // The port is displayed as a border node
+                    .hasNewNodeCount(3) // The new port is displayed in both ends and ports compartments + as border node.
+                    .hasNewEdgeCount(0)
+                    .check(diagram.get(), newDiagram);
+
+            var portsCompartment = new DiagramNavigator(newDiagram)
+                    .nodeWithId(GeneralViewWithTopNodesTestProjectData.GraphicalIds.INTERFACE_DEFINITION_ID)
+                    .childNodeWithLabel("ports")
+                    .getNode();
+            assertThat(portsCompartment.getChildNodes()).hasSize(1);
+            assertThat(portsCompartment.getChildNodes().getFirst().getInsideLabel().getText()).isEqualTo("port1"); // The created element has the expected name
+            var endsCompartment = new DiagramNavigator(newDiagram)
+                    .nodeWithId(GeneralViewWithTopNodesTestProjectData.GraphicalIds.INTERFACE_DEFINITION_ID)
+                    .childNodeWithLabel("ends")
+                    .getNode();
+            assertThat(endsCompartment.getChildNodes()).hasSize(1);
+            assertThat(endsCompartment.getChildNodes().getFirst().getInsideLabel().getText()).isEqualTo("port1"); // The created element has the expected name
+            diagram.set(newDiagram);
+        });
+
+
+        // Create a new element that will inherit from the base element
+        AtomicReference<String> newInterfaceDefinitionNodeId = new AtomicReference<>();
+        String createInterfaceDefinitionToolId = diagramDescriptionIdProvider.getDiagramCreationToolId("New Interface Definition");
+        Runnable createInterfaceDefinitionRunnable = () -> this.toolTester.invokeTool(GeneralViewWithTopNodesTestProjectData.EDITING_CONTEXT_ID, diagram, null, createInterfaceDefinitionToolId);
+        Consumer<Object> createdActionDefinitionDiagramConsumer = assertRefreshedDiagramThat(newDiagram -> {
+            new CheckDiagramElementCount(this.diagramComparator)
+                    .hasNewBorderNodeCount(2) // source and target as border nodes
+                    .hasNewNodeCount(3) // The new InterfaceDefinition is created + source and target nodes
+                    .hasNewEdgeCount(0)
+                    .check(diagram.get(), newDiagram, true);
+            var newNodes = this.diagramComparator.newNodes(diagram.get(), newDiagram);
+            newInterfaceDefinitionNodeId.set(newNodes.getFirst().getId());
+            diagram.set(newDiagram);
+        });
+
+
+        // Create the specialization between the newly created element and the base element
+        String createFeatureTypeToolId = diagramDescriptionIdProvider.getEdgeCreationToolId(GVInterfaceDefinitionEndsCompartmentItemInheritanceTests.this.descriptionNameGenerator.getNodeName(SysmlPackage.eINSTANCE.getInterfaceDefinition()), "New Subclassification");
+        Runnable createFeatureTyping = () -> GVInterfaceDefinitionEndsCompartmentItemInheritanceTests.this.edgeCreationTester.createEdgeUsingNodeId(GeneralViewWithTopNodesTestProjectData.EDITING_CONTEXT_ID, diagram, newInterfaceDefinitionNodeId.get(), GeneralViewWithTopNodesTestProjectData.GraphicalIds.INTERFACE_DEFINITION_ID, createFeatureTypeToolId);
+
+        // Check new created element inherits from the base element, and thus, contains a list item with '^' in its label
+        Consumer<Object> createFeatureTypeDiagramConsumer = assertRefreshedDiagramThat(newDiagram -> {
+            new CheckDiagramElementCount(GVInterfaceDefinitionEndsCompartmentItemInheritanceTests.this.diagramComparator)
+                    .hasNewBorderNodeCount(1)
+                    .hasNewNodeCount(3) // ^port1 in both ports and ends compartments + ^port as border node
+                    .hasNewEdgeCount(1) // The specialization edge
+                    .check(diagram.get(), newDiagram);
+
+            var endsCompartment = new DiagramNavigator(newDiagram)
+                    .nodeWithId(newInterfaceDefinitionNodeId.get())
+                    .childNodeWithLabel("ends")
+                    .getNode();
+            assertThat(endsCompartment.getChildNodes()).hasSize(3);
+            assertThat(endsCompartment.getChildNodes().getFirst().getInsideLabel().getText()).isEqualTo("^" + "port1"); // The inheriting element has the same name prefixed with '^'
+            var portsCompartment = new DiagramNavigator(newDiagram)
+                    .nodeWithId(newInterfaceDefinitionNodeId.get())
+                    .childNodeWithLabel("ports")
+                    .getNode();
+            assertThat(portsCompartment.getChildNodes()).hasSize(3);
+            assertThat(portsCompartment.getChildNodes().getFirst().getInsideLabel().getText()).isEqualTo("^" + "port1"); // The inheriting element has the same name prefixed with '^'
+        });
+
+        StepVerifier.create(flux)
+                .consumeNextWith(initialDiagramContentConsumer)
+                .then(newCreationTool)
+                .consumeNextWith(createdPortAsEndDiagramConsumer)
+                .then(createInterfaceDefinitionRunnable)
+                .consumeNextWith(createdActionDefinitionDiagramConsumer)
+                .then(createFeatureTyping)
+                .consumeNextWith(createFeatureTypeDiagramConsumer)
+                .thenCancel()
+                .verify(Duration.ofSeconds(10));
+    }
+}

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/application/data/GeneralViewWithTopNodesTestProjectData.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/application/data/GeneralViewWithTopNodesTestProjectData.java
@@ -50,6 +50,8 @@ public class GeneralViewWithTopNodesTestProjectData {
 
         public static final String ITEM_USAGE_ID = "78a84b8a-e91c-3338-b447-864793773dd9";
 
+        public static final String INTERFACE_DEFINITION_ID = "3991a939-b68e-3505-9fd4-fda25147b35b";
+
         public static final String INTERFACE_USAGE_ID = "6bc0765c-4f9f-3a9e-ab45-3d717519535c";
 
         public static final String PART_DEFINITION_ID = "fa617798-658e-3812-92f2-52e2fc39f851";

--- a/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/InheritedCompartmentItemFilterSwitch.java
+++ b/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/InheritedCompartmentItemFilterSwitch.java
@@ -30,6 +30,7 @@ import org.eclipse.syson.sysml.ObjectiveMembership;
 import org.eclipse.syson.sysml.OwningMembership;
 import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.PerformActionUsage;
+import org.eclipse.syson.sysml.PortUsage;
 import org.eclipse.syson.sysml.ReferenceUsage;
 import org.eclipse.syson.sysml.RequirementConstraintKind;
 import org.eclipse.syson.sysml.RequirementConstraintMembership;
@@ -189,6 +190,21 @@ public class InheritedCompartmentItemFilterSwitch extends SysmlSwitch<Boolean> {
             result = this.isInheritedAction(object);
         } else {
             result = super.casePerformActionUsage(object);
+        }
+        return result;
+    }
+
+    @Override
+    public Boolean casePortUsage(PortUsage object) {
+        final boolean result;
+        if (this.eReference.equals(SysmlPackage.eINSTANCE.getInterfaceDefinition_InterfaceEnd())) {
+            // we are dealing with interface end
+            // the given PortUsage is an end if it has the isEnd property set.
+            result = object.isIsEnd();
+        } else {
+            EClassifier eType = this.eReference.getEType();
+            EClass eClass = object.eClass();
+            result = eType.equals(eClass) || (eType instanceof EClass eTypeEClass && eTypeEClass.isSuperTypeOf(eClass));
         }
         return result;
     }

--- a/backend/services/syson-model-services/src/main/java/org/eclipse/syson/model/services/aql/ModelQueryAQLService.java
+++ b/backend/services/syson-model-services/src/main/java/org/eclipse/syson/model/services/aql/ModelQueryAQLService.java
@@ -25,7 +25,9 @@ import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.Feature;
 import org.eclipse.syson.sysml.FeatureValue;
 import org.eclipse.syson.sysml.FramedConcernMembership;
+import org.eclipse.syson.sysml.InterfaceDefinition;
 import org.eclipse.syson.sysml.Namespace;
+import org.eclipse.syson.sysml.PortUsage;
 import org.eclipse.syson.sysml.RequirementConstraintMembership;
 import org.eclipse.syson.sysml.TransitionUsage;
 import org.eclipse.syson.sysml.metamodel.services.MetamodelQueryElementService;
@@ -150,5 +152,12 @@ public class ModelQueryAQLService {
      */
     public List<ConcernUsage> getFramedConcerns(Namespace namespace) {
         return this.metamodelQueryElementService.getFramedConcerns(namespace);
+    }
+
+    /**
+     * {{@link MetamodelQueryElementService#getInterfaceEnds(InterfaceDefinition)}}.
+     */
+    public List<PortUsage> getInterfaceEnds(InterfaceDefinition interfaceDefinition) {
+        return this.metamodelQueryElementService.getInterfaceEnds(interfaceDefinition);
     }
 }

--- a/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/MetamodelQueryElementService.java
+++ b/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/MetamodelQueryElementService.java
@@ -35,9 +35,11 @@ import org.eclipse.syson.sysml.FeatureChaining;
 import org.eclipse.syson.sysml.FeatureReferenceExpression;
 import org.eclipse.syson.sysml.FeatureValue;
 import org.eclipse.syson.sysml.FramedConcernMembership;
+import org.eclipse.syson.sysml.InterfaceDefinition;
 import org.eclipse.syson.sysml.Namespace;
 import org.eclipse.syson.sysml.OwningMembership;
 import org.eclipse.syson.sysml.PartUsage;
+import org.eclipse.syson.sysml.PortUsage;
 import org.eclipse.syson.sysml.Redefinition;
 import org.eclipse.syson.sysml.ReferenceUsage;
 import org.eclipse.syson.sysml.Relationship;
@@ -519,5 +521,24 @@ public class MetamodelQueryElementService {
                     .forEach(framedConcerns::add);
         }
         return framedConcerns;
+    }
+
+    /**
+     * Retrieves interface ends ({@link PortUsage}) of the given {@link InterfaceDefinition}.
+     * <p>
+     *     The {@link InterfaceDefinition#getInterfaceEnd()} is not suitable because it collects inherited interface ends as well.
+     *     We are only looking for direct owned interface ends of the given {@link InterfaceDefinition}.
+     * </p>
+     * @param interfaceDefinition an {@link InterfaceDefinition}
+     * @return the list of {@link PortUsage} defined as end of the given interface.
+     */
+    public List<PortUsage> getInterfaceEnds(InterfaceDefinition interfaceDefinition) {
+        List<PortUsage> interfaceEnds = new ArrayList<>();
+        interfaceDefinition.getOwnedFeature().stream()
+                .filter(Feature::isIsEnd)
+                .filter(PortUsage.class::isInstance)
+                .map(PortUsage.class::cast)
+                .forEach(interfaceEnds::add);
+        return interfaceEnds;
     }
 }

--- a/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/InterfaceDefinitionEndsCompartmentItemNodeDescriptionProvider.java
+++ b/backend/views/syson-standard-diagrams-view/src/main/java/org/eclipse/syson/standard/diagrams/view/nodes/InterfaceDefinitionEndsCompartmentItemNodeDescriptionProvider.java
@@ -35,6 +35,6 @@ public class InterfaceDefinitionEndsCompartmentItemNodeDescriptionProvider exten
 
     @Override
     protected String getSemanticCandidateExpression() {
-        return AQLConstants.AQL_SELF + "." + this.eReference.getName() + "->select(endElt | not endElt.isFromStandardLibrary())";
+        return AQLConstants.AQL_SELF + ".getInterfaceEnds()->select(endElt | not endElt.isFromStandardLibrary())";
     }
 }

--- a/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
@@ -23,6 +23,7 @@
 
 ** Fix dropping a nested `AttributeUsage` from the _Explorer_ onto a _General View_ diagram so it is visible on the first drop.
 ** Fix `Comment` graphical nodes so changing their background color no longer changes their border color.
+** Fix the support of `PortUsage` as end inheritance in _ends_ compartment of `InterfaceDefinition` graphical node.
 
 * In all views:
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/2386

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
