### PR TITLE
[2441] Extract semantic creation from createAllocateEdge

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -79,6 +79,7 @@ This removes Rollup warnings about missing global names for externalized peer de
 - https://github.com/eclipse-syson/syson/issues/2453[#2453] [diagrams] Add the Show/Hide section and associated tools to the group palette.
 - https://github.com/eclipse-syson/syson/issues/2463[#2463] [details] Export `ExpressionPropertySection`.
 This lets downstream applications with a custom extension registry display the _Expression value_ property section in the _Details_ view.
+- https://github.com/eclipse-syson/syson/issues/2441[#2441] [services] Refactor `DiagramMutationElementService#createAllocateEdge` to extract semantic creation from diagram service.
 
 === New features
 

--- a/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/DiagramMutationElementService.java
+++ b/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/DiagramMutationElementService.java
@@ -751,17 +751,12 @@ public class DiagramMutationElementService {
      *            the current editing context
      * @param diagramService
      *            the current diagram service
-     * @return the given source element
+     * @return the created {@link AllocationUsage}
      */
-    public Element createAllocateEdge(Element source, Element target, Node sourceNode, IEditingContext editingContext, IDiagramService diagramService) {
-        var owner = source.getOwner();
-        var ownerMembership = SysmlFactory.eINSTANCE.createOwningMembership();
-        owner.getOwnedRelationship().add(ownerMembership);
-        var allocation = SysmlFactory.eINSTANCE.createAllocationUsage();
-        ownerMembership.getOwnedRelatedElement().add(allocation);
-        this.addEndToAllocateEdge(allocation, source);
-        this.addEndToAllocateEdge(allocation, target);
-        return source;
+    public AllocationUsage createAllocateEdge(Element source, Element target, Node sourceNode, IEditingContext editingContext, IDiagramService diagramService) {
+        var allocateEdge = this.metamodelMutationElementService.createAllocateEdge(source, target);
+        this.metamodelMutationElementService.initialize(allocateEdge);
+        return allocateEdge;
     }
 
     /**
@@ -836,18 +831,6 @@ public class DiagramMutationElementService {
             }
         }
         return allocationUsage;
-    }
-
-    private void addEndToAllocateEdge(AllocationUsage edge, Element end) {
-        if (end instanceof Usage usage) {
-            var featureMembership = SysmlFactory.eINSTANCE.createEndFeatureMembership();
-            edge.getOwnedRelationship().add(featureMembership);
-            var feature = SysmlFactory.eINSTANCE.createFeature();
-            featureMembership.getOwnedRelatedElement().add(feature);
-            var reference = SysmlFactory.eINSTANCE.createReferenceSubsetting();
-            feature.getOwnedRelationship().add(reference);
-            reference.setReferencedFeature(usage);
-        }
     }
 
     /**

--- a/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/MetamodelMutationElementService.java
+++ b/backend/services/syson-sysml-metamodel-services/src/main/java/org/eclipse/syson/sysml/metamodel/services/MetamodelMutationElementService.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.syson.sysml.AllocationUsage;
 import org.eclipse.syson.sysml.BindingConnectorAsUsage;
 import org.eclipse.syson.sysml.ConnectionUsage;
 import org.eclipse.syson.sysml.Connector;
@@ -48,6 +49,7 @@ import org.eclipse.syson.sysml.RequirementUsage;
 import org.eclipse.syson.sysml.SysmlFactory;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.Type;
+import org.eclipse.syson.sysml.Usage;
 
 /**
  * Element-related services doing mutations. This class should not depend on sirius-web services or other spring
@@ -384,6 +386,38 @@ public class MetamodelMutationElementService {
             return documentation;
         }
         return null;
+    }
+
+    /**
+     * Creates an allocate edge between the given source and target.
+     *
+     * @param source
+     *            the source of the allocate edge
+     * @param target
+     *            the target of the allocate edge
+     * @return the created {@link AllocationUsage}
+     */
+    public AllocationUsage createAllocateEdge(Element source, Element target) {
+        var owner = source.getOwner();
+        var ownerMembership = SysmlFactory.eINSTANCE.createOwningMembership();
+        owner.getOwnedRelationship().add(ownerMembership);
+        var allocation = SysmlFactory.eINSTANCE.createAllocationUsage();
+        ownerMembership.getOwnedRelatedElement().add(allocation);
+        this.addEndToAllocateEdge(allocation, source);
+        this.addEndToAllocateEdge(allocation, target);
+        return allocation;
+    }
+
+    private void addEndToAllocateEdge(AllocationUsage edge, Element end) {
+        if (end instanceof Usage usage) {
+            var featureMembership = SysmlFactory.eINSTANCE.createEndFeatureMembership();
+            edge.getOwnedRelationship().add(featureMembership);
+            var feature = SysmlFactory.eINSTANCE.createFeature();
+            featureMembership.getOwnedRelatedElement().add(feature);
+            var reference = SysmlFactory.eINSTANCE.createReferenceSubsetting();
+            feature.getOwnedRelationship().add(reference);
+            reference.setReferencedFeature(usage);
+        }
     }
 
     private Feature addConnectorEnd(Connector connector, Feature end, Element endContainer, Element connectorContainer, FeatureDirectionKind defaultDirection) {

--- a/backend/services/syson-sysml-metamodel-services/src/test/java/org/eclipse/syson/sysml/metamodel/services/MetamodelMutationElementServiceTest.java
+++ b/backend/services/syson-sysml-metamodel-services/src/test/java/org/eclipse/syson/sysml/metamodel/services/MetamodelMutationElementServiceTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.syson.sysml.AllocationUsage;
 import org.eclipse.syson.sysml.ConnectionUsage;
 import org.eclipse.syson.sysml.Element;
 import org.eclipse.syson.sysml.FeatureDirectionKind;
@@ -26,6 +27,7 @@ import org.eclipse.syson.sysml.MetadataDefinition;
 import org.eclipse.syson.sysml.MetadataUsage;
 import org.eclipse.syson.sysml.OwningMembership;
 import org.eclipse.syson.sysml.Package;
+import org.eclipse.syson.sysml.PartUsage;
 import org.eclipse.syson.sysml.ReferenceUsage;
 import org.eclipse.syson.sysml.RequirementUsage;
 import org.eclipse.syson.sysml.SysmlFactory;
@@ -186,6 +188,22 @@ public class MetamodelMutationElementServiceTest {
         });
         var targetFlow = this.queryService.getTargetFlowUsageEdge(createdFlow);
         assertThat(targetFlow).isEqualTo(target);
+    }
+
+    @Test
+    @DisplayName("GIVEN two PartUsage, WHEN creating an allocate edge, then an AllocationUsage is created with the correct ends")
+    public void createAllocateEdge() {
+        Package parentPackage = SysmlFactory.eINSTANCE.createPackage();
+        PartUsage partUsage1 = SysmlFactory.eINSTANCE.createPartUsage();
+        this.mutationService.addChildInParent(parentPackage, partUsage1);
+        PartUsage partUsage2 = SysmlFactory.eINSTANCE.createPartUsage();
+        this.mutationService.addChildInParent(parentPackage, partUsage2);
+        AllocationUsage allocationUsage = this.mutationService.createAllocateEdge(partUsage1, partUsage2);
+        assertThat(allocationUsage).isNotNull();
+        assertThat(allocationUsage.getFeature())
+                .hasSize(2)
+                .anySatisfy(feature -> assertThat(feature.getOwnedReferenceSubsetting().getReferencedFeature()).isEqualTo(partUsage1))
+                .anySatisfy(feature -> assertThat(feature.getOwnedReferenceSubsetting().getReferencedFeature()).isEqualTo(partUsage2));
     }
 
     private RequirementUsage createRequirement(String name) {


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/2441
fixes #2441 

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [ ] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [x] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
