### PR TITLE
[2447] Escape the block comment terminator when exporting a comment body

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -52,6 +52,8 @@ This also fixes `relatedFeature`, `sourceFeature` and `targetFeature`, which wer
 - https://github.com/eclipse-syson/syson/issues/2226[#2226] [import] Fix textual import of annotations on relationships so their `annotatedElement` is set and they are returned by `Element#getOwnedAnnotation()`.
 - https://github.com/eclipse-syson/syson/issues/2419[#2419] [export] Fix the export of the prefix metadata carried by the ends of a connector, which were dropped when those ends are declared inline.
 The ends of a connector created from a diagram are owned through an `EndFeatureMembership` and are exported inline, so their metadata, such as the `#original` and `#derive` of a requirement derivation, were lost.
+- https://github.com/eclipse-syson/syson/issues/2447[#2447] [export] Fix the export of a comment body containing `*/`, which closed the block comment early and produced a file that could not be parsed.
+The grammar defines a comment as a non greedy match up to the first `*/`, with no escape sequence and no nesting, so that sequence is exported as `* /` and a warning is reported, since the exported text is then not exactly the one that was written.
 - https://github.com/eclipse-syson/syson/issues/2340[#2340] [diagrams] Replace the name of the _New Perform action_ tool to _New Perform Action_ to be consistent with other tools.
 - https://github.com/eclipse-syson/syson/issues/2437[#2437] [metamodel] Fix elementId when creating a FlowDefinition
 - https://github.com/eclipse-syson/syson/issues/2384[#2384] [import] Fix the import of `TransitionUsage` using _start_ which now set the source to the `StateUsage` _start_ from the standard library instead of `ActionUsage` _start_ from the standard library.

--- a/backend/application/syson-application/src/test/java/org/eclipse/syson/sysml/textual/SysMLElementSerializerTest.java
+++ b/backend/application/syson-application/src/test/java/org/eclipse/syson/sysml/textual/SysMLElementSerializerTest.java
@@ -1980,6 +1980,21 @@ public class SysMLElementSerializerTest {
     }
 
     @Test
