### PR TITLE
[2437] Set elementId during FlowDefinition creation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -51,6 +51,7 @@ This also fixes `relatedFeature`, `sourceFeature` and `targetFeature`, which wer
 - https://github.com/eclipse-syson/syson/issues/2419[#2419] [export] Fix the export of the prefix metadata carried by the ends of a connector, which were dropped when those ends are declared inline.
 The ends of a connector created from a diagram are owned through an `EndFeatureMembership` and are exported inline, so their metadata, such as the `#original` and `#derive` of a requirement derivation, were lost.
 - https://github.com/eclipse-syson/syson/issues/2340[#2340] [diagrams] Replace the name of the _New Perform action_ tool to _New Perform Action_ to be consistent with other tools.
+- https://github.com/eclipse-syson/syson/issues/2437[#2437] [metamodel] Fix elementId when creating a FlowDefinition
 
 === Improvements
 

--- a/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/SysmlFactoryImpl.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/main/java/org/eclipse/syson/sysml/impl/SysmlFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, 2025 Obeo.
+ * Copyright (c) 2023, 2026 Obeo.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -1213,11 +1213,12 @@ public class SysmlFactoryImpl extends EFactoryImpl implements SysmlFactory {
     /**
      * <!-- begin-user-doc --> <!-- end-user-doc -->
      *
-     * @generated
+     * @generated NOT
      */
     @Override
     public FlowDefinition createFlowDefinition() {
         FlowDefinitionImpl flowDefinition = new FlowDefinitionImpl();
+        flowDefinition.setElementId(ElementUtil.generateUUID(flowDefinition).toString());
         return flowDefinition;
     }
 

--- a/backend/metamodel/syson-sysml-metamodel/src/test/java/org/eclipse/syson/sysml/impl/FlowDefinitionTest.java
+++ b/backend/metamodel/syson-sysml-metamodel/src/test/java/org/eclipse/syson/sysml/impl/FlowDefinitionTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.sysml.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.eclipse.syson.sysml.FlowDefinition;
+import org.eclipse.syson.sysml.SysmlFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link FlowDefinition} related tests.
+ *
+ * @author rpage
+ */
+public class FlowDefinitionTest {
+
+    @Test
+    public void testElementIdNotEmpty() {
+        FlowDefinition flowDefinition = SysmlFactory.eINSTANCE.createFlowDefinition();
+        assertFalse(flowDefinition.getElementId().isEmpty());
+    }
+}


### PR DESCRIPTION
Bug: #2437

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
