### PR TITLE
[2483] Prevent AQL validation parser failures

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -65,6 +65,7 @@ The grammar defines a comment as a non greedy match up to the first `*/`, with n
 - https://github.com/eclipse-syson/syson/issues/2384[#2384] [import] Fix the import of `TransitionUsage` using _start_ which now set the source to the `StateUsage` _start_ from the standard library instead of `ActionUsage` _start_ from the standard library.
 - https://github.com/eclipse-syson/syson/issues/2208[#2208] [diagram] Fix the edge tool creating a `ConnectionUsage` between an `ActionUsage` graphical node and the _done_ `ActionUsage` graphical node.
 Prevent the feature chain computer from traversing the whole standard library to compute the shortest path to the _done_ `ActionUsage`.
+- https://github.com/eclipse-syson/syson/issues/2483[#2483] [validation] Prevent AQL parser failures when loading the built-in SysML validation rules.
 
 === Improvements
 

--- a/backend/application/syson-sysml-validation/src/main/java/org/eclipse/syson/sysml/validation/rules/SysMLValidationRule.java
+++ b/backend/application/syson-sysml-validation/src/main/java/org/eclipse/syson/sysml/validation/rules/SysMLValidationRule.java
@@ -664,7 +664,7 @@ public enum SysMLValidationRule implements IValidationRule {
     checkMetadataFeatureSemanticSpecialization(
             SysmlPackage.eINSTANCE.getMetadataFeature(),
             "checkMetadataFeatureSemanticSpecialization",
-            "aql:self.isSemantic() implies let annotatedTypes : Sequence(sysml::Type) = self.annotatedElement->selectAsKind(Type) in let baseTypes : Sequence(sysml::MetadataFeature) = self.evaluateFeature(resolveGlobal( 'Metaobjects::SemanticMetadata::baseType').memberElement.oclAsType(sysml::Feature))->selectAsKind(MetadataFeature) in annotatedTypes->notEmpty() and baseTypes()->notEmpty() and baseTypes()->first().isSyntactic() implies let annotatedType : sysml::Type = annotatedTypes->first() in let baseType : sysml::Element = baseTypes->first().syntaxElement() in if annotatedType.oclIsKindOf(sysml::Classifier) and baseType.oclIsKindOf(sysml::Feature) then baseType.oclAsType(sysml::Feature).type->forAll(t | annotatedType.specializes(t)) else if baseType.oclIsKindOf(sysml::Type) then annotatedType.specializes(baseType.oclAsType(sysml::Type)) else true endif",
+            "aql:self.isSemantic() implies let annotatedTypes : Sequence(sysml::Type) = self.annotatedElement->selectAsKind(Type), baseTypes : Sequence(sysml::MetadataFeature) = self.evaluateFeature(resolveGlobal( 'Metaobjects::SemanticMetadata::baseType').memberElement.oclAsType(sysml::Feature))->selectAsKind(MetadataFeature) in annotatedTypes->notEmpty() and baseTypes->notEmpty() and baseTypes->first().isSyntactic() implies let annotatedType : sysml::Type = annotatedTypes->first(), baseType : sysml::Element = baseTypes->first().syntaxElement() in if annotatedType.oclIsKindOf(sysml::Classifier) and baseType.oclIsKindOf(sysml::Feature) then baseType.oclAsType(sysml::Feature).type->forAll(t | annotatedType.specializes(t)) else if baseType.oclIsKindOf(sysml::Type) then annotatedType.specializes(baseType.oclAsType(sysml::Type)) else true endif endif",
             "If this MetadataFeature is an application of SemanticMetadata, then its annotatingElement must be a Type. The annotated Type must then directly or indirectly specialize the specified value of the baseType, unless the Type is a Classifier and the baseType represents a kind of Feature, in which case the Classifier must directly or indirectly specialize each of the types of the Feature."),
     checkMetadataFeatureSpecialization(
             SysmlPackage.eINSTANCE.getMetadataFeature(),
@@ -1529,7 +1529,7 @@ public enum SysMLValidationRule implements IValidationRule {
     validateInvocationExpressionOwnedFeatures(
             SysmlPackage.eINSTANCE.getInvocationExpression(),
             "validateInvocationExpressionOwnedFeatures",
-            "aql:self.ownedFeature->forAll(f | f <> self.result implies f.direction = sysml::FeatureDirectionKind::_'in')",
+            "aql:self.ownedFeature->forAll(f | f <> self.result implies f.direction = sysml::FeatureDirectionKind::_in)",
             "Other than its result, all the ownedFeatures of an InvocationExpression must have direction = in."),
     validateInvocationExpressionParameterRedefinition(
             SysmlPackage.eINSTANCE.getInvocationExpression(),

--- a/backend/application/syson-sysml-validation/src/test/java/org/eclipse/syson/sysml/validation/rules/SysMLValidationRuleUnitTests.java
+++ b/backend/application/syson-sysml-validation/src/test/java/org/eclipse/syson/sysml/validation/rules/SysMLValidationRuleUnitTests.java
@@ -13,11 +13,14 @@
 package org.eclipse.syson.sysml.validation.rules;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.eclipse.acceleo.query.runtime.Query;
+import org.eclipse.acceleo.query.runtime.impl.QueryBuilderEngine;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,6 +58,18 @@ public class SysMLValidationRuleUnitTests {
     @DisplayName("For each rule, the expression starts with 'aql:'")
     public void testRuleExpressionStartsWithAql() {
         assertThat(allRules).allMatch(rule -> rule.expression().startsWith("aql:"));
+    }
+
+    @Test
+    @DisplayName("For each rule, the AQL expression can be parsed")
+    public void testRuleExpressionsCanBeParsed() {
+        final var environment = Query.newEnvironmentWithDefaultServices(null);
+        final var builder = new QueryBuilderEngine(environment);
+
+        allRules.forEach(rule -> assertThatCode(() -> builder.build(rule.expression()
+                .substring("aql:".length())))
+                        .as(rule.ruleName())
+                        .doesNotThrowAnyException());
     }
 
     @Test

--- a/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
@@ -132,6 +132,10 @@ Exporting such a connection and importing it back no longer loses which end is w
 That sequence closes a comment in the SysML v2 textual notation, so the exported file could no longer be read.
 It is now exported as `* /`, and a warning reports it, since the exported text is then not exactly the one that was written.
 
+* In validation:
+
+** Prevent AQL parser failures when loading the built-in SysML validation rules.
+
 == Improvements
 
 * In diagrams:


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/2483

Fixes #2483

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request?
- [x] Have the relevant issues been added to the pull request?
- [x] Have the relevant labels been added to the issues? (`package:` and `type:`)
- [x] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc` been updated to reference the relevant issue?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc`?

## Documentation

- [ ] Have you included an update of the documentation in your pull request?

No user or developer documentation update is needed for this internal validation parser fix.

## Tests

- [x] Is the code properly tested? The targeted `SysMLValidationRuleUnitTests` suite passes.