### PR TITLE
[2419] Export the metadata of the ends of a connector declared inline

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -47,6 +47,8 @@ It is now _Become nested Concern_ instead of _Become nested Requirement_.
 Following KerML, where `endFeature` is defined as the owned features having `isEnd = true`, the ends owned through a plain `FeatureMembership` are now collected as well, and not only those owned through an `EndFeatureMembership`.
 This also fixes `relatedFeature`, `sourceFeature` and `targetFeature`, which were all empty for such connections.
 - https://github.com/eclipse-syson/syson/issues/2226[#2226] [import] Fix textual import of annotations on relationships so their `annotatedElement` is set and they are returned by `Element#getOwnedAnnotation()`.
+- https://github.com/eclipse-syson/syson/issues/2419[#2419] [export] Fix the export of the prefix metadata carried by the ends of a connector, which were dropped when those ends are declared inline.
+The ends of a connector created from a diagram are owned through an `EndFeatureMembership` and are exported inline, so their metadata, such as the `#original` and `#derive` of a requirement derivation, were lost.
 
 === Improvements
 

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/sysml/textual/SysMLElementSerializerTest.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/sysml/textual/SysMLElementSerializerTest.java
@@ -1681,6 +1681,51 @@ public class SysMLElementSerializerTest {
     }
 
     @Test
