### PR TITLE
[2425] Publish multi-platform Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,9 @@ jobs:
         with:
           images: eclipsesyson/syson
 
+      - name: Set up QEMU to build the Docker image for additional platforms
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
       - name: Set up Docker Buildx to use cache feature
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -229,6 +232,7 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: backend/application/syson-application
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -53,6 +53,7 @@ The ends of a connector created from a diagram are owned through an `EndFeatureM
 
 === Improvements
 
+- https://github.com/eclipse-syson/syson/issues/2425[#2425] [releng] Publish multi-platform Docker images (`linux/amd64` and `linux/arm64`), allowing {product} to run natively on arm64 machines such as Apple Silicon or AWS Graviton without emulation.
 - https://github.com/eclipse-syson/syson/issues/2364[#2364] [requirements table] Support nested `Requirements` in _Requirements table_ view.
 - [releng] Improve the frontend package build by replacing UMD outputs with CommonJS outputs for reusable npm libraries.
 This removes Rollup warnings about missing global names for externalized peer dependencies while keeping React, MUI, Apollo and other shared dependencies outside the published bundles.

--- a/doc/content/modules/installation-guide/pages/how-tos/install/ecosystem_only.adoc
+++ b/doc/content/modules/installation-guide/pages/how-tos/install/ecosystem_only.adoc
@@ -30,8 +30,8 @@ docker run -p 5433:5432 --name syson-postgres -e POSTGRES_USER=dbuser -e POSTGRE
 
 [TIP]
 ====
-Docker images are build to run on x86_64 architecture.
-If you need to run {product} Docker image on a Mac Silicon architecture, run the following command in your terminal before executing the Docker image:
+{product} Docker images are multi-platform (x86_64 and arm64) starting with version v2026.9.0, so they run natively on Mac Silicon and other arm64 machines.
+If you need to run an older {product} Docker image on a Mac Silicon architecture, run the following command in your terminal before executing the Docker image:
 [source, bash]
 ----
 export DOCKER_DEFAULT_PLATFORM=linux/amd64

--- a/doc/content/modules/installation-guide/pages/how-tos/install/local_test.adoc
+++ b/doc/content/modules/installation-guide/pages/how-tos/install/local_test.adoc
@@ -43,8 +43,8 @@ This method deploys {product} matching the version tagged in this documentation 
 
 [TIP]
 ====
-Docker images are build to run on x86_64 architecture.
-If you need to run {product} Docker image on a Mac Silicon architecture, run the following command in your terminal before executing the Docker image:
+{product} Docker images are multi-platform (x86_64 and arm64) starting with version v2026.9.0, so they run natively on Mac Silicon and other arm64 machines.
+If you need to run an older {product} Docker image on a Mac Silicon architecture, run the following command in your terminal before executing the Docker image:
 
 [source, bash]
 ----

--- a/doc/content/modules/installation-guide/pages/troubleshooting.adoc
+++ b/doc/content/modules/installation-guide/pages/troubleshooting.adoc
@@ -38,8 +38,8 @@ If you open the dev tools of your web browser, you may found the following messa
 In this case, please refer to xref:installation-guide:how-tos/https.adoc[].
 
 == Running docker on Mac Silicon architecture
-Docker images are build to run on x86_64 architecture.
-If you need to run {product} docker image on a Mac Silicon architecture, please execute the following command in your terminal before executing the docker image:
+{product} Docker images are multi-platform (x86_64 and arm64) starting with version v2026.9.0, so they run natively on Mac Silicon and other arm64 machines.
+If you need to run an older {product} docker image on a Mac Silicon architecture, please execute the following command in your terminal before executing the docker image:
 [source, bash]
 ----
 export DOCKER_DEFAULT_PLATFORM=linux/amd64

--- a/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
@@ -99,6 +99,9 @@ Exporting such a connection and importing it back no longer loses which end is w
 
 == Improvements
 
+* {product} Docker images are now multi-platform (`linux/amd64` and `linux/arm64`), so they run natively on arm64 machines such as Apple Silicon or AWS Graviton without emulation.
+Setting `DOCKER_DEFAULT_PLATFORM=linux/amd64` is no longer necessary on these machines.
+
 * In diagrams:
 
 * In textual import/export:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,10 @@
-# Execute this command in your shell if you want to run this docker compose file on ARM architectures
+# SysON images are multi-platform (linux/amd64 and linux/arm64) starting with v2026.9.0.
+# To run an older version on an ARM architecture, execute this command in your shell first:
 # export DOCKER_DEFAULT_PLATFORM=linux/amd64
 version: "3.8"
 services:
   database:
     image: postgres:15
-    # Uncomment this option if you want to run this docker compose file on ARM architectures
-    # platform: linux/amd64
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: username


### PR DESCRIPTION
Fixes #2425.

The eclipsesyson/syson Docker images are currently linux/amd64 only, requiring arm64 users (Apple Silicon, AWS Graviton) to force emulation via DOCKER_DEFAULT_PLATFORM=linux/amd64 (#991). Since the jar is architecture independent and built outside Docker, multi-platform publishing needs only:

- docker/setup-qemu-action (SHA-pinned, same version line as the existing buildx action) before the Buildx setup, and
- platforms: linux/amd64,linux/arm64 on the existing push step.

The test image built with load: true for Playwright/Cypress stays single-arch/native, so those jobs are unaffected. The amd64 half of the pushed image reuses the Buildx cache from the test build; the arm64 half builds under QEMU, which only runs the apk add and adduser layers.

Validated locally: docker buildx build --platform linux/amd64,linux/arm64 of the unmodified backend/application/syson-application context completes for both platforms, and the arm64 image runs SysON natively against the standard docker-compose setup.

Also updates the Apple Silicon workaround notes in the installation guide, docker-compose.yml, CHANGELOG.adoc, and the 2026.9.0 release notes to reflect that the workaround only applies to older releases.

Bug: https://github.com/eclipse-syson/syson/issues/2425

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.

