### PR TITLE
[doc] Update the release notes

### DIFF
--- a/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/DiagramQueryViewService.java
+++ b/backend/services/syson-diagram-services/src/main/java/org/eclipse/syson/diagram/services/DiagramQueryViewService.java
@@ -22,6 +22,7 @@ import org.eclipse.sirius.components.core.api.IObjectSearchService;
 import org.eclipse.sirius.components.diagrams.Diagram;
 import org.eclipse.sirius.components.diagrams.Node;
 import org.eclipse.syson.sysml.Element;
+import org.eclipse.syson.sysml.Namespace;
 import org.eclipse.syson.sysml.SysmlPackage;
 import org.eclipse.syson.sysml.Type;
 import org.eclipse.syson.sysml.ViewDefinition;
@@ -59,7 +60,7 @@ public class DiagramQueryViewService {
      * @return {@code true} if the diagram can be created on the provided {@code element}
      */
     public boolean canCreateDiagram(Element element) {
-        return true;
+        return element instanceof Namespace;
     }
 
     /**
@@ -72,7 +73,7 @@ public class DiagramQueryViewService {
             var types = viewUsage.getType();
             if ((types == null || types.isEmpty()) && Objects.equals(StandardDiagramsConstants.GV_QN, viewDefinition)) {
                 isView = true;
-            } else {
+            } else if (types != null) {
                 var expectedViewDefinition = this.elementUtil.findByNameAndType(viewUsage, viewDefinition, ViewDefinition.class);
                 Type type = types.get(0);
                 isView = Objects.equals(type, expectedViewDefinition);
@@ -96,7 +97,7 @@ public class DiagramQueryViewService {
             var types = viewUsage.getType();
             if ((types == null || types.isEmpty()) && Objects.equals(StandardDiagramsConstants.GV_QN, viewDefinition)) {
                 isView = true;
-            } else {
+            } else if (types != null) {
                 var expectedViewDefinition = this.elementUtil.findByNameAndType(viewUsage, viewDefinition, ViewDefinition.class);
                 Type type = types.get(0);
                 isView = Objects.equals(type, expectedViewDefinition);

--- a/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
+++ b/doc/content/modules/user-manual/pages/release-notes/2026.9.0.adoc
@@ -96,9 +96,6 @@ image::release-notes-action-inherited-item-border-nodes.png[ItemUsage border nod
 +
 image::release-notes-port-inherited-item-border-nodes.png[ItemUsage border node inheritance on PortDefinition and PortUsage, width=80%,height=80%]
 
-** Improve the edge tool creating a `FlowUsage`, by creating a `ReferenceUsage` used for the redefinition of the `FlowEnd` only when it is needed.
-** Fix the edge tool creating a `ConnectionUsage` between an `ActionUsage` graphical node and the _done_ `ActionUsage` graphical node.
-
 == Bug fixes
 
 * In diagrams:
@@ -115,8 +112,9 @@ The affected connections were missing their source and target and were therefore
 ** Fix an issue that prevented a nested `AttributeUsage` from becoming visible when it was first dropped from the _Explorer_ onto a _General View_ diagram.
 ** Fix `Comment` graphical nodes so changing their background color no longer changes their border color.
 ** Rename the _New Perform action_ tool to _New Perform Action_ for consistency with other tools.
-** Do not propose the the _New Subclassification_ edge tool from `EnumerationDefinition` graphical nodes' palette, which cannot subclassify another `EnumerationDefinition`.
+** Do not propose the _New Subclassification_ edge tool from `EnumerationDefinition` graphical nodes' palette, which cannot subclassify another `EnumerationDefinition`.
 ** Do not propose the _New Subclassification_ edge tool in the palette when targeting a `Usage` graphical node from a `Definition` graphical node.
+** Fix the edge tool creating a `ConnectionUsage` between an `ActionUsage` graphical node and the _done_ `ActionUsage` graphical node.
 
 * In all views:
 
@@ -128,8 +126,7 @@ The affected connections were missing their source and target and were therefore
 ** Fix the export of the keywords carried by the ends of a connection, such as the `#original` and `#derive` of a `Requirement` derivation, which were missing from the exported text when the connection had been created from a diagram.
 Exporting such a connection and importing it back no longer loses which end is which.
 ** Fix the import of `TransitionUsage` using _start_ which now set the source to the `StateUsage` _start_ from the standard library instead of `ActionUsage` _start_ from the standard library.
-
-** Fix the export of a documentation, a comment or a textual representation whose text contains `*/`.
+** Fix the export of a documentation, a comment or a textual representation whose text contains `\*/`.
 That sequence closes a comment in the SysML v2 textual notation, so the exported file could no longer be read.
 It is now exported as `* /`, and a warning reports it, since the exported text is then not exactly the one that was written.
 ** Preserve cross-document references when a SysML document is uploaded with a directory in its filename.
@@ -149,12 +146,11 @@ image::release-notes-show-hide-section-group-palette.png[New Show/Hide section i
 
 ** In standard diagrams, the group palette now provides _Delete from diagram_ when multiple graphical nodes are selected.
 It removes all selected nodes from the diagram without deleting the corresponding model elements.
-
 ** Selection dialog trees now apply the default _Explorer_ filters, hiding `Memberships`, root `Namespaces`, expose elements, and expression internals.
 It allows to focus on the elements that are relevant for the current model, while still allowing to select library elements.
-
 ** Direct edit no longer parses or modifies expressions.
 Use the dedicated expression tools to create or modify expressions, while direct edit remains focused on labels and feature syntax.
+** Improve the edge tool creating a `FlowUsage`, by creating a `ReferenceUsage` used for the redefinition of the `FlowEnd` only when it is needed.
 
 * In _Details_ view:
 


### PR DESCRIPTION
Signed-off-by: Guillaume Coutable <guillaume.coutable@obeo.fr>

# PLEASE READ ALL ITEMS AND CHECK ONLY RELEVANT CHECKBOXES BELOW

## Auto review

- [x] Have you reviewed this PR? Please do a first quick review, It is very useful to detect typos and missing copyrights, check comments, check your code... The reviewer will thank you for that :)

## Project management

- [x] Has the pull request been added to the relevant milestone?
- [x] Have the `priority:` and `pr:` labels been added to the pull request? (In case of doubt, start with the labels `priority: low` and `pr: to review later`)
- [ ] Have the relevant issues been added to the pull request?
- [ ] Have the relevant labels been added to the issues? (`area:`, `type:`)
- [ ] Have the relevant issues been added to the same project milestone as the pull request?

## Changelog and release notes

- [x] Has the `CHANGELOG.adoc` + `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc` been updated to reference the relevant issues?
- [ ] Have the relevant API breaks been described in the `CHANGELOG.adoc`?
- [ ] Are the new / upgraded dependencies mentioned in the relevant section of the `CHANGELOG.adoc`?
- [ ] In case of a change with a visual impact, are there any screenshots in the `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?
- [ ] In case of a key change, has the change been added to `Key highlights` section in `doc/content/modules/user-manual/pages/release-notes/YYYY.MM.0.adoc`?

## Documentation

- [ ] Have you included an update of the [documentation](https://doc.mbse-syson.org) in your pull request? Please ask yourself if an update (installation manual, user manual, developer manual...) is needed and add one accordingly.

## Tests

- [ ] Is the code properly tested? Any pull request (fix, enhancement or new feature) should come with a test (or several). It could be unit tests, integration tests or cypress tests depending on the context. Only doc and releng pull request do not need for tests.
