### PR TITLE
[2486] Resolve cross-document references for nested SysML files

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -66,6 +66,7 @@ The grammar defines a comment as a non greedy match up to the first `*/`, with n
 - https://github.com/eclipse-syson/syson/issues/2208[#2208] [diagram] Fix the edge tool creating a `ConnectionUsage` between an `ActionUsage` graphical node and the _done_ `ActionUsage` graphical node.
 Prevent the feature chain computer from traversing the whole standard library to compute the shortest path to the _done_ `ActionUsage`.
 - https://github.com/eclipse-syson/syson/issues/2483[#2483] [validation] Prevent AQL parser failures when loading the built-in SysML validation rules.
+- https://github.com/eclipse-syson/syson/issues/2486[#2486] [import/export] Resolve cross-document references for nested SysML files.
 
 === Improvements
 

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/SysONJsonResourceProcessor.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/SysONJsonResourceProcessor.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.services;
+
+import com.google.gson.JsonObject;
+
+import java.util.Objects;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.sirius.components.emf.services.api.IEMFEditingContext;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+
+/**
+ * JSON resource processor applying SysON-specific reference loading behavior while preserving the behavior of another
+ * processor.
+ *
+ * @author cbrun
+ */
+public class SysONJsonResourceProcessor implements JsonResource.IJsonResourceProcessor {
+
+    private final JsonResource.IJsonResourceProcessor delegate;
+
+    /**
+     * Creates a new processor.
+     *
+     * @param delegate
+     *            the processor to invoke before SysON-specific behavior
+     */
+    public SysONJsonResourceProcessor(JsonResource.IJsonResourceProcessor delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    @Override
+    public void preDeserialization(JsonResource resource, JsonObject jsonObject) {
+        this.delegate.preDeserialization(resource, jsonObject);
+    }
+
+    @Override
+    public void postSerialization(JsonResource resource, JsonObject jsonObject) {
+        this.delegate.postSerialization(resource, jsonObject);
+    }
+
+    @Override
+    public void postObjectLoading(JsonResource resource, EObject eObject, JsonObject jsonObject, boolean isTopObject) {
+        this.delegate.postObjectLoading(resource, eObject, jsonObject, isTopObject);
+    }
+
+    @Override
+    public Object getValue(JsonResource resource, EObject eObject, EStructuralFeature feature, Object value) {
+        return this.delegate.getValue(resource, eObject, feature, value);
+    }
+
+    @Override
+    public String getEObjectUri(JsonResource resource, EObject eObject, EReference eReference, String uri) {
+        String updatedUri = this.delegate.getEObjectUri(resource, eObject, eReference, uri);
+        if (updatedUri != null) {
+            int prefixEnd = updatedUri.indexOf(' ');
+            if (prefixEnd >= 0) {
+                String prefix = updatedUri.substring(0, prefixEnd + 1);
+                String referenceUri = updatedUri.substring(prefixEnd + 1);
+                if (referenceUri.startsWith("../") && resource.getURI() != null && resource.getURI().segmentCount() == 1) {
+                    // Upload sanitization deresolves links against the folder-bearing file name before the document gets its
+                    // flat persistent URI.
+                    referenceUri = IEMFEditingContext.RESOURCE_SCHEME + ":///" + referenceUri.replaceFirst("^(?:\\.\\./)+", "");
+                }
+                updatedUri = prefix + referenceUri;
+            }
+        }
+        return updatedUri;
+    }
+}

--- a/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/SysONResourceLoader.java
+++ b/backend/application/syson-application-configuration/src/main/java/org/eclipse/syson/application/services/SysONResourceLoader.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.services;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.sirius.components.emf.ResourceMetadataAdapter;
+import org.eclipse.sirius.components.emf.migration.MigrationService;
+import org.eclipse.sirius.components.emf.migration.api.IMigrationParticipant;
+import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+import org.eclipse.sirius.web.application.editingcontext.services.api.IResourceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+/**
+ * SysON resource loader applying the SysON JSON resource processor when loading project documents.
+ *
+ * @author cbrun
+ */
+@Service
+@Primary
+public class SysONResourceLoader implements IResourceLoader {
+
+    private final Logger logger = LoggerFactory.getLogger(SysONResourceLoader.class);
+
+    private final List<IMigrationParticipant> migrationParticipants;
+
+    /**
+     * Creates a new resource loader.
+     *
+     * @param migrationParticipants
+     *            the migration participants to apply when requested
+     */
+    public SysONResourceLoader(List<IMigrationParticipant> migrationParticipants) {
+        this.migrationParticipants = List.copyOf(migrationParticipants);
+    }
+
+    @Override
+    public Optional<Resource> toResource(ResourceSet resourceSet, String id, String name, String content, boolean applyMigrationParticipants, boolean isReadOnly) {
+        Optional<Resource> optionalResource = Optional.empty();
+
+        HashMap<Object, Object> loadOptions = new HashMap<>();
+        JsonResource.IJsonResourceProcessor processor = new JsonResource.IJsonResourceProcessor.NoOp();
+        if (applyMigrationParticipants) {
+            var migrationService = new MigrationService(this.migrationParticipants);
+            loadOptions.put(JsonResource.OPTION_EXTENDED_META_DATA, migrationService);
+            processor = migrationService;
+        }
+        loadOptions.put(JsonResource.OPTION_JSON_RESSOURCE_PROCESSOR, new SysONJsonResourceProcessor(processor));
+
+        var resource = new JSONResourceFactory().createResource(new JSONResourceFactory().createResourceURI(id));
+        try (var inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
+            resourceSet.getResources().add(resource);
+            resource.eAdapters().add(new ResourceMetadataAdapter(name, isReadOnly));
+            resource.load(inputStream, loadOptions);
+            optionalResource = Optional.of(resource);
+        } catch (IOException | IllegalArgumentException exception) {
+            this.logger.atWarn()
+                    .setMessage("An error occured while loading document {}")
+                    .addArgument(id)
+                    .setCause(exception)
+                    .log();
+            resourceSet.getResources().remove(resource);
+        }
+        return optionalResource;
+    }
+}

--- a/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/SysONResourceLoaderTest.java
+++ b/backend/application/syson-application-configuration/src/test/java/org/eclipse/syson/application/services/SysONResourceLoaderTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.syson.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.sirius.components.emf.services.JSONResourceFactory;
+import org.eclipse.sirius.emfjson.resource.JsonResource;
+import org.eclipse.syson.sysml.NamespaceImport;
+import org.eclipse.syson.sysml.Package;
+import org.eclipse.syson.sysml.SysmlFactory;
+import org.eclipse.syson.sysml.SysmlPackage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SysONResourceLoader}.
+ *
+ * @author cbrun
+ */
+public class SysONResourceLoaderTest {
+
+    private static final String TARGET_ELEMENT_ID = "11111111-1111-4111-8111-111111111111";
+
+    private static final String IMPORT_ELEMENT_ID = "22222222-2222-4222-8222-222222222222";
+
+    @Test
+    @DisplayName("GIVEN a parent-relative cross-document reference, WHEN loading a flat document URI, THEN the reference is resolved")
+    void parentRelativeCrossDocumentReferenceIsResolvedOnLoad() {
+        ResourceSet resourceSet = new ResourceSetImpl();
+        resourceSet.getPackageRegistry().put(SysmlPackage.eNS_URI, SysmlPackage.eINSTANCE);
+
+        UUID targetDocumentId = UUID.randomUUID();
+        JsonResource targetResource = this.createResource(resourceSet, targetDocumentId);
+        Package targetPackage = SysmlFactory.eINSTANCE.createPackage();
+        targetPackage.setElementId(TARGET_ELEMENT_ID);
+        targetPackage.setDeclaredName("TargetPackage");
+        targetResource.getContents().add(targetPackage);
+
+        String content = """
+                {
+                  "json": { "version": "1.0", "encoding": "utf-8" },
+                  "ns": { "sysml": "%s" },
+                  "content": [{
+                    "id": "%s",
+                    "eClass": "sysml:NamespaceImport",
+                    "data": {
+                      "elementId": "%s",
+                      "importedNamespace": "sysml:Package ../../%s#%s"
+                    }
+                  }]
+                }
+                """.formatted(SysmlPackage.eNS_URI, IMPORT_ELEMENT_ID, IMPORT_ELEMENT_ID, targetDocumentId, TARGET_ELEMENT_ID);
+
+        var sourceResource = new SysONResourceLoader(List.of()).toResource(resourceSet, UUID.randomUUID().toString(), "Source.sysml", content, false, false);
+
+        assertThat(sourceResource).isPresent();
+        assertThat(this.findNamespaceImport(sourceResource.get()).getImportedNamespace()).isSameAs(targetPackage);
+    }
+
+    private JsonResource createResource(ResourceSet resourceSet, UUID documentId) {
+        JsonResource resource = new JSONResourceFactory().createResource(new JSONResourceFactory().createResourceURI(documentId.toString()));
+        resourceSet.getResources().add(resource);
+        return resource;
+    }
+
+    private NamespaceImport findNamespaceImport(Resource resource) {
+        NamespaceImport result = null;
+        var iterator = resource.getAllContents();
+        while (result == null && iterator.hasNext()) {
+            if (iterator.next() instanceof NamespaceImport namespaceImport) {
+                result = namespaceImport;
+            }
+        }
+        assertThat(result).isNotNull();
+        return result;
+    }
+}