+    public void documentationContainingACommentTerminator() {
+        PartUsage partUsage = this.builder.createWithName(PartUsage.class, "PartUsage1");
+        this.builder.createIn(Documentation.class, partUsage).setBody("Closing a block comment looks like */ in the code");
+
+        // The terminator is separated so it no longer closes the comment, which would leave the rest of the body
+        // exported as if it were SysML v2 code.
+        this.assertTextualFormEquals("""
+                part PartUsage1 {
+                    doc /* Closing a block comment looks like * / in the code */
+                }""", partUsage);
+        assertTrue(this.status.stream()
+                .anyMatch(reported -> reported.severity() == Severity.WARNING && reported.message().contains("closes a comment")));
+    }
+
+    @Test
     public void documentation() {
 
         PartDefinition partDef = this.builder.createWithName(PartDefinition.class, "Part Def1");

--- a/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/textual/SysMLElementSerializer.java
+++ b/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/textual/SysMLElementSerializer.java
@@ -170,6 +170,12 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
 
     private static final String SPACE = " ";
 
+    /** The sequence closing a block comment, which cannot appear inside a comment body. */
+    private static final String COMMENT_TERMINATOR = "*/";
+
+    /** The form the block comment terminator is exported as, so it no longer closes the comment. */
+    private static final String ESCAPED_COMMENT_TERMINATOR = "* /";
+
     private final String lineSeparator;
 
     private final String indentation;
@@ -2530,8 +2536,36 @@ public class SysMLElementSerializer extends SysmlSwitch<String> {
 
     private String getCommentBody(String body) {
         Appender subBuilder = this.newAppender();
-        subBuilder.append("/* ").append(body).append(" */");
+        subBuilder.append("/* ").append(this.escapeCommentTerminator(body)).append(" */");
         return subBuilder.toString();
+    }
+
+    /**
+     * Replace the occurrences of the block comment terminator in a comment body.
+     * <p>
+     * The grammar defines a comment as {@code /*[\s\S]*?*}{@code /}, a non greedy match up to the first {@code *}
+     * {@code /}, with no escape sequence and no nesting, so that sequence cannot be represented inside a comment body.
+     * Left as it is, it closes the comment early and the rest of the body is exported as if it were SysML v2 code,
+     * giving a file which does not parse. It is separated by a space instead, which is reported since the exported text
+     * is then not exactly the one which was written.
+     * </p>
+     * <p>
+     * The reverse replacement is deliberately not done on import: a body may legitimately contain the separated form,
+     * and turning it back would corrupt it.
+     * </p>
+     *
+     * @param body
+     *            the body of a comment, a documentation or a textual representation
+     * @return the body, with any block comment terminator separated by a space
+     */
+    private String escapeCommentTerminator(String body) {
+        if (body == null || !body.contains(COMMENT_TERMINATOR)) {
+            return body;
+        }
+        this.reportConsumer.accept(Status.warning(
+                "A comment body contains \"{0}\", which closes a comment. It has been exported as \"{1}\" so the text remains valid.",
+                COMMENT_TERMINATOR, ESCAPED_COMMENT_TERMINATOR));
+        return body.replace(COMMENT_TERMINATOR, ESCAPED_COMMENT_TERMINATOR);
     }
 
     private void appendLocale(Appender builder, String local) {

--- a/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
@@ -124,6 +124,10 @@ The affected connections were missing their source and target and were therefore
 Exporting such a connection and importing it back no longer loses which end is which.
 ** Fix the import of `TransitionUsage` using _start_ which now set the source to the `StateUsage` _start_ from the standard library instead of `ActionUsage` _start_ from the standard library.
 
+** Fix the export of a documentation, a comment or a textual representation whose text contains `*/`.
+That sequence closes a comment in the SysML v2 textual notation, so the exported file could no longer be read.
+It is now exported as `* /`, and a warning reports it, since the exported text is then not exactly the one that was written.
+
 == Improvements
 
 * {product} Docker images now support `linux/amd64` and `linux/arm64` and run natively on arm64 machines such as Apple Silicon or AWS Graviton.


### PR DESCRIPTION

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [x] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.

---

The unchecked boxes of the *Project management* section are the ones I have no
permission for: the milestone and the labels, on this pull request and on the
issue. Could someone from the team set them? The remaining unchecked boxes do
not apply: there is no API break, no dependency change, and no visual impact
since this only changes the exported text.

Fixes https://github.com/eclipse-syson/syson/issues/2447

## Problem

`getCommentBody` concatenated the body between `/* ` and ` */` without any
escaping, so a body containing the terminator closed the comment early and the
rest of it was exported as if it were SysML v2 code:

```sysml
doc /* Closing a block comment looks like */ in the code */
```

The comment ends at the first terminator, `in the code` is left as code and the
trailing one is dangling, so the exported file does not parse. Documenting a
piece of code is enough to run into it.

## Fix

The grammar defines a comment as

```
REGULAR_COMMENT: /\*[\s\S]*?\*/
```

a non greedy match up to the first terminator, with no escape sequence and no
nesting, so that sequence cannot be represented inside a comment body. It is
separated by a space instead:

```sysml
doc /* Closing a block comment looks like * / in the code */
```

Since the exported text is then not exactly the one that was written, it is
reported as a warning through the existing report consumer rather than changed
silently. The export was silently broken before, and a silent rewrite would
only move the surprise somewhere else.

The reverse replacement is deliberately not done on import: a body may
legitimately contain the separated form, and turning it back would corrupt it.

`getCommentBody` is used for the body of a `Comment`, of a `Documentation` and
of a `TextualRepresentation`, so all three are covered by the single change.

## Tests

`SysMLElementSerializerTest.documentationContainingACommentTerminator` exports
a documentation whose body contains the terminator, and checks both the
separated form in the output and the reported warning.

The 124 existing tests of `SysMLElementSerializerTest` and the 47 tests of
`ImportExportTests` still pass.

## Note

This came out of #2436, where the documentation widget of the *Details* view is
to be replaced by the RichTextEditor. It is not specific to rich text though,
the defect is there today, which is why it is fixed separately and does not
wait for the SiriusWeb release.