+    public void connectionUsageWithMetadataOnItsEnds() {
+        PartUsage rootPart = this.builder.createWithName(PartUsage.class, "owner1");
+
+        PortUsage socket = this.builder.createInWithName(PortUsage.class, rootPart, "socket");
+        PortUsage outlet = this.builder.createInWithName(PortUsage.class, rootPart, "outlet");
+
+        InterfaceUsage interfaceUsage = this.builder.createWithName(InterfaceUsage.class, "interface1");
+        this.addAsFeatureMember(rootPart, interfaceUsage);
+
+        EndFeatureMembership sourceEnd = this.createConnectionEndFeatureMembership(socket);
+        this.applyMetadataOnEnd(sourceEnd, "original");
+        EndFeatureMembership targetEnd = this.createConnectionEndFeatureMembership(outlet);
+        this.applyMetadataOnEnd(targetEnd, "derive");
+        interfaceUsage.getOwnedRelationship().add(sourceEnd);
+        interfaceUsage.getOwnedRelationship().add(targetEnd);
+
+        this.assertTextualFormEquals("connection interface1 connect #original socket to #derive outlet;", interfaceUsage);
+    }
+
+    /**
+     * Applies a prefix metadata on the end owned by the given membership, the way {@code #original} and {@code #derive}
+     * are applied on the ends of a requirement derivation.
+     */
+    private void applyMetadataOnEnd(EndFeatureMembership endFeatureMembership, String metadataDefinitionName) {
+        MetadataDefinition metadataDefinition = this.fact.createMetadataDefinition();
+        metadataDefinition.setDeclaredName(metadataDefinitionName);
+
+        MetadataUsage metadataUsage = this.fact.createMetadataUsage();
+        OwningMembership owningMembership = this.fact.createOwningMembership();
+        owningMembership.getOwnedRelatedElement().add(metadataUsage);
+        owningMembership.setMemberElement(metadataUsage);
+
+        FeatureTyping featureTyping = this.fact.createFeatureTyping();
+        featureTyping.setType(metadataDefinition);
+        featureTyping.setTypedFeature(metadataUsage);
+        metadataUsage.getOwnedRelationship().add(featureTyping);
+
+        endFeatureMembership.getOwnedRelatedElement().stream()
+                .filter(Feature.class::isInstance)
+                .map(Feature.class::cast)
+                .findFirst()
+                .ifPresent(endFeature -> endFeature.getOwnedRelationship().add(owningMembership));
+    }
+
+    @Test
     public void interfaceUsageWithUnresolvedPortEnd() {
         PartUsage rootPart = this.builder.createWithName(PartUsage.class, "part1");
 

--- a/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/textual/SysMLElementSerializer.java
+++ b/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/textual/SysMLElementSerializer.java
@@ -1743,6 +1743,9 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
     }
 
     private void appendConnectorEnd(Appender builder, Feature endFeature) {
+        // Prefix metadata of the end, such as the #original and #derive of a requirement derivation. Without this the
+        // metadata of an end owned through an EndFeatureMembership would be dropped by the export.
+        this.appendExtensionKeyword(builder, endFeature);
 
         // Handle ownedRelationship += OwnedMultiplicity
         endFeature.getOwnedRelationship().stream().filter(OwningMembership.class::isInstance)

--- a/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
@@ -92,6 +92,11 @@ Those connections were missing their source and their target, and were therefore
 ** Fix expression creation and editing on `SuccessionAsUsage` elements.
 ** Fix the _Typed by_ property in the _Details_ view so a `Usage` can only be typed by its corresponding `Definition` kind.
 
+* In textual import/export:
+
+** Fix the export of the keywords carried by the ends of a connection, such as the `#original` and `#derive` of a requirement derivation, which were missing from the exported text when the connection had been created from a diagram.
+Exporting such a connection and importing it back no longer loses which end is which.
+
 == Improvements
 
 * In diagrams:


### PR DESCRIPTION
# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [ ] Has the pull request been added to the relevant milestone?
- [ ] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [ ] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.

---

Sorry about the removed template, it is restored above.

The unchecked boxes of the *Project management* section are the ones I have no
permission for: the milestone and the labels, on this pull request and on the
issue. Could someone from the team set them? The remaining unchecked boxes do
not apply here: there is no API break, no dependency change, and no visual
impact since this only changes the exported text.

Fixes https://github.com/eclipse-syson/syson/issues/2419

## Problem

The prefix metadata carried by the ends of a connector are dropped by the
export when those ends are owned through an `EndFeatureMembership`, which is
the shape produced by every connector created from a diagram.

`appendConnectorEnd` writes the multiplicity, the declared name and the
reference subsetting of an end, but not its prefix metadata, although
`appendExtensionKeyword` is already used for that purpose elsewhere, on the
connector itself for instance.

This went unnoticed because a connector whose ends are owned through a plain
`FeatureMembership`, which is what the textual import produces, does not go
through `appendConnectorEnd` at all: `appendConnectorPart` finds no
`EndFeatureMembership`, the ends are left out of `childrenMembershipToSkip`,
and they end up serialized as regular children, metadata included. Only the
inline form loses them.

Concretely, a requirement derivation created from a diagram exported as

```sysml
#DerivationMetadata connect P::original to P::derived;
```

losing the `#original` and `#derive` of its ends, so which requirement is the
original one and which one is derived was no longer stated in the exported
text. Importing that text back gives a derivation whose direction can only be
guessed from the declaration order of its ends.

## Fix

Call the existing `appendExtensionKeyword` on the end at the beginning of
`appendConnectorEnd`. The same derivation now exports as

```sysml
#DerivationMetadata connect #OriginalRequirementMetadata P::original to #DerivedRequirementMetadata P::derived;
```

## Tests

`SysMLElementSerializerTest.connectionUsageWithMetadataOnItsEnds` serializes a
connection whose two ends are owned through an `EndFeatureMembership` and carry
a prefix metadata each, and checks that both are exported:

```
connection interface1 connect #original socket to #derive outlet;
```

The 123 existing tests of `SysMLElementSerializerTest` and the 47 tests of
`ImportExportTests` still pass, so the round trip of the connections whose ends
come from the textual import is unaffected.

## Notes

I found this while preparing the edge tool creating a requirement derivation
from the *General View*, requested in #2413: a derivation created from the
diagram would have exported without its direction. The problem is not specific
to derivations though, it affects the metadata of any inline connector end,
which is why it is fixed separately, before that tool.

There are no changed or removed lines, only additions.