--- a/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
@@ -131,6 +131,7 @@ Exporting such a connection and importing it back no longer loses which end is w
 ** Fix the export of a documentation, a comment or a textual representation whose text contains `*/`.
 That sequence closes a comment in the SysML v2 textual notation, so the exported file could no longer be read.
 It is now exported as `* /`, and a warning reports it, since the exported text is then not exactly the one that was written.
+** Preserve cross-document references when a SysML document is uploaded with a directory in its filename.
 
 * In validation:
 


### PR DESCRIPTION
Bug: https://github.com/eclipse-syson/syson/issues/2486

Fixes #2486

The upstream cause is tracked in Sirius Web #6852: https://github.com/eclipse-sirius/sirius-web/issues/6852

This PR adds a SysON-scoped workaround while the Sirius Web fix is being developed. It normalizes parent-relative cross-document references when persisted JSON documents are reloaded under flat sirius:/// resource URIs.

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review
- [x] Have you reviewed this PR?

## Project management
- [x] The issue is linked to this PR.
- [x] Appropriate labels are applied to the issue.
- [x] The issue is assigned to the appropriate milestone.

## Code quality
- [x] The code follows the project coding conventions.
- [x] The implementation is limited to the affected loading path.

## Documentation
- [x] The changelog and release notes have been updated.
- [ ] Documentation has been updated where necessary.

No user or developer documentation update is needed for this internal loading workaround.

## Tests
- [x] A regression test has been added.
- [x] The targeted test suite passes.

## Other
- [ ] This PR introduces an API break.
- [ ] This PR introduces a dependency change.
- [ ] This PR introduces a visual change.
- [ ] This PR requires special release notes.

Targeted verification: SysONResourceLoaderTest passes with Maven and Checkstyle.